### PR TITLE
Upgrade pip before install starts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ jobs:
           command: |
             python -m venv ~/code/venv
             echo "source ~/code/venv/bin/activate" >> $BASH_ENV
+      - run: pip install --upgrade pip
       - run:
           name: Install Requirements
           command: |


### PR DESCRIPTION
Problem :night_with_stars: 
---
![image](https://user-images.githubusercontent.com/13764397/65301840-554ac500-db79-11e9-85d0-2165c417b9bf.png)

Solution :sunrise: 
---
Add step before install begins to upgrade pip, which results in substantially faster `Requirement already satisfied...` checking. Down to ~8sec over 20 some odd seconds per install and test requirements.