### PR TITLE
Add **kwargs to sub_providers (iroc and ncs_reader)

### DIFF
--- a/gordo_components/data_provider/ncs_reader.py
+++ b/gordo_components/data_provider/ncs_reader.py
@@ -29,7 +29,11 @@ class NcsReader(GordoBaseDataProvider):
     }
 
     def __init__(
-        self, client: core.AzureDLFileSystem, threads: Optional[int] = 1, **kwargs
+        self,
+        client: core.AzureDLFileSystem,
+        threads: Optional[int] = 1,
+        remove_status_codes: Optional[list] = [0],
+        **kwargs,
     ):
         """
         Creates a reader for tags from the Norwegian Continental Shelf. Currently
@@ -39,11 +43,15 @@ class NcsReader(GordoBaseDataProvider):
         ----------
         threads : Optional[int]
             Number of threads to use. If None then use 1 thread
+        remove_status_codes: Optional[list]
+            Removes data with Status code(s) in the list. By default it removes data
+            with Status code 0.
 
         """
         super().__init__(**kwargs)
         self.client = client
         self.threads = threads
+        self.remove_status_codes = remove_status_codes
         logger.info(f"Starting NCS reader with {self.threads} threads")
 
     def can_handle_tag(self, tag: SensorTag):
@@ -58,7 +66,6 @@ class NcsReader(GordoBaseDataProvider):
         to_ts: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
-        remove_status_codes: Optional[list] = [0],
     ) -> Iterable[pd.Series]:
         """
         See GordoBaseDataProvider for documentation
@@ -78,7 +85,7 @@ class NcsReader(GordoBaseDataProvider):
                     tag=tag,
                     years=years,
                     dry_run=dry_run,
-                    remove_status_codes=remove_status_codes,
+                    remove_status_codes=self.remove_status_codes,
                 ),
                 tag_list,
             )
@@ -113,7 +120,7 @@ class NcsReader(GordoBaseDataProvider):
         dry_run: bool
             if True, don't download data, just check info, log, and return
         remove_status_codes: list
-            removes data with Status code(s) in the list. By default it removes data
+            Removes data with Status code(s) in the list. By default it removes data
             with Status code 0.
 
         Returns

--- a/gordo_components/data_provider/providers.py
+++ b/gordo_components/data_provider/providers.py
@@ -123,6 +123,7 @@ class DataLakeProvider(GordoBaseDataProvider):
         )
         self.threads = threads
         self.client = None
+        self.kwargs = kwargs
 
     def load_series(
         self,
@@ -159,7 +160,7 @@ class DataLakeProvider(GordoBaseDataProvider):
 
     def _get_sub_dataproviders(self):
         data_providers = [
-            t_reader(client=self._get_client(), threads=self.threads)
+            t_reader(client=self._get_client(), threads=self.threads, **self.kwargs)
             for t_reader in DataLakeProvider._SUB_READER_CLASSES
         ]
         return data_providers


### PR DESCRIPTION
The test: ```test_load_series_with_filter_bad_data``` broke because it used a parameter (```remove_bad_values```) which is now passed from kwargs in the DataLakeProvider (so it can be used by end-users). Therefore that test is fixed by passing the parameter directly into the NcsReader's __init__.  Fixes #387 