### PR TITLE
Simplify data serialization

### DIFF
--- a/gordo_components/server/utils.py
+++ b/gordo_components/server/utils.py
@@ -3,9 +3,9 @@
 import logging
 import functools
 import timeit
-import typing
 import dateutil
 from datetime import datetime
+from typing import Union, List
 
 import pandas as pd
 
@@ -25,58 +25,7 @@ basic dataframe output, respectively.
 logger = logging.getLogger(__name__)
 
 
-def dataframe_from_dict(
-    data: dict, tags: typing.List[str], name: str
-) -> typing.Union[pd.DataFrame, Response]:
-    """
-    Convert data supported by :meth:`pandas.DataFrame.from_dict` into a DataFrame
-    and ensure the columns are the ``tags``. Will return a :class:`flask.Response` if
-    parsing of the data into a DataFrame failed.
-
-    Parameters
-    ----------
-    df: Union[dict, list]
-        Any data supported by :py:meth:`pandas.DataFrame.from_dict`
-    tags: List[str]
-        The expected column names for the dataframe. If data supplied does not
-        have column names, but the length of those columns matches the tags, these
-        tags will be used as column names.
-    name: str
-        How to format the :class:`flask.Response` message when referring to the data supplied.
-        This will only be used if parsing the data into a DataFrame object fails.
-
-    Returns
-    -------
-    Union[pandas.DataFrame, flask.Response]
-    """
-    # Parse X and possibly y into a dataframe
-    try:
-        df = pd.DataFrame.from_dict(data)
-    except ValueError:
-        return make_response((jsonify(dict(message=f"Unable to parse '{name}'")), 400))
-    else:
-        # All tags are in the columns, so we'll take the subset to match the tags.
-        # **this also ensures the order of the columns is the order of the tags**
-        if all(tag in df.columns for tag in tags):
-            df = df[tags]
-
-        # n_features matches, set columns to be tag names
-        # This is the case that column names were not supplied, such as 'bare'
-        # nested arrays.
-        elif len(df.columns) == len(tags):
-            df.columns = tags
-
-        # Size isn't what was expected either, we have no idea what this is.
-        else:
-            message = dict(
-                message=f"Expected feature names/length of: {tags}/{len(tags)} in {name} "
-                f"but found {df.columns}/{len(df.columns)}"
-            )
-            return make_response((jsonify(message), 400))
-        return df
-
-
-def multi_lvl_column_dataframe_to_dict(df: pd.DataFrame) -> typing.List[dict]:
+def multi_lvl_column_dataframe_to_dict(df: pd.DataFrame) -> dict:
     """
     Convert a dataframe which has a :class:`pandas.MultiIndex` as columns into a dict
     where each key is the top level column name, and the value is the array
@@ -89,7 +38,7 @@ def multi_lvl_column_dataframe_to_dict(df: pd.DataFrame) -> typing.List[dict]:
     Parameters
     ----------
     df: pandas.DataFrame
-        Dataframe expected to have columns of type :class:`pandas.MultiIndex`
+        Dataframe expected to have columns of type :class:`pandas.MultiIndex` 2 levels deep.
 
     Returns
     -------
@@ -99,63 +48,80 @@ def multi_lvl_column_dataframe_to_dict(df: pd.DataFrame) -> typing.List[dict]:
 
     Examples
     --------
+    >>> import pprint
     >>> import pandas as pd
     >>> import numpy as np
     >>> columns = pd.MultiIndex.from_tuples((f"feature{i}", f"sub-feature-{ii}") for i in range(2) for ii in range(2))
-    >>> df = pd.DataFrame(np.arange(8).reshape((2, 4)), columns=columns)
+    >>> index = pd.date_range('2019-01-01', '2019-02-01', periods=2)
+    >>> df = pd.DataFrame(np.arange(8).reshape((2, 4)), columns=columns, index=index)
     >>> df  # doctest: +NORMALIZE_WHITESPACE
-           feature0                    feature1
-      sub-feature-0 sub-feature-1 sub-feature-0 sub-feature-1
-    0             0             1             2             3
-    1             4             5             6             7
-    >>> multi_lvl_column_dataframe_to_dict(df)
-    [{'feature0': [0, 1], 'feature1': [2, 3]}, {'feature0': [4, 5], 'feature1': [6, 7]}]
+                    feature0                    feature1
+               sub-feature-0 sub-feature-1 sub-feature-0 sub-feature-1
+    2019-01-01             0             1             2             3
+    2019-02-01             4             5             6             7
+    >>> serialized = multi_lvl_column_dataframe_to_dict(df)
+    >>> pprint.pprint(serialized)
+    {'feature0': {'sub-feature-0': {'2019-01-01': 0, '2019-02-01': 4},
+                  'sub-feature-1': {'2019-01-01': 1, '2019-02-01': 5}},
+     'feature1': {'sub-feature-0': {'2019-01-01': 2, '2019-02-01': 6},
+                  'sub-feature-1': {'2019-01-01': 3, '2019-02-01': 7}}}
+
+    """
+    # Need to copy, because Python's mutability allowed .index assignment to mutate the passed df
+    data = df.copy()
+    if isinstance(data.index, pd.DatetimeIndex):
+        data.index = data.index.astype(str)
+    return {
+        col: data[col].to_dict()
+        if isinstance(data[col], pd.DataFrame)
+        else pd.DataFrame(data[col]).to_dict()
+        for col in data.columns.get_level_values(0)
+    }
+
+
+def multi_lvl_column_dataframe_from_dict(data: dict) -> pd.DataFrame:
+    """
+    The inverse procedure done by :func:`.multi_lvl_column_dataframe_from_dict`
+    Reconstructed a MultiIndex column dataframe from a previously serialized one.
+
+    Expects ``data`` to be a nested dictionary where each top level key has a value
+    capable of being loaded from :func:`pandas.core.DataFrame.from_dict`
+
+    Parameters
+    ----------
+    data: dict
+        Data to be loaded into a MultiIndex column dataframe
+
+    Returns
+    -------
+    pandas.core.DataFrame
+        MultiIndex column dataframe.
+
+    Examples
+    --------
+    >>> serialized = {
+    ... 'feature0': {'sub-feature-0': {'2019-01-01': 0, '2019-02-01': 4},
+    ...              'sub-feature-1': {'2019-01-01': 1, '2019-02-01': 5}},
+    ... 'feature1': {'sub-feature-0': {'2019-01-01': 2, '2019-02-01': 6},
+    ...              'sub-feature-1': {'2019-01-01': 3, '2019-02-01': 7}}
+    ... }
+    >>> multi_lvl_column_dataframe_from_dict(serialized)  # doctest: +NORMALIZE_WHITESPACE
+                    feature0                    feature1
+           sub-feature-0 sub-feature-1 sub-feature-0 sub-feature-1
+    2019-01-01             0             1             2             3
+    2019-02-01             4             5             6             7
     """
 
-    # Note: It is possible to do this more simply with nested dict comprehension,
-    # but ends up making it ~5x slower.
-
-    # This gets the 'top level' names of the multi level column names
-    # it will contain names like 'model-output' and then sub column(s)
-    # of the actual model output.
-    names = df.columns.get_level_values(0).unique()
-
-    # Now a series where each row has an index with the name of the feature
-    # which corresponds to 'names' above.
-    records = (
-        # Stack the dataframe so second level column names become second level indexs
-        df.stack()
-        # For each column now, unstack the previous second level names (which are now the indexes of the series)
-        # back into a dataframe with those names, and convert to list; if it's a Series we'll need to reshape it
-        .apply(
-            lambda col: col.reindex(df[col.name].columns, level=1)
-            .unstack()
-            .dropna(axis=1)
-            .values.tolist()
-            if isinstance(df[col.name], pd.DataFrame)
-            else df[col.name].values.reshape(-1, 1).tolist()
-        )
+    keys = data.keys()
+    df: pd.DataFrame = pd.concat(
+        (pd.DataFrame.from_dict(data[key]) for key in keys), axis=1, keys=keys
     )
-
-    results: typing.List[dict] = []
-
-    for i, name in enumerate(names):
-
-        # For each top level name, we'll select its column, unstack so that
-        # previous second level names moved into the index will then be column
-        # names again, and convert that to a list, matched to the name.
-        values = map(lambda row: {name: row}, records[name])
-
-        # If we have results, we'll update the record/row data with this
-        # current name. ie {'col1': [1, 2}} -> {'col1': [1, 2], 'col2': [3, 4]}
-        # if the current column name is 'col2' and values [3, 4] for the first row,
-        # and so on.
-        if i == 0:
-            results = list(values)
-        else:
-            [rec.update(d) for rec, d in zip(results, values)]
-
-    return results
+    try:
+        df.index = pd.to_datetime(df.index)
+    except ValueError:
+        logger.debug("Could not parse index to pandas.DatetimeIndex")
+        pass  # It wasn't a datetime index after all, no worries.
+    return df
 
 
 def parse_iso_datetime(datetime_str: str) -> datetime:
@@ -166,6 +132,53 @@ def parse_iso_datetime(datetime_str: str) -> datetime:
             f" Example: for UTC timezone use {datetime_str + 'Z'} or {datetime_str + '+00:00'} "
         )
     return parsed_date
+
+
+def _df_or_response_from_dict(
+    data: Union[dict, list], expected_columns: List[str]
+) -> Union[Response, pd.DataFrame]:
+    """
+    Convert a dict or list of dicts into a :class:`pandas.core.DataFrame`.
+    Setting the column names to ``expected_columns`` if not already labeled and
+    the length of the columns match the length of the expected columns.
+
+    If it fails, it will return an instance of :class:`flask.wrappers.Response`
+
+    Parameters
+    ----------
+    data: Union[dict, list]
+        Data to convert into a dataframe with :meth:`pandas.core.DataFrame.from_dict`
+    expected_columns: List[str]
+        List of expected column names to give if the dataframe does not consist of them
+        but the number of columns matches ``len(expected_columns)``
+
+    Returns
+    -------
+    Union[flask.wrappers.Response, pandas.core.DataFrame]
+    """
+    df = pd.DataFrame.from_dict(data)
+
+    if not all(col in df.columns for col in expected_columns):
+
+        # If the length doesn't mach, then we can't reliably determine what data we have hre.
+        if len(df.columns) != len(expected_columns):
+            msg = dict(
+                message=f"Unexpected features: "
+                f"was expecting {expected_columns} length of {len(expected_columns)}, "
+                f"but got {df.columns} length of {len(df.columns)}"
+            )
+            return make_response((jsonify(msg), 400))
+
+        # Otherwise we were send a list/ndarray data format which we assume the client has
+        # ordered correctly to the order of the expected_columns.
+        else:
+            df.columns = expected_columns
+
+    # All columns exist in the dataframe, select them which thus ensures order and removes extra columns
+    else:
+        df = df[expected_columns]
+
+    return df
 
 
 def extract_X_y(method):
@@ -203,15 +216,17 @@ def extract_X_y(method):
                 return make_response((jsonify(message), 400))
 
             # Convert X and (maybe) y into dataframes.
-            X = dataframe_from_dict(
-                X, tags=list(tag.name for tag in self.tags), name="X"
-            )
+            try:
+                X = multi_lvl_column_dataframe_from_dict(X)
+            except (AttributeError, ValueError):
+                X = _df_or_response_from_dict(X, [t.name for t in self.tags])
 
             # Y is ok to be None for BaseView, view(s) like Anomaly might require it.
-            if y is not None and self.target_tags:
-                y = dataframe_from_dict(
-                    y, list(tag.name for tag in self.target_tags), name="y"
-                )
+            if y is not None:
+                try:
+                    y = multi_lvl_column_dataframe_from_dict(y)
+                except (AttributeError, ValueError):
+                    y = _df_or_response_from_dict(y, [t.name for t in self.target_tags])
 
             # If either X or y came back as a Response type, there was an error
             for data_or_resp in [X, y]:

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -17,7 +17,6 @@ from sklearn.base import BaseEstimator
 from gordo_components.client import Client, utils as client_utils
 from gordo_components.client.utils import EndpointMetadata
 from gordo_components.client import io as client_io
-from gordo_components.client.client import dataframe_from_dict_with_list_values
 from gordo_components.client.forwarders import ForwardPredictionsIntoInflux
 from gordo_components.data_provider import providers
 from gordo_components.server import utils as server_utils
@@ -433,10 +432,10 @@ def test_ml_server_dataframe_to_dict_and_back(tags: typing.List[str]):
     df = model_utils.make_base_dataframe(tags, original_input, model_output)
 
     # Server then converts this into a dict which maps top level names to lists
-    as_dict_to_list_vals = server_utils.multi_lvl_column_dataframe_to_dict(df)
+    serialized = server_utils.multi_lvl_column_dataframe_to_dict(df)
 
     # Client reproduces this dataframe
-    df_clone = dataframe_from_dict_with_list_values(as_dict_to_list_vals)
+    df_clone = server_utils.multi_lvl_column_dataframe_from_dict(serialized)
 
     # each subset of column under the top level names should be equal
     top_lvl_names = df.columns.get_level_values(0)


### PR DESCRIPTION
Will close #403 

Approach
------------
Server uses a method to serialized a `MultiIndex` column df into a json serializable `dict`, implemented a complimentary inverse of such a function for the client to use. This simplifies the (de)serialization of data between the client and the server. 

Did not pursue `msgpack` yet, as this seems to satisfy our issue anyhow, so maybe that's not needed anyway.