### PR TITLE
Cli dockstring fix

### DIFF
--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -154,6 +154,14 @@ def build(
     data_config: dict
         kwargs to be used in intializing the dataset. Should also
         contain kwarg 'type' which references the dataset to use. ie. InfluxBackedDataset
+    data_provider: str
+        A quoted data provider configuration in  JSON/YAML format.
+        Should also contain key 'type' which references the data provider to use.
+
+        Example::
+
+          '{"type": "DataLakeProvider", "storename" : "example_store"}'
+
     metadata: dict
         Any additional metadata to save under the key 'user-defined'
     model_register_dir: path

--- a/gordo_components/cli/custom_types.py
+++ b/gordo_components/cli/custom_types.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import json
 import typing
 
 import yaml
@@ -13,7 +12,7 @@ from gordo_components.data_provider import providers
 
 class DataProviderParam(click.ParamType):
     """
-    Load a DataProvider from JSON/dict representation or from a JSON file
+    Load a DataProvider from JSON/YAML representation or from a JSON/YAML file
     """
 
     name = "data-provider"
@@ -21,7 +20,7 @@ class DataProviderParam(click.ParamType):
     def convert(self, value, param, ctx):
         if os.path.isfile(value):
             with open(value) as f:
-                kwargs = json.load(f)
+                kwargs = yaml.safe_load(f)
         else:
             kwargs = yaml.safe_load(value)
 


### PR DESCRIPTION
Change docstring of build in ```cli.py``` to contain data-provider and also change the ```DataProviderParam``` in ```custom_types.py``` to accept yaml from file, not only json.  Fixes #438