### PR TITLE
Ensure that start and end has UTC tzone on date_range call

### DIFF
--- a/gordo_components/data_provider/iroc_reader.py
+++ b/gordo_components/data_provider/iroc_reader.py
@@ -2,6 +2,7 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from dateutil import tz
 from typing import Iterable, List
 
 import pandas as pd
@@ -57,8 +58,8 @@ class IrocReader(GordoBaseDataProvider):
         all_base_paths = (
             f"{base_path}/{t.year:0>4d}/{t.month:0>2d}/{t.day:0>2d}/"
             for t in pd.date_range(
-                start=from_ts - pd.Timedelta("1D"),
-                end=to_ts + pd.Timedelta("1D"),
+                start=from_ts.astimezone(tz.tzutc()) - pd.Timedelta("1D"),
+                end=to_ts.astimezone(tz.tzutc()) + pd.Timedelta("1D"),
                 freq="D",
             )
         )

--- a/tests/gordo_components/data_provider/test_data_provider_iroc.py
+++ b/tests/gordo_components/data_provider/test_data_provider_iroc.py
@@ -167,3 +167,28 @@ NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,-0.497645,2018-05-02T06:44:29.7830000Z,Anal
         )
         # We get one dataframe per tag, so 3
         self.assertEqual(3, len(res))
+
+    @mock.patch.object(
+        IrocReader,
+        "_fetch_all_iroc_files_from_paths",
+        side_effect=lambda all_base_paths, from_ts, to_ts, tag_list: [
+            read_iroc_file(
+                file_obj=StringIO(IROC_HAPPY_PATH_CSV),
+                from_ts=from_ts,
+                to_ts=to_ts,
+                tag_list=tag_list,
+            )
+        ],
+    )
+    def test_load_series_happy_path_different_timezones(self, _mocked_method):
+        """Happy-path testing of load_dataframe"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        res = list(
+            iroc_reader.load_series(
+                from_ts=isoparse("2018-05-02T01:56:00+02:00"),
+                to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                tag_list=IROC_HAPPY_TAG_LIST,
+            )
+        )
+        # We get one dataframe per tag, so 3
+        self.assertEqual(3, len(res))


### PR DESCRIPTION
Fix https://github.com/equinor/gordo-infrastructure/issues/287

Essentially - the date_range() method could have start and end datetime inputs with different time-zone, since we get the these timestamps from various sources (config file, date in bash etc). 

Convert them to utc.