### PR TITLE
Support eventually consistent endpoint metadata in Watchman

### DIFF
--- a/gordo_components/watchman/endpoints_status.py
+++ b/gordo_components/watchman/endpoints_status.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+
+import threading
+from typing import List, Optional
+from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+from flask import current_app
+
+from gordo_components.watchman.gordo_k8s_interface import (
+    Service,
+    list_model_builders,
+    ModelBuilderPod,
+)
+
+
+EndpointStatus = namedtuple(
+    "EndpointStatus",
+    [
+        "endpoint",
+        "target",
+        "metadata",
+        "healthy",
+        "model_builder_status",
+        "model_server_status",
+    ],
+)
+ModelBuilderStatus = namedtuple("ModelBuilderStatus", "status logs")
+ModelServerStatus = namedtuple("ModelServerStatus", "status logs")
+
+
+class EndpointStatuses:
+    """
+    Represents a thread-safe interface to getting endpoint metadata / statuses
+    for use inside of Watchman.
+
+    Can, in a separate thread, call ``EndpointStatuses.update()`` to re-call all
+    endpoints and get thier metadata.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._statuses: List[dict] = None
+
+    def update(self):
+        """
+        Update the object's endpoints to reflect their current state.
+        """
+        with self._lock:
+            self._statuses = self._endpoints_statuses()
+
+    def statuses(self, n_logs: Optional[int] = None) -> List[dict]:
+        """
+        Return the current List[EndpointStatus] as a list of JSON serializable dicts
+
+        Returns
+        -------
+        List[dict]
+        """
+        if not n_logs:
+            with self._lock:
+                return self._statuses
+
+        # Otherwise we need a 'fresh' view of the statuses to include latest logs
+        else:
+            return self._endpoints_statuses(n_logs)
+
+    @staticmethod
+    def _check_endpoint(
+        host: str,
+        namespace: str,
+        project_name: str,
+        target: str,
+        endpoint: str,
+        builder_pod: Optional[ModelBuilderPod] = None,
+        n_logs: Optional[int] = None,
+    ) -> EndpointStatus:
+        """
+        Check if a given endpoint returning metadata about it.
+
+        Parameters
+        ----------
+        host: str
+            Name of the host to query
+        namespace: str
+            Namespace k8s client should operate in.
+        project_name: str
+            The name of this project we're going to query for.
+        target: str
+            Name of the target, aka machine-name
+        endpoint: str
+            Endpoint to check. ie. /gordo/v0/test-project/test-machine
+        builder_pod: Optional[ModelBuilderPod]
+            A reference to the pod responsible for building the model for this target
+        n_logs: int
+            Number of lines worth of logs to fetch from builders and services
+
+        Returns
+        -------
+        EndpointStatus
+        """
+
+        endpoint = endpoint[1:] if endpoint.startswith("/") else endpoint
+        base_url = f'http://{host}/{endpoint.rstrip("/")}'
+
+        metadata_resp = requests.get(f"{base_url}/metadata", timeout=2)
+        metadata = metadata_resp.json() if metadata_resp.ok else dict()
+
+        # Get model builder status / logs
+        if builder_pod is not None:
+            # Get the current phase and logs of the pod responsible for model building
+            status_model_builder, logs_model_builder = (
+                builder_pod.status.phase,
+                builder_pod.logs() if n_logs is None else builder_pod.logs(n_logs),
+            )
+        else:
+            status_model_builder, logs_model_builder = None, None  # type: ignore
+
+        # Get server (a Kubernetes service) status / logs
+        if n_logs is not None:
+            service = Service(  # type: ignore
+                namespace=namespace, name=f"gordoserver-{project_name}-{target}"
+            )
+            service_status, service_logs = service.status, service.logs(n_logs)
+        else:
+            service_status, service_logs = None, None  # type: ignore
+
+        return EndpointStatus(
+            endpoint=endpoint,
+            target=target,
+            metadata=metadata,
+            healthy=metadata_resp.ok,
+            model_builder_status=ModelBuilderStatus(
+                status=status_model_builder, logs=logs_model_builder
+            ),
+            model_server_status=ModelServerStatus(
+                status=service_status, logs=service_logs
+            ),
+        )
+
+    @staticmethod
+    def _endpoints_statuses(n_logs: Optional[int] = None) -> List[dict]:
+
+        # Get a list of ModelBuilderPod instances and map to target names
+        if n_logs is not None:
+            builders = list_model_builders(
+                namespace=current_app.config["NAMESPACE"],
+                project_name=current_app.config["PROJECT_NAME"],
+                project_version=current_app.config["PROJECT_VERSION"],
+            )
+            builders = {pod.target_name: pod for pod in builders}
+        else:
+            builders = {}
+
+        with ThreadPoolExecutor(max_workers=25) as executor:
+            futures = {
+                executor.submit(
+                    EndpointStatuses._check_endpoint,
+                    host=f'ambassador.{current_app.config["AMBASSADOR_NAMESPACE"]}',
+                    namespace=current_app.config["NAMESPACE"],
+                    project_name=current_app.config["PROJECT_NAME"],
+                    target=target,
+                    endpoint=endpoint,
+                    builder_pod=builders.get(target),
+                    n_logs=n_logs,
+                ): endpoint
+                for target, endpoint in zip(
+                    current_app.config["TARGET_NAMES"], current_app.config["ENDPOINTS"]
+                )
+            }
+
+            # List of dicts: [{'endpoint': /path/to/endpoint, 'healthy': bool, 'metadata': dict, ...}]
+            status_results = []
+            for f in futures:
+
+                exception = f.exception()
+
+                if exception is not None:
+                    status_results.append(
+                        {
+                            "endpoint": futures[f],
+                            "healthy": False,
+                            "error": f"Unable to properly probe endpoint: {exception}",
+                        }
+                    )
+                else:
+                    status = f.result()  # type: EndpointStatus
+
+                    status_results.append(
+                        {
+                            "endpoint": futures[f],
+                            "healthy": status.healthy,
+                            "endpoint-metadata": status.metadata,
+                            "model-server": {
+                                "logs": status.model_server_status.logs,
+                                "status": status.model_server_status.status,
+                            },
+                            "model-builder": {
+                                "logs": status.model_builder_status.logs,
+                                "status": status.model_builder_status.status,
+                            },
+                        }
+                    )
+            return status_results

--- a/gordo_components/watchman/server.py
+++ b/gordo_components/watchman/server.py
@@ -2,40 +2,25 @@
 
 import os
 import logging
-from collections import namedtuple
-from concurrent.futures import ThreadPoolExecutor
-from typing import Iterable, Optional, List
-
-import requests
-from cachetools import cached, TTLCache
+from functools import wraps
+from typing import Iterable, Optional
 from flask import Flask, jsonify, make_response, request, current_app
 from flask.views import MethodView
+from apscheduler.schedulers.background import BackgroundScheduler
 
 from gordo_components import __version__
-from gordo_components.watchman.gordo_k8s_interface import (
-    Service,
-    list_model_builders,
-    ModelBuilderPod,
-)
+from gordo_components.watchman.endpoints_status import EndpointStatuses
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get("WATCHMAN_LOGLEVEL", "INFO").upper())
 
 
-EndpointStatus = namedtuple(
-    "EndpointStatus",
-    [
-        "endpoint",
-        "target",
-        "metadata",
-        "healthy",
-        "model_builder_status",
-        "model_server_status",
-    ],
-)
-ModelBuilderStatus = namedtuple("ModelBuilderStatus", "status logs")
-ModelServerStatus = namedtuple("ModelServerStatus", "status logs")
+ENDPOINT_STATUSES = EndpointStatuses()
+
+# Setup the scheduler to update the endpoint statuses, (fired in build_app)
+scheduler = BackgroundScheduler()
+scheduler.add_job(ENDPOINT_STATUSES.update, trigger="interval", minutes=5)
 
 
 class WatchmanApi(MethodView):
@@ -44,153 +29,17 @@ class WatchmanApi(MethodView):
     are up or not.
     """
 
-    @staticmethod
-    def _check_endpoint(
-        host: str,
-        namespace: str,
-        project_name: str,
-        target: str,
-        endpoint: str,
-        builder_pod: Optional[ModelBuilderPod] = None,
-        n_logs: Optional[int] = None,
-    ) -> EndpointStatus:
-        """
-        Check if a given endpoint returning metadata about it.
-
-        Parameters
-        ----------
-        host: str
-            Name of the host to query
-        namespace: str
-            Namespace k8s client should operate in.
-        project_name: str
-            The name of this project we're going to query for.
-        target: str
-            Name of the target, aka machine-name
-        endpoint: str
-            Endpoint to check. ie. /gordo/v0/test-project/test-machine
-        builder_pod: Optional[ModelBuilderPod]
-            A reference to the pod responsible for building the model for this target
-        n_logs: int
-            Number of lines worth of logs to fetch from builders and services
-
-        Returns
-        -------
-        EndpointStatus
-        """
-
-        endpoint = endpoint[1:] if endpoint.startswith("/") else endpoint
-        base_url = f'http://{host}/{endpoint.rstrip("/")}'
-
-        metadata_resp = requests.get(f"{base_url}/metadata", timeout=2)
-        metadata = metadata_resp.json() if metadata_resp.ok else dict()
-
-        # Get model builder status / logs
-        if builder_pod is not None:
-            # Get the current phase and logs of the pod responsible for model building
-            status_model_builder, logs_model_builder = (
-                builder_pod.status.phase,
-                builder_pod.logs() if n_logs is None else builder_pod.logs(n_logs),
-            )
-        else:
-            status_model_builder, logs_model_builder = None, None  # type: ignore
-
-        # Get server (a Kubernetes service) status / logs
-        if n_logs is not None:
-            service = Service(  # type: ignore
-                namespace=namespace, name=f"gordoserver-{project_name}-{target}"
-            )
-            service_status, service_logs = service.status, service.logs(n_logs)
-        else:
-            service_status, service_logs = None, None  # type: ignore
-
-        return EndpointStatus(
-            endpoint=endpoint,
-            target=target,
-            metadata=metadata,
-            healthy=metadata_resp.ok,
-            model_builder_status=ModelBuilderStatus(
-                status=status_model_builder, logs=logs_model_builder
-            ),
-            model_server_status=ModelServerStatus(
-                status=service_status, logs=service_logs
-            ),
-        )
-
-    @staticmethod
-    @cached(cache=TTLCache(maxsize=1024, ttl=5))
-    def _endpoints_statuses(n_logs: Optional[int]) -> List[dict]:
-
-        # Get a list of ModelBuilderPod instances and map to target names
-        if n_logs is not None:
-            builders = list_model_builders(
-                namespace=current_app.config["NAMESPACE"],
-                project_name=current_app.config["PROJECT_NAME"],
-                project_version=current_app.config["PROJECT_VERSION"],
-            )
-            builders = {pod.target_name: pod for pod in builders}
-        else:
-            builders = {}
-
-        with ThreadPoolExecutor(max_workers=25) as executor:
-            futures = {
-                executor.submit(
-                    WatchmanApi._check_endpoint,
-                    host=f'ambassador.{current_app.config["AMBASSADOR_NAMESPACE"]}',
-                    namespace=current_app.config["NAMESPACE"],
-                    project_name=current_app.config["PROJECT_NAME"],
-                    target=target,
-                    endpoint=endpoint,
-                    builder_pod=builders.get(target),
-                    n_logs=n_logs,
-                ): endpoint
-                for target, endpoint in zip(
-                    current_app.config["TARGET_NAMES"], current_app.config["ENDPOINTS"]
-                )
-            }
-
-            # List of dicts: [{'endpoint': /path/to/endpoint, 'healthy': bool, 'metadata': dict, ...}]
-            status_results = []
-            for f in futures:
-
-                exception = f.exception()
-
-                if exception is not None:
-                    status_results.append(
-                        {
-                            "endpoint": futures[f],
-                            "healthy": False,
-                            "error": f"Unable to properly probe endpoint: {exception}",
-                        }
-                    )
-                else:
-                    status = f.result()  # type: EndpointStatus
-
-                    status_results.append(
-                        {
-                            "endpoint": futures[f],
-                            "healthy": status.healthy,
-                            "endpoint-metadata": status.metadata,
-                            "model-server": {
-                                "logs": status.model_server_status.logs,
-                                "status": status.model_server_status.status,
-                            },
-                            "model-builder": {
-                                "logs": status.model_builder_status.logs,
-                                "status": status.model_builder_status.status,
-                            },
-                        }
-                    )
-            return status_results
-
     def get(self):
 
         n_logs = int(request.args.get("logs") or 20) if "logs" in request.args else None
-        status_results = self._endpoints_statuses(n_logs)
+
+        # If _statuses is None, it hasn't been updated yet by the scheduler.
+        if ENDPOINT_STATUSES._statuses is None:
+            ENDPOINT_STATUSES.update()
 
         payload = jsonify(
             {
-                "endpoints": status_results,
+                "endpoints": ENDPOINT_STATUSES.statuses(n_logs),
                 "project-name": current_app.config["PROJECT_NAME"],
             }
         )
@@ -207,6 +56,20 @@ def healthcheck():
         {"version": __version__, "config": current_app.config["TARGET_NAMES"]}
     )
     return payload, 200
+
+
+def run_override(func):
+    """
+    Wrapper to Flask's app.run function which will first start the scheduler
+    and then call the original app.run()
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        scheduler.start()
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 def build_app(
@@ -238,6 +101,10 @@ def build_app(
     app.add_url_rule(
         rule="/", view_func=WatchmanApi.as_view("watchman_api"), methods=["GET"]
     )
+
+    # Ensure that calling app.run will start the scheduler
+    app.run = run_override(app.run)  # type: ignore
+
     return app
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+apscheduler~=3.6
 Click~=7.0
 cachetools~=3.1
 h5py~=2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ aiodns==2.0.0
 aiohttp==3.5.4
 alabaster==0.7.12         # via sphinx
 aniso8601==6.0.0          # via flask-restplus
+apscheduler==3.6.0
 asn1crypto==0.24.0        # via cryptography
 astor==0.7.1              # via tensorflow
 async-timeout==3.0.1      # via aiohttp
@@ -66,7 +67,7 @@ pyjwt==1.7.1              # via adal
 pyparsing==2.4.0          # via packaging
 pyrsistent==0.15.1        # via jsonschema
 python-dateutil==2.8.0
-pytz==2019.1              # via babel, flask-restplus, influxdb, pandas
+pytz==2019.1              # via apscheduler, babel, flask-restplus, influxdb, pandas, tzlocal
 pyyaml==5.1
 recommonmark==0.5.0
 requests-oauthlib==1.2.0  # via kubernetes
@@ -75,7 +76,7 @@ rsa==4.0                  # via google-auth
 scikit-learn==0.20.3
 scipy==1.2.1              # via keras, scikit-learn
 simplejson==3.16.0
-six==1.12.0               # via absl-py, cryptography, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras, keras-preprocessing, kubernetes, mock, packaging, pip-tools, protobuf, pyrsistent, python-dateutil, sphinx, tensorboard, tensorflow, tensorflow-estimator, websocket-client
+six==1.12.0               # via absl-py, apscheduler, cryptography, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras, keras-preprocessing, kubernetes, mock, packaging, pip-tools, protobuf, pyrsistent, python-dateutil, sphinx, tensorboard, tensorflow, tensorflow-estimator, websocket-client
 snowballstemmer==1.2.1    # via sphinx
 sphinx-click==2.1.0
 sphinx-rtd-theme==0.4.3
@@ -87,6 +88,7 @@ tensorflow==1.13.1
 termcolor==1.1.0          # via tensorflow
 typing-extensions==3.7.2  # via aiohttp
 typing==3.6.6             # via aiodns
+tzlocal==1.5.1            # via apscheduler
 urllib3==1.24.2
 websocket-client==0.56.0  # via kubernetes
 werkzeug==0.15.2          # via flask, tensorboard


### PR DESCRIPTION
Will close #281 

Uses [APScheduler](https://apscheduler.readthedocs.io/en/latest/index.html) to update `EndpointStatuses` every 5 minutes. `EndpointStatuses` holds a list of the endpoint statuses as `dict`s which are locked when read with `.statuses()` or updated with `.update()` 

Will get "fresh" statuses when requesting `?logs`/`?logs=20` in the URL to get logs of the model server and builder. 