### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-absl-py==0.7.1            # via tensorboard, tensorflow
+absl-py==0.8.0            # via tensorboard, tensorflow
 adal==1.2.2               # via azure-datalake-store, kubernetes
 aiodns==2.0.0
 aiohttp==3.5.4
@@ -14,7 +14,7 @@ asn1crypto==0.24.0        # via cryptography
 astor==0.8.0              # via tensorflow
 async-timeout==3.0.1      # via aiohttp
 attrs==19.1.0             # via aiohttp, jsonschema
-azure-datalake-store==0.0.46
+azure-datalake-store==0.0.47
 cachetools==3.1.1
 cchardet==2.1.4
 certifi==2019.6.16        # via kubernetes, requests
@@ -28,30 +28,30 @@ flask==1.1.1
 gast==0.2.2               # via tensorflow
 google-auth==1.6.3        # via kubernetes
 google-pasta==0.1.7       # via tensorflow
-grpcio==1.22.0            # via tensorboard, tensorflow
+grpcio==1.23.0            # via tensorboard, tensorflow
 h5py==2.9.0
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, requests, yarl
-influxdb==5.2.2
+influxdb==5.2.3
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1
 joblib==0.13.2
 jsonschema==3.0.2         # via flask-restplus
 keras-applications==1.0.8  # via keras, tensorflow
 keras-preprocessing==1.1.0  # via keras, tensorflow
-keras==2.2.4
+keras==2.2.5
 kubernetes==8.0.2
 markdown==3.1.1           # via tensorboard
 markupsafe==1.1.1         # via jinja2
 multidict==4.5.2          # via aiohttp, yarl
-numexpr==2.6.9
-numpy==1.17.0
+numexpr==2.7.0
+numpy==1.17.1
 oauthlib==3.1.0           # via requests-oauthlib
-pandas==0.25.0
+pandas==0.25.1
 pip-tools==3.9.0
 protobuf==3.9.1
 pyasn1-modules==0.2.6     # via google-auth
-pyasn1==0.4.6             # via pyasn1-modules, rsa
+pyasn1==0.4.7             # via pyasn1-modules, rsa
 pycares==3.0.0            # via aiodns
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via adal
@@ -71,14 +71,14 @@ tensorflow-estimator==1.14.0  # via tensorflow
 tensorflow==1.14.0
 termcolor==1.1.0          # via tensorflow
 typing-extensions==3.7.4  # via aiohttp
-typing==3.7.4             # via aiodns
+typing==3.7.4.1           # via aiodns
 tzlocal==2.0.0            # via apscheduler
 urllib3==1.25.3
 websocket-client==0.56.0  # via kubernetes
 werkzeug==0.15.5          # via flask, tensorboard
-wheel==0.33.4             # via tensorboard, tensorflow
+wheel==0.33.6             # via tensorboard, tensorflow
 wrapt==1.11.2             # via tensorflow
 yarl==1.3.0               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.1.0        # via apscheduler, jsonschema, kubernetes, markdown, protobuf, tensorboard
+# setuptools==41.2.0        # via apscheduler, jsonschema, kubernetes, markdown, protobuf, tensorboard


### PR DESCRIPTION
Patch versions of pandas, numpy, and keras, pluss dependencies.

Pandas has a patch release 0.25.1, which [fixes several regressions](https://pandas.pydata.org/pandas-docs/version/0.25/whatsnew/v0.25.1.html), including several time-related ones, so we probably want it. 