### PR TITLE
Add model offset to metadata

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -8,6 +8,9 @@ import time
 from pathlib import Path
 from typing import Union, Optional, Dict, Any
 
+import pandas as pd
+import numpy as np
+
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import cross_val_score, TimeSeriesSplit
 from sklearn.metrics import explained_variance_score, make_scorer
@@ -123,6 +126,28 @@ def build_model(
     metadata["model"].update(_get_metadata(model))
 
     return model, metadata
+
+
+def _determine_offset(model: BaseEstimator, X: Union[np.ndarray, pd.DataFrame]) -> int:
+    """
+    Determine the model's offset. How much does the output of the model differ
+    from its input?
+
+    Parameters
+    ----------
+    model: sklearn.base.BaseEstimator
+        Trained model with either ``predict`` or ``transform`` method, preference
+        given to ``predict``.
+    X: Union[np.ndarray, pd.DataFrame]
+        Data to pass to the model's ``predict`` or ``transform`` method.
+
+    Returns
+    -------
+    int
+        The difference between X and the model's output lengths.
+    """
+    out = model.predict(X) if hasattr(model, "predict") else model.transform(X)
+    return len(X) - len(out)
 
 
 def _save_model_for_workflow(

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -115,6 +115,7 @@ def build_model(
     metadata["dataset"] = dataset.get_metadata()
     utc_dt = datetime.datetime.now(datetime.timezone.utc)
     metadata["model"] = {
+        "model-offset": _determine_offset(model, X),
         "model-creation-date": str(utc_dt.astimezone()),
         "model-builder-version": __version__,
         "model-config": model_config,

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -44,6 +44,8 @@ def metadata_check(metadata, check_history):
     assert "model" in metadata
     assert "cross-validation" in metadata["model"]
     assert "scores" in metadata["model"]["cross-validation"]
+    assert "model-offset" in metadata["model"]
+    assert isinstance(metadata["model"]["model-offset"], int)
 
     # Scores is allowed to be an empty dict. in a case where the pipeline/transformer
     # doesn't implement a .score()


### PR DESCRIPTION
Part of #443 

Problem :radioactive: 
-----------
When serving a model such as LSTMs, we don't have a clear idea that it will return less data than it got in; less looking in depth at the model metadata in an non-deterministic way.

Solution :racehorse: 
-----------
During model building, determine what the offset of the model is, and put that in a predetermined place in the model's metadata. `model-offset`