### PR TITLE
Make client auto choose prediction endpoint

### DIFF
--- a/gordo_components/client/io.py
+++ b/gordo_components/client/io.py
@@ -6,6 +6,16 @@ import aiohttp
 from werkzeug.exceptions import BadRequest
 
 
+class HttpUnprocessableEntity(BaseException):
+    """
+    Represents an error from an HTTP status code of 422: UnprocessableEntity.
+    Used in our case for calling /anomaly/prediction on a model which does not
+    support anomaly behavior.
+    """
+
+    pass
+
+
 async def fetch_json(
     url: str, *args, session: Optional[aiohttp.ClientSession] = None, **kwargs
 ) -> dict:
@@ -73,7 +83,9 @@ async def _handle_json(resp: aiohttp.ClientResponse) -> dict:
         content = await resp.content.read()
         msg = f"Failed to get JSON with status code: {resp.status}: {content}"
 
-        if 400 <= resp.status <= 499:
+        if resp.status == 422:
+            raise HttpUnprocessableEntity()
+        elif 400 <= resp.status <= 499:
             raise BadRequest(msg)
         else:
             raise IOError(msg)


### PR DESCRIPTION
Will close #400 

Problem
-----------
We use to have to manually specify `prediction_path` to `Client` for either `/prediction` or `/anomaly/prediction`

Solution
-----------
Now that we are returning `422` status code if the model being served is not an AnomalyDetector, the client can default to `/anomaly/prediction` and when it gets a `422` can update its `prediction_path` to `/prediction` instead for all future requests.