### PR TITLE
Allow serialization of hidden Gordo models & wrapper for metric functions

### DIFF
--- a/gordo_components/model/utils.py
+++ b/gordo_components/model/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import typing
+import functools
 from typing import Optional, Union, List
 from datetime import timedelta, datetime
 
@@ -8,6 +9,19 @@ import numpy as np
 import pandas as pd
 
 from gordo_components.dataset.sensor_tag import SensorTag
+
+
+def metric_wrapper(metric):
+    """
+    Ensures that a given metric works properly when the model itself returns
+    a y which is shorter than the target y.
+    """
+
+    @functools.wraps(metric)
+    def _wrapper(y_true, y_pred, *args, **kwargs):
+        return metric(y_true[-len(y_pred) :], y_pred, *args, **kwargs)
+
+    return _wrapper
 
 
 def make_base_dataframe(

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Dict
 from tempfile import TemporaryDirectory
 
 import pytest
-import sklearn
 import numpy as np
 
 import gordo_components


### PR DESCRIPTION
Meant as a temp fix, until we can get `GordoBase` models to be pickle-able (namely, Keras models because we save the tensorflow graph as part of the model).

Problem :warning: 
-----------
If a Keras model is hidden in an attribute of another estimator, the serializer won't see it and attempt to pickle it; which won't work.

Solution :bulb: 
-----------
Iterate over the attributes of the estimator, and if it's a GordoBase, save the model to a sub dir where this model will be saved, and update the original attribute to hold metadata about how to load back that attribute.


Bonus! :tada: 
---------
Added wrapper for scoring functions to ensure their input is aligned. ie. If X, y was given to an LSTM, it's output is less than `y`, the wrapper will match the offset of `yhat` so the scoring function operates without problem.