### PR TITLE
Clean up tests / CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,26 @@ commands:
             source ~/code/venv/bin/activate
             python setup.py test<< parameters.for >>
       - run:
-          name: Upload Test Coverage
-          command: bash <(curl -s https://codecov.io/bash)
+          name: Move coverage report to workspace
+          command: |
+            mkdir /tmp/coverage-reports
+            mv ./coverage.xml /tmp/coverage-reports/<< parameters.for >>-coverage.xml
+      - persist_to_workspace:
+          root: /tmp/coverage-reports
+          paths:
+            - ./*-coverage.xml
       - save-eggs-cache
+  upload-coverage-reports:
+    description: "Upload the coverage reports"
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/coverage-reports
+      - run:
+          name: "Upload coverage reports"
+          command: |
+            cp /tmp/coverage-reports/*.xml .
+            bash <(curl -s https://codecov.io/bash)
 
 jobs:
 
@@ -229,6 +246,11 @@ jobs:
       - run-test:
           for: allelse
 
+  upload-coverage-reports:
+    executor: python-executor
+    steps:
+      - upload-coverage-reports
+
 workflows:
   version: 2.1
 
@@ -279,9 +301,8 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
-      - push-images:
+      - upload-coverage-reports:
           requires:
-            - make-images
             - test-builder
             - test-cli
             - test-client
@@ -294,6 +315,15 @@ workflows:
             - test-watchman
             - test-formatting
             - test-allelse
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - push-images:
+          requires:
+            - make-images
+            - upload-coverage-reports
           filters:
             branches:
               only:

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -27,40 +27,6 @@ from gordo_components.cli import custom_types
 from tests import utils as tu
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("session", (True, False))
-@pytest.mark.parametrize("timeout", (5, None))
-@pytest.mark.parametrize("params", ({"key": "value"}, {}))
-async def test_client_fetch_json(httpbin, session, timeout, params):
-    """
-    Test fetch_json accepts specific kwargs
-    """
-    session = aiohttp.ClientSession() if session else None
-    resp = await client_io.fetch_json(
-        f"http://{httpbin}/get", session=session, timeout=timeout, params=params
-    )
-    assert params == resp["args"]
-    if session:
-        await session.close()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("session", (True, False))
-@pytest.mark.parametrize("timeout", (5, None))
-@pytest.mark.parametrize("json", ({"key": "value"}, {}))
-async def test_client_post_json(httpbin, session, timeout, json):
-    """
-    Test post_json accepts specific kwargs
-    """
-    session = aiohttp.ClientSession() if session else None
-    resp = await client_io.post_json(
-        f"http://{httpbin}/post", session=session, timeout=timeout, json=json
-    )
-    assert json == resp["json"]
-    if session:
-        await session.close()
-
-
 def test_client_get_metadata(watchman_service):
     """
     Test client's ability to get metadata from some target


### PR DESCRIPTION
Problems :skull_and_crossbones: 
-----------

- Uploading code coverage on each tests cost some time, maybe ~1-2min per in some bad cases.
- Client's get/post json tests use httpbin dockerfile, which we don't like
- Model tests by far take the longest, ~5-7mins

Solution :nail_care: 
-----------

- [x] Collect the reports into a `workspace` and then upload all at once
- [x] Remove those client post/fetch json tests
~Optimize the model component testing~