### PR TITLE
Support predicting N number of tags

### DIFF
--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -22,7 +22,6 @@ from sklearn.metrics import explained_variance_score
 from sklearn.exceptions import NotFittedError
 from gordo_components.model.base import GordoBase
 
-
 # This is required to run `register_model_builder` against registered factories
 from gordo_components.model.factories import *  # pragma: no flakes
 

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -88,6 +88,15 @@ class BaseModelView(Resource):
     def tags(self) -> typing.List[SensorTag]:
         return normalize_sensor_tags(current_app.metadata["dataset"]["tag_list"])
 
+    @property
+    def target_tags(self) -> typing.List[SensorTag]:
+        if "target_tag_list" in current_app.metadata["dataset"]:
+            return normalize_sensor_tags(
+                current_app.metadata["dataset"]["target_tag_list"]
+            )
+        else:
+            return []
+
     @staticmethod
     def _parse_iso_datetime(datetime_str: str) -> datetime:
         parsed_date = dateutil.parser.isoparse(datetime_str)  # type: ignore
@@ -283,6 +292,8 @@ class BaseModelView(Resource):
             self._data = data  # Assign the base response DF for any children to use
 
         context["tags"] = self.tags
+        context["target-tags"] = self.target_tags
+
         if data is not None:
             context["data"] = self.multi_lvl_column_dataframe_to_dict(data)
         return make_response((jsonify(context), context.pop("status-code", 200)))


### PR DESCRIPTION
Add ability to use models meant for single target predictions, to produce predictions for N number of targets. So that we can use some tags to predict some other tags.

This will depend on a future implementation where the `TimeSeriesDataset` is capable of returning a `y` 

Part of #354 