### PR TITLE
Generalization of fields read by IROC reader

### DIFF
--- a/gordo_components/dataset/sensor_tag.py
+++ b/gordo_components/dataset/sensor_tag.py
@@ -21,6 +21,7 @@ TAG_TO_ASSET = [
     TagPatternToAsset(re.compile(r"^per.", re.IGNORECASE), "1295-pera"),
     TagPatternToAsset(re.compile(r"^gfa.", re.IGNORECASE), "1110-gfa"),
     TagPatternToAsset(re.compile(r"^ninenine.+::.+", re.IGNORECASE), "ninenine"),
+    TagPatternToAsset(re.compile(r"^uon_ef.+::.+", re.IGNORECASE), "uon_ef"),
 ]
 
 

--- a/tests/gordo_components/data_provider/test_data_provider_iroc.py
+++ b/tests/gordo_components/data_provider/test_data_provider_iroc.py
@@ -16,6 +16,23 @@ IROC_HAPPY_TAG_LIST = [
 HAPPY_FROM_TS = isoparse("2018-05-02T01:56:00+00:00")
 HAPPY_TO_TS = isoparse("2018-05-03T01:56:00+00:00")
 
+IROC_MANY_ASSETS_TAG_LIST = [
+    SensorTag("NINENINE.OPCIS::NNFCDPC01.AI1410J0", None),
+    SensorTag("NINENINE.OPCIS::NNFCDPC01.AI1840C1J0", None),
+    SensorTag("NINENINE.OPCIS::NNFCDPC01.AI1840E1J0", None),
+    SensorTag("UON_EF.OPCIS::LO006-B1H.PRCASXIN", None),
+    SensorTag("UON_EF.OPCIS::LO006-B1H.PRTUBXIN", None),
+    SensorTag("UON_EF.OPCIS::LO006-B1H_M1.PRSTAXIN", None),
+    SensorTag("UON_EF.OPCIS::LO006-B1H_M1.RTGASDIN", None),
+]
+
+IROC_NO_ASSET_TAG_LIST = [
+    SensorTag("NOT.OPCIS::NNFCDPC01.AI1410J0", None),
+    SensorTag("AN.OPCIS::NNFCDPC01.AI1840C1J0", None),
+    SensorTag("IROC.OPCIS::NNFCDPC01.AI1840E1J0", None),
+    SensorTag("ASSET.OPCIS::LO006-B1H.PRCASXIN", None),
+]
+
 # Functioning CSV for IROC. Has 6 lines, 5 different timestamps
 # (2018-05-02T06:44:29.7830000Z occurs twice) and 3 different tags.
 IROC_HAPPY_PATH_CSV = u"""tag,value,timestamp,status
@@ -101,6 +118,32 @@ NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,-0.497645,2018-05-02T06:44:29.7830000Z,Anal
                 from_ts=isoparse("2018-05-02T01:56:00+00:00"),
                 to_ts=isoparse("2018-05-03T01:56:00+00:00"),
                 tag_list=[],
+            )
+        )
+        self.assertEqual([], res)
+
+    def test_load_series_many_assets(self, _mocked_method):
+        """load_series will return an empty generator when called with tags
+        related to several assets"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        res = list(
+            iroc_reader.load_series(
+                from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                tag_list=IROC_MANY_ASSETS_TAG_LIST,
+            )
+        )
+        self.assertEqual([], res)
+
+    def test_load_series_no_asset_found(self, _mocked_method):
+        """load_series will return an empty generator when called with tags
+        that cannot be related to any asset"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        res = list(
+            iroc_reader.load_series(
+                from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                tag_list=IROC_NO_ASSET_TAG_LIST,
             )
         )
         self.assertEqual([], res)


### PR DESCRIPTION
Duplicated the base_path_to_asset function present in Ncs_reader to the IrocReader.
Introduced new tag : path for eagle ford (uon_ef)
Added some checks in case of multiple/no asset found.

Close #169