### PR TITLE
Fix overwrite of y in KerasLSTMAutoEncoder.fit

### DIFF
--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -421,8 +421,8 @@ class KerasLSTMAutoEncoder(KerasLSTMBaseEstimator):
             lookback_window=self.lookback_window,
             lookahead=lookahead,
         )
-        x, y = tsg[0]
-        super().fit(X=x, y=y, epochs=1, verbose=0)
+        _x, _y = tsg[0]
+        super().fit(X=_x, y=_y, epochs=1, verbose=0)
 
         tsg = create_keras_timeseriesgenerator(
             X=X,


### PR DESCRIPTION
Problem :alarm_clock: 
-----------
After refactoring the models to take a `y`, a mistake was made by me, in which during the fitting, the original `y` was overwritten with what was suppose to be the primer to create the underlying model.

Solution :bulb: 
-----------
Give that `y` a different name, explicit that it is _not_ the original `X` and `y` it should be fitting on.