### PR TITLE
Client adjust for offset

### DIFF
--- a/gordo_components/client/utils.py
+++ b/gordo_components/client/utils.py
@@ -8,7 +8,8 @@ from influxdb import DataFrameClient, InfluxDBClient
 
 # Representation of data gathered from Watchman for a given endpoint
 EndpointMetadata = namedtuple(
-    "Endpoint", "target_name healthy endpoint tag_list target_tag_list resolution"
+    "Endpoint",
+    "target_name healthy endpoint tag_list target_tag_list resolution model_offset",
 )
 
 # Prediction result representation, name=str, predictions=dataframe, error_messages=List[str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def trained_model_directory(sensors: List[SensorTag]):
                     "target_tag_list": sensors,
                 },
                 "name": "machine-1",
+                "model": {"model-offset": 0},
                 "user-defined": {"model-name": "test-model"},
             },
         )

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -292,7 +292,7 @@ def test_client_cli_predict(
     if forwarder_args and data_provider:
         vals = influx_client.query(query)
         assert len(vals) == 1
-        assert len(vals["resampled"]) == 28
+        assert len(vals["resampled"]) == 48
         influx_client.drop_measurement("resampled")
 
     # Did it save dataframes to output dir if specified?
@@ -380,6 +380,7 @@ def _endpoint_metadata(name: str, healthy: bool) -> EndpointMetadata:
         tag_list=None,
         target_tag_list=None,
         resolution=None,
+        model_offset=None,
     )
 
 

--- a/tests/gordo_components/client/test_forwarders.py
+++ b/tests/gordo_components/client/test_forwarders.py
@@ -23,6 +23,7 @@ async def test_influx_forwarder(influxdb):
         tag_list=tu.SENSORTAG_LIST,
         target_tag_list=tu.SENSORTAG_LIST,
         resolution="10T",
+        model_offset=0,
     )
 
     # Feature outs which match length of tags


### PR DESCRIPTION
Will close #443 

Problem :question: 
-----------
When the client asks the ML server for predictions, it doesn't know about any offset the model might have and thus doesn't now (or care) that the returned length may be different.

Solution :hammer: 
-----------
#444 Adds `model-offset` to the metadata in a predefined location. This has the client look at that value and 'backup' the initial requested start date by the `resolution` * `model-offset` so that returned predictions will contain the initially requested prediction time range.



Dependencies :handshake: 
-------------------
- #444 

