### PR TITLE
Add missing space in docker_push.sh

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -29,7 +29,7 @@
 #                  Defaults to false
 # DOCKER_REPO: The docker repository of concern
 
-if [[ -z "${DOCKER_REGISTRY}"]]; then
+if [[ -z "${DOCKER_REGISTRY}" ]]; then
     echo "DOCKER_REGISTRY must be set, exiting"
     exit 1
 fi


### PR DESCRIPTION
Problem :man_technologist: 
-----------
I suck at writing bash scripts.

Solution :writing_hand: 
-----------
Add missing space to the `docker_push.sh`, because that's of utmost importance.

---

![image](https://user-images.githubusercontent.com/13764397/65267425-3ca8c380-db15-11e9-9118-b172d84cf0b7.png)
