### PR TITLE
Extract model metadata from the depths

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -145,7 +145,7 @@ def _get_metadata(model: BaseEstimator, metadata: dict = dict()) -> dict:
     """
     Recursively check for :class:`gordo_components.model.base.GordoBase` in a
     given ``model``. If such a model exists buried inside of a
-    :class:`sklearn.pipelilne.Pipeline` which is then part of another
+    :class:`sklearn.pipeline.Pipeline` which is then part of another
     :class:`sklearn.base.BaseEstimator`, this function will return its metadata.
 
     Parameters

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import pytest
 import os
 import dateutil.parser
@@ -27,182 +26,163 @@ def get_random_data():
     return data
 
 
-class ModelBuilderTestCase(unittest.TestCase):
-    """
-    Test functionality of the builder processes
-    """
+def metadata_check(metadata, check_history):
+    assert "name" in metadata
+    assert "model" in metadata
+    assert "cross-validation" in metadata["model"]
+    assert "scores" in metadata["model"]["cross-validation"]
 
-    def test_output_dir(self):
-        """
-        Test building of model will create subdirectories for model saving if needed.
-        """
-        from gordo_components.builder import build_model
-
-        with TemporaryDirectory() as tmpdir:
-
-            model_config = {"sklearn.decomposition.pca.PCA": {"svd_solver": "auto"}}
-            data_config = get_random_data()
-            output_dir = os.path.join(tmpdir, "some", "sub", "directories")
-
-            model, metadata = build_model(
-                name="model-name",
-                model_config=model_config,
-                data_config=data_config,
-                metadata={},
-            )
-
-            self.metadata_check(metadata, False)
-
-            _save_model_for_workflow(
-                model=model, metadata=metadata, output_dir=output_dir
-            )
-
-            # Assert the model was saved at the location
-            # using gordo_components.serializer should create some subdir(s)
-            # which start with 'n_step'
-            dirs = [d for d in os.listdir(output_dir) if d.startswith("n_step")]
-            self.assertGreaterEqual(
-                len(dirs),
-                1,
-                msg="Expected saving of model to create at "
-                f"least one subdir, but got {len(dirs)}",
-            )
-
-    def test_model_builder_model_withouth_pipeline(self):
-
-        # MinMax is only a transformer and does not have a score either.
-        raw_model_config = """
-        sklearn.preprocessing.data.MinMaxScaler:
-            feature_range: [-1, 1]
-        """
-
-        model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
-        data_config = get_random_data()
-
-        model, metadata = build_model(
-            name="model-name",
-            model_config=model_config,
-            data_config=data_config,
-            metadata={},
+    # Scores is allowed to be an empty dict. in a case where the pipeline/transformer
+    # doesn't implement a .score()
+    if metadata["model"]["cross-validation"]["scores"] != dict():
+        assert "explained-variance" in metadata["model"]["cross-validation"]["scores"]
+    if check_history:
+        assert "history" in metadata["model"]
+        assert all(
+            name in metadata["model"]["history"] for name in ("params", "loss", "acc")
         )
 
-        self.metadata_check(metadata, False)
 
-    def test_model_builder_save_history(self):
-        """Checks that the metadata contains the keras model build history"""
-        raw_model_config = """
-        gordo_components.model.models.KerasAutoEncoder:
-            kind: feedforward_hourglass
-        """
+def test_output_dir(tmp_dir):
+    """
+    Test building of model will create subdirectories for model saving if needed.
+    """
+    from gordo_components.builder import build_model
 
-        model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
-        data_config = get_random_data()
+    model_config = {"sklearn.decomposition.pca.PCA": {"svd_solver": "auto"}}
+    data_config = get_random_data()
+    output_dir = os.path.join(tmp_dir.name, "some", "sub", "directories")
 
-        model, metadata = build_model(
-            name="model-name",
-            model_config=model_config,
-            data_config=data_config,
-            metadata={},
-        )
+    model, metadata = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+    )
+    metadata_check(metadata, False)
 
-        self.metadata_check(metadata, True)
+    _save_model_for_workflow(model=model, metadata=metadata, output_dir=output_dir)
 
-    def test_model_builder_pipeline(self):
-        raw_model_config = """
+    # Assert the model was saved at the location
+    # using gordo_components.serializer should create some subdir(s)
+    # which start with 'n_step'
+    dirs = [d for d in os.listdir(output_dir) if d.startswith("n_step")]
+    assert (
+        len(dirs) >= 1
+    ), "Expected saving of model to create at least one subdir, but got {len(dirs)}"
+
+
+def test_model_builder_model_withouth_pipeline():
+
+    # MinMax is only a transformer and does not have a score either.
+    raw_model_config = """
+    sklearn.preprocessing.data.MinMaxScaler:
+        feature_range: [-1, 1]
+    """
+
+    model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
+    data_config = get_random_data()
+
+    model, metadata = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+    )
+    metadata_check(metadata, False)
+
+
+def test_model_builder_save_history():
+    """Checks that the metadata contains the keras model build history"""
+    raw_model_config = """
+    gordo_components.model.models.KerasAutoEncoder:
+        kind: feedforward_hourglass
+    """
+
+    model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
+    data_config = get_random_data()
+
+    model, metadata = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+    )
+    metadata_check(metadata, True)
+
+
+def test_model_builder_pipeline():
+    raw_model_config = """
+    sklearn.pipeline.Pipeline:
+        steps:
+          - sklearn.preprocessing.data.MinMaxScaler
+          - sklearn.decomposition.pca.PCA:
+              svd_solver: auto
+    """
+
+    model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
+    data_config = get_random_data()
+
+    model, metadata = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+    )
+    metadata_check(metadata, False)
+
+
+def test_model_builder_pipeline_in_pipeline():
+    from gordo_components.builder import build_model
+    import yaml
+
+    raw_model_config = """
         sklearn.pipeline.Pipeline:
             steps:
-              - sklearn.preprocessing.data.MinMaxScaler
-              - sklearn.decomposition.pca.PCA:
-                  svd_solver: auto
+              - sklearn.pipeline.Pipeline:
+                  steps:
+                    - sklearn.preprocessing.data.MinMaxScaler
+              - sklearn.pipeline.Pipeline:
+                  steps:
+                    - sklearn.decomposition.pca.PCA:
+                        svd_solver: auto
         """
 
-        model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
-        data_config = get_random_data()
+    model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
+    data_config = get_random_data()
 
-        model, metadata = build_model(
-            name="model-name",
-            model_config=model_config,
-            data_config=data_config,
-            metadata={},
-        )
+    model, metadata = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+    )
+    metadata_check(metadata, False)
 
-        self.metadata_check(metadata, False)
 
-    def test_model_builder_pipeline_in_pipeline(self):
-        from gordo_components.builder import build_model
-        import yaml
+def test_provide_saved_model_simple_happy_path(tmp_dir):
+    """
+    Test provide_saved_model with no caching
+    """
+    model_config = {"sklearn.decomposition.pca.PCA": {"svd_solver": "auto"}}
+    data_config = get_random_data()
+    output_dir = os.path.join(tmp_dir.name, "model")
 
-        raw_model_config = """
-            sklearn.pipeline.Pipeline:
-                steps:
-                  - sklearn.pipeline.Pipeline:
-                      steps:
-                        - sklearn.preprocessing.data.MinMaxScaler
-                  - sklearn.pipeline.Pipeline:
-                      steps:
-                        - sklearn.decomposition.pca.PCA:
-                            svd_solver: auto
-            """
+    model_location = provide_saved_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+        output_dir=output_dir,
+    )
 
-        model_config = yaml.load(raw_model_config, Loader=yaml.FullLoader)
-        data_config = get_random_data()
-
-        model, metadata = build_model(
-            name="model-name",
-            model_config=model_config,
-            data_config=data_config,
-            metadata={},
-        )
-
-        self.metadata_check(metadata, False)
-
-    def metadata_check(self, metadata, check_history):
-        self.assertTrue("name" in metadata)
-        self.assertTrue("model" in metadata)
-        self.assertTrue("cross-validation" in metadata["model"])
-        self.assertTrue("scores" in metadata["model"]["cross-validation"])
-
-        # Scores is allowed to be an empty dict. in a case where the pipeline/transformer
-        # doesn't implement a .score()
-        if metadata["model"]["cross-validation"]["scores"] != dict():
-            self.assertTrue(
-                "explained-variance" in metadata["model"]["cross-validation"]["scores"]
-            )
-        if check_history:
-            self.assertTrue("history" in metadata["model"])
-            self.assertTrue("params" in metadata["model"]["history"])
-            self.assertTrue("loss" in metadata["model"]["history"])
-            self.assertTrue("acc" in metadata["model"]["history"])
-
-    def test_provide_saved_model_simple_happy_path(self):
-        """
-        Test provide_saved_model with no caching
-        """
-
-        with TemporaryDirectory() as tmpdir:
-
-            model_config = {"sklearn.decomposition.pca.PCA": {"svd_solver": "auto"}}
-            data_config = get_random_data()
-            output_dir = os.path.join(tmpdir, "model")
-
-            model_location = provide_saved_model(
-                name="model-name",
-                model_config=model_config,
-                data_config=data_config,
-                metadata={},
-                output_dir=output_dir,
-            )
-
-            # Assert the model was saved at the location
-            # using gordo_components.serializer should create some subdir(s)
-            # which start with 'n_step'
-            dirs = [d for d in os.listdir(model_location) if d.startswith("n_step")]
-            self.assertGreaterEqual(
-                len(dirs),
-                1,
-                msg="Expected saving of model to create at "
-                f"least one subdir, but got {len(dirs)}",
-            )
+    # Assert the model was saved at the location
+    # using gordo_components.serializer should create some subdir(s)
+    # which start with 'n_step'
+    dirs = [d for d in os.listdir(model_location) if d.startswith("n_step")]
+    assert (
+        len(dirs) >= 1
+    ), "Expected saving of model to create at least one subdir, but got {len(dirs)}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Will close #418 

Context
-----------
Models such as our `Keras` models generate some metadata which we like to have; typically with `.get_metadata()`

Problem
-----------
When a model is tucked away inside a pipeline, we use to dig into it, finding the last step and ran this `.get_metadata()`

Now as the model is in a pipeline, which is then in another estimator which is passed as a parameter, and an arbitrary amount of nested models later, we basically don't know where the _final_ model is at.

Solution
-----------
Recursively check attributes of the model for sub-models which are `GordoBase` instances.