### PR TITLE
Upgrade Travis ubuntu to xenial 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache: pip
 os:
   - linux
 
+dist: xenial
 
 jobs:
   include:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,11 @@
 import asyncio
 import logging
 import tempfile
-import time
 from typing import List
 
-import docker
 import ruamel.yaml
 import pytest
 import numpy as np
-import requests
 
 from gordo_components.server import server
 from gordo_components import serializer
@@ -104,42 +101,6 @@ def gordo_ml_server_client(request, trained_model_directory):
         app.testing = True
 
         yield app.test_client()
-
-
-@pytest.fixture(scope="session")
-def httpbin(host: str = "localhost", port: int = 9001):
-    """
-    Start a httpbin instance for testing general http requests
-    """
-    client = docker.from_env()
-
-    logger.info("Starting up httpbin!")
-    try:
-        httpbin = client.containers.run(
-            image="kennethreitz/httpbin",
-            ports={f"80/tcp": f"{port}"},
-            remove=True,
-            detach=True,
-        )
-
-        # Wait up to 60 seconds for it to start.
-        time.sleep(0.5)
-        for _ in range(60):
-            if requests.get(
-                f"http://{host}:{port}/get", timeout=1, proxies={"http": "", "HTTP": ""}
-            ).ok:
-                break
-        else:
-            raise RuntimeError("Was not able to start httpbin instance!")
-
-        logger.info(f"Started httpbin: {httpbin.name}")
-        yield f"{host}:{port}"
-
-    finally:
-        logger.info("Killing httpbin container")
-        if httpbin:
-            httpbin.kill()
-        logger.info("Killed httpbin container")
 
 
 @pytest.fixture(scope="session")

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -24,40 +24,6 @@ from gordo_components.cli import custom_types
 from tests import utils as tu
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("session", (True, False))
-@pytest.mark.parametrize("timeout", (5, None))
-@pytest.mark.parametrize("params", ({"key": "value"}, {}))
-async def test_client_fetch_json(httpbin, session, timeout, params):
-    """
-    Test fetch_json accepts specific kwargs
-    """
-    session = aiohttp.ClientSession() if session else None
-    resp = await client_io.fetch_json(
-        f"http://{httpbin}/get", session=session, timeout=timeout, params=params
-    )
-    assert params == resp["args"]
-    if session:
-        await session.close()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("session", (True, False))
-@pytest.mark.parametrize("timeout", (5, None))
-@pytest.mark.parametrize("json", ({"key": "value"}, {}))
-async def test_client_post_json(httpbin, session, timeout, json):
-    """
-    Test post_json accepts specific kwargs
-    """
-    session = aiohttp.ClientSession() if session else None
-    resp = await client_io.post_json(
-        f"http://{httpbin}/post", session=session, timeout=timeout, json=json
-    )
-    assert json == resp["json"]
-    if session:
-        await session.close()
-
-
 def test_client_get_metadata(watchman_service):
     """
     Test client's ability to get metadata from some target


### PR DESCRIPTION
This removes the httpbin-based tests which downloaded a httpbin docker image and used it to test our async get/post wrappers.

It also updates the travis ubuntu version to 16.04. This is soon the default, so good to be on it to be ready for the future. 