### PR TITLE
Support single level dataframes in serialization funcs

### DIFF
--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -386,8 +386,8 @@ class Client:
         """
 
         json = {
-            "X": server_utils.multi_lvl_column_dataframe_to_dict(X.iloc[chunk]),
-            "y": server_utils.multi_lvl_column_dataframe_to_dict(y.iloc[chunk])
+            "X": server_utils.dataframe_to_dict(X.iloc[chunk]),
+            "y": server_utils.dataframe_to_dict(y.iloc[chunk])
             if y is not None
             else None,
         }
@@ -448,9 +448,7 @@ class Client:
             # Process response and return if no exception
             else:
 
-                predictions = server_utils.multi_lvl_column_dataframe_from_dict(
-                    resp["data"]
-                )
+                predictions = server_utils.dataframe_from_dict(resp["data"])
 
                 # Forward predictions to any other consumer if registered.
                 if self.prediction_forwarder is not None:
@@ -550,9 +548,7 @@ class Client:
             )
 
         logger.info(f"Processing {start} -> {end}")
-        predictions = server_utils.multi_lvl_column_dataframe_from_dict(
-            response["data"]
-        )
+        predictions = server_utils.dataframe_from_dict(response["data"])
 
         if self.prediction_forwarder is not None:
             await self.prediction_forwarder(

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -161,7 +161,7 @@ class AnomalyView(BaseModelView):
             return make_response(jsonify(msg), 422)  # 422 Unprocessable Entity
 
         context: typing.Dict[typing.Any, typing.Any] = dict()
-        context["data"] = utils.multi_lvl_column_dataframe_to_dict(anomaly_df)
+        context["data"] = utils.dataframe_to_dict(anomaly_df)
         context["time-seconds"] = f"{timeit.default_timer() - start_time:.4f}"
         return make_response(jsonify(context), context.pop("status-code", 200))
 

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -145,12 +145,6 @@ class AnomalyView(BaseModelView):
             }
             return make_response((jsonify(message), 400))
 
-        # It is ok for y to be a subset of features in X, but we need at least one
-        # to compare against to calculate an error.
-        if not any(col in g.y.columns for col in [t.name for t in self.tags]):
-            message = {"message": "y is not a subset of X, cannot do anomaly detection"}
-            return make_response(jsonify(message), 400)
-
         # Now create an anomaly dataframe from the base response dataframe
         try:
             anomaly_df = current_app.model.anomaly(g.X, g.y, frequency=self.frequency)

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -206,7 +206,7 @@ class BaseModelView(Resource):
                 target_tag_list=self.target_tags,
                 index=X.index,
             )
-            context["data"] = server_utils.multi_lvl_column_dataframe_to_dict(data)
+            context["data"] = server_utils.dataframe_to_dict(data)
             return make_response((jsonify(context), context.pop("status-code", 200)))
 
 

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -432,10 +432,10 @@ def test_ml_server_dataframe_to_dict_and_back(tags: typing.List[str]):
     df = model_utils.make_base_dataframe(tags, original_input, model_output)
 
     # Server then converts this into a dict which maps top level names to lists
-    serialized = server_utils.multi_lvl_column_dataframe_to_dict(df)
+    serialized = server_utils.dataframe_to_dict(df)
 
     # Client reproduces this dataframe
-    df_clone = server_utils.multi_lvl_column_dataframe_from_dict(serialized)
+    df_clone = server_utils.dataframe_from_dict(serialized)
 
     # each subset of column under the top level names should be equal
     top_lvl_names = df.columns.get_level_values(0)

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -43,7 +43,7 @@ def test_anomaly_prediction_endpoint(
     assert "data" in resp.json
 
     # Load data into dataframe
-    data = server_utils.multi_lvl_column_dataframe_from_dict(resp.json["data"])
+    data = server_utils.dataframe_from_dict(resp.json["data"])
 
     # Only different between POST and GET is POST will return None for
     # start and end dates, because the server can't know what those are
@@ -94,7 +94,7 @@ def test_overlapping_time_buckets(influxdb, gordo_ml_server_client):
         json={"start": "2016-01-01T00:11:00+00:00", "end": "2016-01-01T00:21:00+00:00"},
     )
     assert resp.status_code == 200
-    data = server_utils.multi_lvl_column_dataframe_from_dict(resp.json["data"])
+    data = server_utils.dataframe_from_dict(resp.json["data"])
 
     assert len(data) == 1, f"Expected one prediction, got: {resp.json}"
     assert data["start"].iloc[0].tolist() == ["2016-01-01T00:10:00+00:00"]

--- a/tests/gordo_components/server/test_base_view.py
+++ b/tests/gordo_components/server/test_base_view.py
@@ -43,7 +43,7 @@ def test_prediction_endpoint_post_ok(sensors, gordo_ml_server_client, data_to_po
 
     assert resp.status_code == 200
 
-    data = server_utils.multi_lvl_column_dataframe_from_dict(resp.json["data"])
+    data = server_utils.dataframe_from_dict(resp.json["data"])
 
     # Expected column names
     assert all(key in data for key in ("model-output", "model-input"))

--- a/tests/gordo_components/server/test_utils.py
+++ b/tests/gordo_components/server/test_utils.py
@@ -1,28 +1,62 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 import pandas as pd
 import numpy as np
 
 from gordo_components.server import utils as server_utils
 
 
-def test_multi_lvl_column_dataframe_from_to_dict():
+@pytest.mark.parametrize(
+    "df",
+    [
+        # Multi-column
+        pd.DataFrame(
+            np.random.random((10, 4)),
+            columns=pd.MultiIndex.from_product(
+                (("feature1", "feature2"), ("col1", "col2"))
+            ),
+            index=pd.date_range("2016-01-01", "2016-02-01", periods=10),
+        ),
+        # Normal dataframe, no date index
+        pd.DataFrame(
+            np.random.random((10, 4)), columns=["col1", "col2", "col3", "col4"]
+        ),
+    ],
+)
+def test_dataframe_from_to_dict(df):
+    """
+    Test (de)serializations back and forth between dataframe -> dict -> dataframe
+    """
+    index_was_datetimes: bool = isinstance(df.index, pd.DatetimeIndex)
 
-    columns = pd.MultiIndex.from_product((("feature1", "feature2"), ("col1", "col2")))
-    df = pd.DataFrame(
-        np.random.random((10, 4)),
-        columns=columns,
-        index=pd.date_range("2016-01-01", "2016-02-01", periods=10),
-    )
+    cloned = server_utils.dataframe_from_dict(server_utils.dataframe_to_dict(df))
 
-    assert isinstance(df.index, pd.DatetimeIndex)
-
-    cloned = server_utils.multi_lvl_column_dataframe_from_dict(
-        server_utils.multi_lvl_column_dataframe_to_dict(df)
-    )
-
-    # Ensure the function hasn't mutated the index.
-    assert isinstance(df.index, pd.DatetimeIndex)
+    if index_was_datetimes:
+        # Ensure the function hasn't mutated the index.
+        assert isinstance(df.index, pd.DatetimeIndex)
 
     assert np.allclose(df.values, cloned.values)
     assert df.columns.tolist() == cloned.columns.tolist()
+    assert df.index.tolist() == cloned.index.tolist()
+
+
+@pytest.mark.parametrize(
+    "expect_multi_lvl, data",
+    [
+        (False, {"col1": [0, 1, 2, 3], "col2": [0, 1, 2, 3]}),
+        (True, {("ft1", "col1"): [0, 1, 2, 3], ("ft1", "col2"): [0, 1, 2, 3]}),
+        (True, {"ft1": {"col1": [0, 1, 2]}, "ft2": {"col1": [0, 1, 2]}}),
+        (False, [[0, 1, 2], [0, 1, 2]]),
+    ],
+)
+def test_dataframe_to_from_dict(expect_multi_lvl: bool, data: dict):
+    """
+    Creating dataframes from various raw data structures should have determined behavior
+    such as not creating MultiIndex columns with a dict of simple key to array mappings.
+    """
+    df = server_utils.dataframe_from_dict(data)
+    if expect_multi_lvl:
+        assert isinstance(df.columns, pd.MultiIndex)
+    else:
+        assert not isinstance(df.columns, pd.MultiIndex)


### PR DESCRIPTION
Problem :alarm_clock: 
-----------
Sending a multi-level column dataframe to the server, while serving a model with `ColumnTransformer` will cause it to fail.

Solution :checkered_flag: 
-----------
Trying to _only_ accept single level dataframes, causes problems when `.to_dict()` on a dataframe with `datatime` index, is not JSON serializable.

Fortunately, this problem is already addressed in the serialization functions of multi-level dataframes. Therefore, updating those functions to serialize and deserialize single level dataframes solves both issues. And thus have renamed those functions to `dataframe_from/to_dict` 

Bonus :gift: 
--------
While running the gordo test project, the `RandomForestRegressor` as a `DiffBasedAnomalyDetector` failed with 
```json
{"message": "y is not a subset of X, cannot do anomaly detection"}
```
But this is no longer valid; for example, our `DiffBasedAnomalyDetector` only compares the `y` against the model output. So that check in the `AnomalyView` was removed.