### PR TITLE
Use .get_params() in pipeline_into_definition

### DIFF
--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -163,6 +163,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase):
             Parameters used in this estimator
         """
         params = super().get_params(**params)
+        params.pop("build_fn", None)
         params.update({"kind": self.kind})
         params.update(self.kwargs)
         return params


### PR DESCRIPTION
Will close #332 

Before we only looked at the step's __init__ args, which didn't
account for kwargs sent to the model.