### PR TITLE
Support parametrizing model location file

### DIFF
--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -89,6 +89,12 @@ DEFAULT_MODEL_CONFIG = (
     "multiple times. Separate key,valye by a comma. ie: --model-parameter key,val "
     "--model-parameter some_key,some_value",
 )
+@click.option(
+    "--model-location-file",
+    help="Full path to a file to create and write the location of where the serialized model is placed.",
+    type=click.File(mode="w", lazy=False),
+    default="/tmp/model-location.txt",
+)
 def build(
     name,
     output_dir,
@@ -98,6 +104,7 @@ def build(
     model_register_dir,
     print_cv_scores,
     model_parameter,
+    model_location_file,
 ):
     """
     Build a model and deposit it into 'output_dir' given the appropriate config
@@ -128,6 +135,8 @@ def build(
     model_parameter: List[Tuple]
         List of model key-values, wheres the values will be injected into the model
         config wherever there is a jinja variable with the key.
+    model_location_file: str/path
+        Path to a file to open and write the location of the serialized model to.
 
     """
 
@@ -196,8 +205,8 @@ def build(
         for score in all_scores:
             print(score)
 
-    with open("/tmp/model-location.txt", "w") as f:
-        f.write(model_location)
+    # Write out the model location to this file.
+    model_location_file.write(model_location)
     return 0
 
 


### PR DESCRIPTION
Closes #188 
Was hardcoded to `/tmp/model-location.txt` now `gordo-components build --model-location-file /whatevs.txt`