### PR TITLE
Add multithreaded download of tags from NCS

### DIFF
--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -95,6 +95,13 @@ DEFAULT_MODEL_CONFIG = (
     type=click.File(mode="w", lazy=False),
     default="/tmp/model-location.txt",
 )
+@click.option(
+    "--data-provider-threads",
+    help="Number of threads to use for the data provider when fetching data",
+    envvar="DATA_PROVIDER_THREADS",
+    type=int,
+    default=1,
+)
 def build(
     name,
     output_dir,
@@ -105,6 +112,7 @@ def build(
     print_cv_scores,
     model_parameter,
     model_location_file,
+    data_provider_threads,
 ):
     """
     Build a model and deposit it into 'output_dir' given the appropriate config
@@ -137,7 +145,8 @@ def build(
         config wherever there is a jinja variable with the key.
     model_location_file: str/path
         Path to a file to open and write the location of the serialized model to.
-
+    data_provider_threads: int
+        Number of threads to use for the data provider when fetching data.
     """
 
     # TODO: Move all data related input from environment variable to data_config,
@@ -154,7 +163,7 @@ def build(
     data_config["to_ts"] = dateutil.parser.isoparse(data_config.pop("train_end_date"))
 
     # Set default data provider for data config
-    data_config["data_provider"] = DataLakeProvider()
+    data_config["data_provider"] = DataLakeProvider(threads=data_provider_threads)
     asset = data_config.get("asset", None)
     tag_list = normalize_sensor_tags(data_config["tag_list"], asset)
 

--- a/gordo_components/cli/client.py
+++ b/gordo_components/cli/client.py
@@ -49,7 +49,12 @@ def client(ctx: click.Context, *args, **kwargs):
 @click.command("predict")
 @click.argument("start", type=IsoFormatDateTime())
 @click.argument("end", type=IsoFormatDateTime())
-@click.option("--data-provider", type=DataProviderParam(), help="DataProvider dict")
+@click.option(
+    "--data-provider",
+    type=DataProviderParam(),
+    help="DataProvider dict. Must contain a 'type' key with the name of a DataProvider "
+    "as  value. If it does not contains a 'threads' key, 1 will be used ",
+)
 @click.option(
     "--output-dir",
     type=click.Path(exists=True),

--- a/gordo_components/cli/custom_types.py
+++ b/gordo_components/cli/custom_types.py
@@ -29,6 +29,8 @@ class DataProviderParam(click.ParamType):
             self.fail(f"Cannot create DataProvider without 'type' key defined")
 
         kind = kwargs.pop("type")
+        if "threads" not in kwargs:
+            kwargs["threads"] = 1
 
         Provider = getattr(providers, kind, None)
         if Provider is None:

--- a/gordo_components/data_provider/iroc_reader.py
+++ b/gordo_components/data_provider/iroc_reader.py
@@ -29,6 +29,8 @@ class IrocReader(GordoBaseDataProvider):
         super().__init__(**kwargs)
         self.client = client
         self.threads = threads
+        if self.threads is None:
+            self.threads = 50
 
     def load_series(
         self,


### PR DESCRIPTION
The default is now to have threads `None`, which leaves it to the data-provider to choose. For IROC it is constant 50 threads, for NCS it is your nr of cores * 5 (this is the default "smart" choice for ThreadPoolExecutor). 

Gordo model builder hard-codes it to 1 thread to save memory.

This closes #341 