### PR TITLE
Fix logging-issue stemming from absl

### DIFF
--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -5,6 +5,8 @@ CLI interfaces
 """
 
 import logging
+import warnings
+import traceback
 import os
 
 import jinja2
@@ -25,6 +27,29 @@ from gordo_components.dataset.sensor_tag import normalize_sensor_tags
 
 import dateutil.parser
 
+try:
+    # FIXME(https://github.com/abseil/abseil-py/issues/99)
+    # FIXME(https://github.com/abseil/abseil-py/issues/102)
+    # Unfortunately, many libraries that include absl (including Tensorflow)
+    # will get bitten by double-logging due to absl's incorrect use of
+    # the python logging library:
+    #   2019-07-19 23:47:38,829 my_logger   779 : test
+    #   I0719 23:47:38.829330 139904865122112 foo.py:63] test
+    #   2019-07-19 23:47:38,829 my_logger   779 : test
+    #   I0719 23:47:38.829469 139904865122112 foo.py:63] test
+    # The code below fixes this double-logging.  FMI see:
+    #   https://github.com/tensorflow/tensorflow/issues/26691#issuecomment-500369493
+
+    import absl.logging
+
+    logging.root.removeHandler(absl.logging._absl_handler)
+    absl.logging._warn_preinit_stderr = False
+
+except Exception:
+    warnings.warn(f"Failed to fix absl logging bug {traceback.format_exc()}")
+    pass
+
+
 # Set log level, defaulting to DEBUG
 log_level = os.getenv("LOG_LEVEL", "DEBUG").upper()
 azure_log_level = os.getenv("AZURE_DATALAKE_LOG_LEVEL", "INFO").upper()
@@ -33,6 +58,7 @@ logging.basicConfig(
     level=getattr(logging, log_level),
     format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
 )
+
 logger = logging.getLogger(__name__)
 logging.getLogger("azure.datalake").setLevel(azure_log_level)
 


### PR DESCRIPTION
Tensorflow imports absl, and it breaks the standard logging module in
python by setting a handler on the root-level logger. The result is
that the log-level does not get set, and the format is all wrong.
This patch introduces an ugly fix I found on the internet to handle it.
Hopefully we can delete it in the future.

References:
https://github.com/tensorflow/tensorflow/issues/29842
https://github.com/tensorflow/tensorflow/issues/26691
https://github.com/abseil/abseil-py/issues/99