### PR TITLE
Add name as a mandatory input to model building, and insert into metadata at higher level

### DIFF
--- a/examples/Gordo-Workflow-High-Level.ipynb
+++ b/examples/Gordo-Workflow-High-Level.ipynb
@@ -120,6 +120,7 @@
    "outputs": [],
    "source": [
     "pipe, metadata = build_model(\n",
+    "    name=config['model'],\n",
     "    model_config=model_config, \n",
     "    data_config=data_config,\n",
     "    metadata=machine_config['metadata']\n",

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -167,7 +167,7 @@ def _get_final_gordo_base_step(model: BaseEstimator):
 
 
 def calculate_model_key(
-    model_config: dict, data_config: dict, metadata: Optional[dict] = None
+    name: str, model_config: dict, data_config: dict, metadata: Optional[dict] = None
 ) -> str:
     """
     Calculates a hash-key from a model and data-config.
@@ -178,6 +178,8 @@ def calculate_model_key(
 
     Parameters
     ----------
+    name: str
+        Name of the model
     model_config: dict
         Config for the model. See
         :func:`gordo_components.builder.build_model.build_model`.
@@ -195,7 +197,7 @@ def calculate_model_key(
 
     Examples
     -------
-    >>> len(calculate_model_key(model_config={"model": "something"},
+    >>> len(calculate_model_key(name="My-model", model_config={"model": "something"},
     ... data_config={"tag_list": ["tag1", "tag 2"]} ))
     128
     """
@@ -214,6 +216,7 @@ def calculate_model_key(
     # generate different json which again gives different hash)
     json_rep = json.dumps(
         {
+            "name": name,
             "model_config": model_config,
             "data_config": data_config,
             "user-defined": metadata,
@@ -276,7 +279,7 @@ def provide_saved_model(
     Union[os.PathLike, str]:
         Path to the model
     """
-    cache_key = calculate_model_key(model_config, data_config, metadata=metadata)
+    cache_key = calculate_model_key(name, model_config, data_config, metadata=metadata)
     if model_register_dir:
         logger.info(
             f"Model caching activated, attempting to read model-location with key "
@@ -285,7 +288,7 @@ def provide_saved_model(
         if replace_cache:
             logger.info("replace_cache activated, deleting any existing cache entry")
             cache_key = calculate_model_key(
-                model_config, data_config, metadata=metadata
+                name, model_config, data_config, metadata=metadata
             )
             disk_registry.delete_value(model_register_dir, cache_key)
 

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -22,13 +22,18 @@ logger = logging.getLogger(__name__)
 
 
 def build_model(
-    model_config: dict, data_config: Union[GordoBaseDataset, dict], metadata: dict
+    name: str,
+    model_config: dict,
+    data_config: Union[GordoBaseDataset, dict],
+    metadata: dict,
 ):
     """
     Build a model and serialize to a directory for later serving.
 
     Parameters
     ----------
+    name: str
+        Name of model to be built
     model_config: dict
         Mapping of Model to initialize and any additional kwargs which are to be used in it's initialization.
         Example::
@@ -79,6 +84,7 @@ def build_model(
     time_elapsed_model = time.time() - start
 
     metadata = {"user-defined": metadata}
+    metadata["name"] = name
     metadata["dataset"] = dataset.get_metadata()
     utc_dt = datetime.datetime.now(datetime.timezone.utc)
     metadata["model"] = {
@@ -226,6 +232,7 @@ def calculate_model_key(
 
 
 def provide_saved_model(
+    name: str,
     model_config: dict,
     data_config: dict,
     metadata: dict,
@@ -243,6 +250,8 @@ def provide_saved_model(
 
     Parameters
     ----------
+    name: str
+        Name of the model to be built
     model_config: dict
         Config for the model. See
         :func:`gordo_components.builder.build_model.build_model`.
@@ -300,7 +309,7 @@ def provide_saved_model(
                 f"{model_register_dir}."
             )
     model, metadata = build_model(
-        model_config=model_config, data_config=data_config, metadata=metadata
+        name=name, model_config=model_config, data_config=data_config, metadata=metadata
     )
     model_location = _save_model_for_workflow(
         model=model, metadata=metadata, output_dir=output_dir

--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -53,6 +53,7 @@ DEFAULT_MODEL_CONFIG = (
 
 
 @click.command()
+@click.argument("name", envvar="MODEL_NAME")
 @click.argument("output-dir", default="/data", envvar="OUTPUT_DIR")
 @click.argument(
     "model-config", envvar="MODEL_CONFIG", default=DEFAULT_MODEL_CONFIG, type=str
@@ -85,6 +86,7 @@ DEFAULT_MODEL_CONFIG = (
     "--model-parameter some_key,some_value",
 )
 def build(
+    name,
     output_dir,
     model_config,
     data_config,
@@ -100,6 +102,8 @@ def build(
     \b
     Parameters
     ----------
+    name: str
+        Name given to the model to build
     output_dir: str
         Directory to save model & metadata to.
     model_config: str
@@ -153,7 +157,7 @@ def build(
     model_config = yaml.full_load(model_config)
 
     model_location = provide_saved_model(
-        model_config, data_config, metadata, output_dir, model_register_dir
+        name, model_config, data_config, metadata, output_dir, model_register_dir
     )
     # If the model is cached but without CV scores then we force a rebuild. We do this
     # by deleting the entry in the cache and then rerun `provide_saved_model`
@@ -169,6 +173,7 @@ def build(
             )
 
             model_location = provide_saved_model(
+                name,
                 model_config,
                 data_config,
                 metadata,

--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -186,9 +186,7 @@ class Client:
 
         return [
             EndpointMetadata(
-                target_name=data["endpoint-metadata"]["metadata"]["user-defined"][
-                    "machine-name"
-                ],
+                target_name=data["endpoint-metadata"]["metadata"]["name"],
                 healthy=data["healthy"],
                 endpoint=f'{self.base_url}{data["endpoint"].rstrip("/")}',
                 tag_list=normalize_sensor_tags(

--- a/gordo_components/watchman/gordo_k8s_interface.py
+++ b/gordo_components/watchman/gordo_k8s_interface.py
@@ -242,7 +242,7 @@ class ModelBuilderPod(Pod):
         Get a Gordo ModelBuilderPod representation from the raw kubernetes V1Pod object
 
         This specific one is expected to have spec.containers[0].env which contains
-        a 'MACHINE_NAME' kubernetes.models.V1EnvVar
+        a 'MODEL_NAME' kubernetes.models.V1EnvVar
 
         Parameters
         ----------
@@ -257,12 +257,12 @@ class ModelBuilderPod(Pod):
             raise ValueError(f"This pod does not appear to be a ModelBuilder pod.")
 
         for envar in pod.spec.containers[0].env:
-            if envar.name == "MACHINE_NAME":
+            if envar.name == "MODEL_NAME":
                 self.target_name = envar.value
                 break
         else:
             raise ValueError(
-                f"Unable to find the MACHINE_NAME in this pod's environment spec"
+                f"Unable to find the MODEL_NAME in this pod's environment spec"
             )
 
         super().__init__(pod, *args, **kwargs)

--- a/gordo_components/watchman/server.py
+++ b/gordo_components/watchman/server.py
@@ -66,7 +66,7 @@ class WatchmanApi(MethodView):
         project_name: str
             The name of this project we're going to query for.
         target: str
-            Name of the target, aka machine-name
+            Name of the target, aka model name
         endpoint: str
             Endpoint to check. ie. /gordo/v0/test-project/test-machine
         builder_pod: Optional[ModelBuilderPod]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,10 +77,8 @@ def trained_model_directory(sensors: List[SensorTag]):
             tmp_dir,
             metadata={
                 "dataset": {"tag_list": sensors, "resolution": "10T"},
-                "user-defined": {
-                    "model-name": "test-model",
-                    "machine-name": "machine-1",
-                },
+                "name": "machine-1",
+                "user-defined": {"model-name": "test-model"},
             },
         )
         yield tmp_dir

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -44,7 +44,10 @@ class ModelBuilderTestCase(unittest.TestCase):
             output_dir = os.path.join(tmpdir, "some", "sub", "directories")
 
             model, metadata = build_model(
-                model_config=model_config, data_config=data_config, metadata={}
+                name="model-name",
+                model_config=model_config,
+                data_config=data_config,
+                metadata={},
             )
 
             self.metadata_check(metadata, False)
@@ -74,7 +77,10 @@ class ModelBuilderTestCase(unittest.TestCase):
         data_config = get_random_data()
 
         model, metadata = build_model(
-            model_config=model_config, data_config=data_config, metadata={}
+            name="model-name",
+            model_config=model_config,
+            data_config=data_config,
+            metadata={},
         )
 
         self.metadata_check(metadata, False)
@@ -90,7 +96,10 @@ class ModelBuilderTestCase(unittest.TestCase):
         data_config = get_random_data()
 
         model, metadata = build_model(
-            model_config=model_config, data_config=data_config, metadata={}
+            name="model-name",
+            model_config=model_config,
+            data_config=data_config,
+            metadata={},
         )
 
         self.metadata_check(metadata, True)
@@ -108,7 +117,10 @@ class ModelBuilderTestCase(unittest.TestCase):
         data_config = get_random_data()
 
         model, metadata = build_model(
-            model_config=model_config, data_config=data_config, metadata={}
+            name="model-name",
+            model_config=model_config,
+            data_config=data_config,
+            metadata={},
         )
 
         self.metadata_check(metadata, False)
@@ -133,12 +145,16 @@ class ModelBuilderTestCase(unittest.TestCase):
         data_config = get_random_data()
 
         model, metadata = build_model(
-            model_config=model_config, data_config=data_config, metadata={}
+            name="model-name",
+            model_config=model_config,
+            data_config=data_config,
+            metadata={},
         )
 
         self.metadata_check(metadata, False)
 
     def metadata_check(self, metadata, check_history):
+        self.assertTrue("name" in metadata)
         self.assertTrue("model" in metadata)
         self.assertTrue("cross-validation" in metadata["model"])
         self.assertTrue("scores" in metadata["model"]["cross-validation"])
@@ -163,6 +179,7 @@ class ModelBuilderTestCase(unittest.TestCase):
             output_dir = os.path.join(tmpdir, "model")
 
             model_location = provide_saved_model(
+                name="model-name",
                 model_config=model_config,
                 data_config=data_config,
                 metadata={},
@@ -230,6 +247,7 @@ def test_provide_saved_model_caching(
         registry_dir = os.path.join(tmpdir, "registry")
 
         model_location = provide_saved_model(
+            name="model-name",
             model_config=model_config,
             data_config=data_config,
             output_dir=output_dir,
@@ -241,6 +259,7 @@ def test_provide_saved_model_caching(
             data_config["tag_list"] = tag_list
         new_output_dir = os.path.join(tmpdir, "model2")
         model_location2 = provide_saved_model(
+            name="model-name",
             model_config=model_config,
             data_config=data_config,
             output_dir=new_output_dir,

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -46,6 +46,7 @@ class CliTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
+                MODEL_NAME="model-name",
                 OUTPUT_DIR=tmpdir,
                 DATA_CONFIG=DATA_CONFIG,
                 MODEL_CONFIG=json.dumps(MODEL_CONFIG),
@@ -66,6 +67,7 @@ class CliTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
+                MODEL_NAME="model-name",
                 OUTPUT_DIR=os.path.join(tmpdir, "dir1"),
                 DATA_CONFIG=DATA_CONFIG,
                 MODEL_CONFIG=json.dumps(MODEL_CONFIG),
@@ -79,6 +81,7 @@ class CliTestCase(unittest.TestCase):
 
             # OUTPUT_DIR is the only difference
             with temp_env_vars(
+                MODEL_NAME="model-name",
                 OUTPUT_DIR=os.path.join(tmpdir, "dir2"),
                 DATA_CONFIG=DATA_CONFIG,
                 MODEL_CONFIG=json.dumps(MODEL_CONFIG),
@@ -98,6 +101,7 @@ class CliTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
+                MODEL_NAME="model-name",
                 OUTPUT_DIR=os.path.join(tmpdir, "dir1"),
                 DATA_CONFIG=DATA_CONFIG,
                 MODEL_CONFIG=json.dumps(MODEL_CONFIG),
@@ -110,6 +114,7 @@ class CliTestCase(unittest.TestCase):
                 first_path = f.read()
 
             with temp_env_vars(
+                MODEL_NAME="model-name",
                 OUTPUT_DIR=os.path.join(tmpdir, "dir2"),
                 # NOTE: Different train dates!
                 DATA_CONFIG=(
@@ -151,7 +156,10 @@ class CliTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
-                OUTPUT_DIR=tmpdir, DATA_CONFIG=DATA_CONFIG, MODEL_CONFIG=model
+                MODEL_NAME="model-name",
+                OUTPUT_DIR=tmpdir,
+                DATA_CONFIG=DATA_CONFIG,
+                MODEL_CONFIG=model,
             ):
                 args = [
                     "build",

--- a/tests/mocking/k8s_mocking.py
+++ b/tests/mocking/k8s_mocking.py
@@ -76,9 +76,7 @@ def mock_kubernetes_read_namespaced_pod(*_args, **_kwargs):
             containers=[
                 models.V1Container(
                     name="some-generated-test-container-name",
-                    env=[
-                        models.V1EnvVar(name="MACHINE_NAME", value="test-machine-name")
-                    ],
+                    env=[models.V1EnvVar(name="MODEL_NAME", value="test-machine-name")],
                 )
             ]
         ),


### PR DESCRIPTION
The output of this is that the metadata structure gets a "name": "machine-whateveritis-name" next to the "dataset" etc. So the endpoints will change. The config is not changed.

Require https://github.com/equinor/gordo-infrastructure/pull/274
Close #238 

Old structure: endpoint-metadata -> metadata-> user-defined -> machine-name
New structure: endpoint-metadata -> metadata -> name

Old example:
![Screenshot 2019-05-29 at 15 17 08](https://user-images.githubusercontent.com/3764922/58560476-80558580-8225-11e9-998c-bd962f036746.png)

New example:
![Screenshot 2019-05-29 at 15 18 35](https://user-images.githubusercontent.com/3764922/58560495-8e0b0b00-8225-11e9-951b-8aeb3763dc58.png)
