### PR TITLE
Move workflow_generator and config_elements into components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,18 @@ jobs:
       - run-test:
           for: allelse
 
+  test-config-elements:
+    executor: python-executor
+    steps:
+      - run-test:
+          for: config_elements
+
+  test-workflow-generator:
+    executor: python-executor
+    steps:
+      - run-test:
+          for: workflow_generator
+
   upload-coverage-reports:
     executor: python-executor
     steps:
@@ -269,6 +281,9 @@ workflows:
       - test-client:
           requires:
             - install
+      - test-config-elements:
+          requires:
+            - install
       - test-data-provider:
           requires:
             - install
@@ -285,6 +300,9 @@ workflows:
           requires:
             - install
       - test-util:
+          requires:
+            - install
+      - test-workflow-generator:
           requires:
             - install
       - test-watchman:
@@ -307,12 +325,14 @@ workflows:
             - test-builder
             - test-cli
             - test-client
+            - test-config-elements
             - test-data-provider
             - test-dataset
             - test-model
             - test-serializer
             - test-server
             - test-util
+            - test-workflow-generator
             - test-watchman
             - test-formatting
             - test-allelse

--- a/Dockerfile-argo
+++ b/Dockerfile-argo
@@ -1,0 +1,51 @@
+# Installs workflow-generator, kubectl and argo. Runs workflow-generator on the machine-config
+# stored in the environment variable MACHINE_CONFIG, or if that is empty, the file
+# /code/config.yml, which is then the callers responsibility to mount in.
+
+FROM python:3.6.9 as builder
+
+ARG HTTPS_PROXY
+ARG KUBECTL_VERSION="v1.12.1"
+ARG ARGO_VERSION="v2.2.1"
+
+#donwload & install kubectl
+RUN curl -sSL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl &&\
+  chmod +x /usr/local/bin/kubectl
+
+#download & install argo
+RUN curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64 &&\
+  chmod +x /usr/local/bin/argo
+
+# Copy source code
+COPY . /code
+# Copy .git to deduce version number
+COPY .git /code/
+
+WORKDIR /code
+RUN rm -rf /code/dist \
+    && python setup.py sdist \
+    && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
+
+FROM python:3.6.9-slim-stretch
+
+# Install requirements separately for improved docker caching
+COPY requirements.txt /code/
+RUN pip install -r /code/requirements.txt
+
+COPY ./run_workflow_and_argo.sh /code/run_workflow_and_argo.sh
+
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=builder /usr/local/bin/argo /usr/local/bin/argo
+RUN apt-get update && apt-get install -y \
+    curl \
+    jq \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY resources /code/resources
+
+# Install the current distribution of gordo-infrastructure
+COPY --from=builder /code/dist/gordo-components-packed.tar.gz .
+RUN pip install ./gordo-components-packed.tar.gz
+
+
+CMD ["bash", "/code/run_workflow_and_argo.sh"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ MODEL_BUILDER_IMG_NAME := gordo-model-builder
 MODEL_SERVER_IMG_NAME  := gordo-model-server
 WATCHMAN_IMG_NAME := gordo-watchman
 CLIENT_IMG_NAME := gordo-client
+WORKFLOW_GENERATOR_IMG_NAME := gordo-deploy
+
+# Create the image capable of rendering argo workflow generator
+workflow-generator:
+	docker build . -f Dockerfile-argo -t $(WORKFLOW_GENERATOR_IMG_NAME)
 
 # Create the image capable to building/training a model
 model-builder:
@@ -18,6 +23,11 @@ watchman:
 
 client:
 	docker build . -f Dockerfile-Client -t $(CLIENT_IMG_NAME)
+
+push-workflow-generator: workflow-generator
+	export DOCKER_NAME=$(WORKFLOW_GENERATOR_IMG_NAME);\
+	export DOCKER_IMAGE=$(WORKFLOW_GENERATOR_IMG_NAME);\
+	bash ./docker_push.sh
 
 push-server: model-server
 	export DOCKER_NAME=$(MODEL_SERVER_IMG_NAME);\
@@ -40,10 +50,10 @@ push-client: client
 	bash ./docker_push.sh
 
 # Publish images to the currently logged in docker repo
-push-dev-images: push-builder push-server push-watchman push-client
+push-dev-images: push-builder push-server push-watchman push-client push-workflow-generator
 
 push-prod-images: export GORDO_PROD_MODE:="true"
-push-prod-images: push-builder push-server push-watchman push-client
+push-prod-images: push-builder push-server push-watchman push-client push-workflow-generator
 
 # Make the python source distribution
 sdist:
@@ -51,7 +61,7 @@ sdist:
 	rm -rf ./dist/
 	python setup.py sdist
 
-images: model-builder model-server watchman client
+images: model-builder model-server watchman client workflow-generator
 
 test:
 	python setup.py test
@@ -64,4 +74,4 @@ docs:
 
 all: test images push-dev-images
 
-.PHONY: model-builder model-server client watchman push-server push-builder push-watchman push-client push-dev-images push-prod-images images test all docs
+.PHONY: model-builder model-server client watchman push-server push-builder push-watchman push-client push-dev-images push-prod-images images test all docs workflow-generator push-workflow-generator

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,65 @@
+machines:
+
+  - name: ct-23-0001 #1st machine
+    dataset:
+      tags: #list of tags for 1st machine
+        - TAG1
+        - TAG2
+        - TAG3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+    runtime:
+      server:
+        resources:
+          requests: # The resources we require reserved
+            memory: 1700 # Request 1.7G of memory
+            cpu: 2000 # Request two cores, while e.g. 250 would mean a quarter core
+          limits: # The resources we are limited to using.
+            memory: 2000 #Kill the server if it uses more than 2GB
+            cpu: 2000 #Throttle the server to never using more than 2 cores
+
+
+  - name: ct-23-0002 #2nd machine
+    dataset:
+      resolution: 2T
+      tags: #list of tags for 2nd machine
+        - TAG1
+        - TAG2
+        - TAG3
+      train_start_date: 2018-05-20T01:00:04+02:00
+      train_end_date: 2019-05-10T15:05:50+02:00
+    runtime:
+      server: #one can override just a single resource request as well
+        resources:
+          requests:
+            memory: 1000
+      influx: # Dont push results for this single model to influx
+        enable: False
+
+  - name: ct-23-0003 #3rd machine
+    dataset:
+      tags: #list of tags for 3rd machine
+        - TAG1
+        - TAG2
+        - TAG3
+      train_start_date: 2018-09-15T13:03:04+02:00
+      train_end_date: 2019-03-11T11:05:10+02:00
+
+globals:
+  runtime:
+    influx: # Change to False to disable influx. Default value: True
+      enable: True
+    builder: # The model builder can only be customized globally, any per-machine settings will be ignored.
+      resources:
+        requests:
+          memory: 4000 #3 GB of memory
+          cpu: 2000 #2 cores
+        # since limits are not specified, the defaults are used (3GB memory and 32 cores CPU), but since the memory
+        # limit (3GB) is less than request(4GB), which is not allowed, the memory limit will be lifted to match
+        # the memory request (4GB).
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/gordo_components/config_elements/base.py
+++ b/gordo_components/config_elements/base.py
@@ -1,0 +1,19 @@
+# -*- config: utf-8 -*-
+
+import abc
+from typing import Dict, Any
+
+
+class ConfigElement(abc.ABC):
+    """
+    Represents functionality of an element found within a gordo config file.
+    """
+
+    @abc.abstractclassmethod
+    def from_config(
+        cls, config: Dict[str, Any], project_name: str, config_globals=None
+    ) -> "ConfigElement":
+        """
+        Take one section of a config file and parse it into a given element
+        """
+        ...

--- a/gordo_components/config_elements/data_provider.py
+++ b/gordo_components/config_elements/data_provider.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from typing import Dict, Any
+
+from .base import ConfigElement
+
+
+class DataProvider(ConfigElement):
+    """
+    Represents a DataProvider
+    """
+
+    def __init__(self, type: str = "DataLakeProvider", **kwargs):
+        """
+        Parameters
+        ----------
+        type: str
+            Type of DataProvider to initialize
+        kwargs: dict
+            Other parameters which will be provided to the dataprovider on
+            initialization
+        """
+        self.data_provider_type = type
+        self.kwargs = kwargs
+
+    def to_dict(self):
+        config = {"type": self.data_provider_type}
+        config.update(self.kwargs)  # Other optional kwargs, such as threads
+        return config
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "DataProvider":  # type: ignore
+        return cls(**config)

--- a/gordo_components/config_elements/dataset.py
+++ b/gordo_components/config_elements/dataset.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+from typing import Dict, Any, List
+from datetime import datetime
+
+from .base import ConfigElement
+from gordo_components.config_elements.validators import (
+    ValidTagList,
+    ValidDatetime,
+    ValidDatasetKwargs,
+)
+
+
+class Dataset(ConfigElement):
+    """
+    Represents a dataset key element by machine within the config file
+    and used to create a Dataset from components
+    """
+
+    # Required arguments for Dataset
+    tags = ValidTagList()
+    target_tag_list = ValidTagList()
+    train_start_date = ValidDatetime()
+    train_end_date = ValidDatetime()
+
+    # Optional kwargs to constructing the dataset, such as 'resolution'
+    kwargs = ValidDatasetKwargs()
+
+    def __init__(
+        self,
+        tags: List[str],
+        target_tag_list: List[str],
+        train_start_date: datetime,
+        train_end_date: datetime,
+        **kwargs,
+    ):
+        """
+        Parameters
+        ----------
+        tags: List[str]
+            Tags the dataset consists of.
+        train_start_date: datetime
+            Earliest possible date (inclusive) of the dataset
+        train_end_date: datetime
+            Latest possible date of the dataset, must be after `train_start_date`
+        kwargs
+
+        """
+        self.tags = tags
+        self.target_tag_list = target_tag_list
+        self.train_start_date = train_start_date
+        self.train_end_date = train_end_date
+        if train_start_date >= train_end_date:
+            raise ValueError(
+                f"train_start_date ({train_start_date}) must be before "
+                f"train_end_date ({train_end_date})"
+            )
+        self.kwargs = kwargs
+
+    def to_dict(self):
+        config = {
+            "type": "TimeSeriesDataset",
+            "tags": self.tags,
+            "target_tag_list": self.target_tag_list,
+            "train_start_date": self.train_start_date.isoformat(),
+            "train_end_date": self.train_end_date.isoformat(),
+        }
+        config.update(self.kwargs)  # Other optional kwargs, such as resolution.
+
+        return config
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "Dataset":  # type: ignore
+
+        # Set target_tag_list as tags if it wasn't set; we always expect there to be target tags
+        config.setdefault("target_tag_list", config["tags"])
+
+        return cls(**config)

--- a/gordo_components/config_elements/machine.py
+++ b/gordo_components/config_elements/machine.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+from typing import Dict, Any
+
+import yaml
+from gordo_components.config_elements.data_provider import DataProvider
+
+from gordo_components.config_elements.dataset import Dataset
+from gordo_components.config_elements.validators import (
+    ValidUrlString,
+    ValidMetadata,
+    ValidModel,
+    ValidDataset,
+    ValidMachineRuntime,
+    ValidDataProvider,
+)
+from gordo_components.workflow_generator.helpers import patch_dict
+from .base import ConfigElement
+
+
+class Machine(ConfigElement):
+    """
+    Represents a single machine in a config file
+    """
+
+    name = ValidUrlString()
+    project_name = ValidUrlString()
+    host = ValidUrlString()
+    model = ValidModel()
+    dataset = ValidDataset()
+    data_provider = ValidDataProvider()
+    metadata = ValidMetadata()
+    runtime = ValidMachineRuntime()
+
+    def __init__(
+        self,
+        name: str,
+        model: dict,
+        dataset: Dataset,
+        data_provider: DataProvider,
+        project_name: str,
+        metadata=None,
+        runtime=None,
+    ):
+
+        if runtime is None:
+            runtime = dict()
+        if metadata is None:
+            metadata = dict()
+        self.name = name
+        self.model = model
+        self.dataset = dataset
+        self.data_provider = data_provider
+        self.runtime = runtime
+
+        self.metadata = metadata
+        self.project_name = project_name
+
+        self.host = f"gordoserver-{self.project_name}-{self.name}"
+
+    @classmethod
+    def from_config(
+        cls, config: Dict[str, Any], project_name: str, config_globals=None
+    ):
+        if config_globals is None:
+            config_globals = dict()
+
+        name = config["name"]
+        model = config.get("model") or config_globals.get("model")
+
+        local_runtime = config.get("runtime", dict())
+        runtime = patch_dict(config_globals.get("runtime", dict()), local_runtime)
+
+        dataset = Dataset.from_config(
+            config.get("dataset") or config_globals.get("dataset")
+        )
+
+        data_provider = DataProvider.from_config(
+            patch_dict(
+                config_globals.get("data_provider", dict()),
+                config.get("data_provider", dict()),
+            )
+        )
+
+        metadata = {
+            "global-metadata": config_globals.get("metadata", dict()),
+            "machine-metadata": config.get("metadata", dict()),
+        }
+        return cls(
+            name,
+            model,
+            dataset,
+            data_provider=data_provider,
+            metadata=metadata,
+            runtime=runtime,
+            project_name=project_name,
+        )
+
+    def __str__(self):
+        return yaml.dump(self.to_dict())
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "dataset": self.dataset.to_dict(),
+            "model": self.model,
+            "metadata": self.metadata,
+            "runtime": self.runtime,
+            "data_provider": self.data_provider.to_dict(),
+            "project_name": self.project_name,
+        }

--- a/gordo_components/config_elements/normalized_config.py
+++ b/gordo_components/config_elements/normalized_config.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from typing import List
+
+from gordo_components.config_elements.validators import fix_runtime
+from gordo_components.workflow_generator.helpers import patch_dict
+from .machine import Machine
+
+
+def _calculate_influx_resources(nr_of_machines):
+    return {
+        "requests": {
+            # The requests must be limited to keep the machine schedulable
+            "memory": min(1500 + (200 * nr_of_machines), 28000),  # Between 1G and 28G
+            "cpu": min(500 + (10 * nr_of_machines), 4000),  # Between 500m and 4000m
+        },
+        "limits": {
+            "memory": min(1500 + (200 * nr_of_machines), 48000),
+            "cpu": 10000 + (20 * nr_of_machines),
+        },
+    }
+
+
+class NormalizedConfig:
+
+    DEFAULT_RUNTIME_GLOBALS = {
+        "runtime": {
+            "server": {
+                "resources": {
+                    "requests": {"memory": 750, "cpu": 100},
+                    "limits": {"memory": 1500, "cpu": 1000},
+                }
+            },
+            "builder": {
+                "resources": {
+                    "requests": {"memory": 1000, "cpu": 500},
+                    "limits": {"memory": 3000, "cpu": 32000},
+                }
+            },
+            "client": {
+                "resources": {
+                    "requests": {"memory": 2000, "cpu": 100},
+                    "limits": {"memory": 2500, "cpu": 2000},
+                },
+                "max_instances": 30,
+            },
+            "influx": {"enable": True},
+        }
+    }
+
+    """
+    Represents a fully loaded config file
+    """
+
+    machines: List[Machine]
+    globals: dict
+
+    def __init__(self, config: dict, project_name: str):
+        default_globals = self.DEFAULT_RUNTIME_GLOBALS
+        default_globals["runtime"]["influx"][  # type: ignore
+            "resources"
+        ] = _calculate_influx_resources(len(config["machines"]))
+
+        passed_globals = config.get("globals", dict())
+        patched_globals = patch_dict(default_globals, passed_globals)
+        if patched_globals.get("runtime"):
+            patched_globals["runtime"] = fix_runtime(patched_globals.get("runtime"))
+
+        self.machines = [
+            Machine.from_config(
+                conf, project_name=project_name, config_globals=patched_globals
+            )
+            for conf in config["machines"]
+        ]  # type: List[Machine]
+
+        self.globals = patched_globals

--- a/gordo_components/config_elements/validators.py
+++ b/gordo_components/config_elements/validators.py
@@ -1,0 +1,309 @@
+# -*- coding: utf-8 -*-
+import collections
+import copy
+import re
+import datetime
+
+import dictdiffer
+import pandas as pd
+import dateutil.parser
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BaseDescriptor:
+    """
+    Base descriptor class
+
+    New object should override __set__(self, instance, value) method to check
+    if 'value' meets required needs.
+    """
+
+    def __get__(self, instance, owner):
+        return instance.__dict__[self.name]
+
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __set__(self, instance, value):
+        raise NotImplementedError("Setting value not implemented for this Validator!")
+
+
+class ValidDataset(BaseDescriptor):
+    """
+    Descriptor for attributes requiring type gordo_infrastructure.config_elements.Dataset
+    """
+
+    def __set__(self, instance, value):
+
+        # Avoid circular dependency imports
+        from gordo_components.config_elements.dataset import Dataset
+
+        if not isinstance(value, Dataset):
+            raise TypeError(
+                f"Expected value to be an instance of Dataset config element, found {value}"
+            )
+        instance.__dict__[self.name] = value
+
+
+class ValidDatasetKwargs(BaseDescriptor):
+    """
+    Descriptor for attributes requiring type gordo_infrastructure.config_elements.Dataset
+    """
+
+    def _verify_resolution(self, resolution: str):
+        """
+        Verifies that a resolution string is supported in pandas
+        """
+        try:
+            pd.tseries.frequencies.to_offset(resolution)
+        except ValueError:
+            raise ValueError(
+                'Values for "resolution" must match pandas frequency terms: '
+                "http://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html"
+            )
+
+    def __set__(self, instance, value):
+        if not isinstance(value, dict):
+            raise TypeError(f"Expected kwargs to be an instance of dict, found {value}")
+
+        # Check that if 'resolution' is defined, it's one of supported pandas resampling frequencies
+        if "resolution" in value:
+            self._verify_resolution(value["resolution"])
+        instance.__dict__[self.name] = value
+
+
+class ValidModel(BaseDescriptor):
+    """
+    Descriptor for attributes requiring type Union[dict, str]
+
+    TODO: Once we have access to gordo_components we can validate the provided model itself is valid
+    """
+
+    def __set__(self, instance, value):
+        if not isinstance(value, dict) and not isinstance(value, str):
+            raise ValueError(
+                f"Must provide a valid model config, either model path or mapping config"
+            )
+        instance.__dict__[self.name] = value
+
+
+class ValidMetadata(BaseDescriptor):
+    """
+    Descriptor for attributes requiring type Optional[dict]
+    """
+
+    def __set__(self, instance, value):
+        if value is not None and not isinstance(value, dict):
+            raise ValueError(f"Can either be None or an instance of dict")
+        instance.__dict__[self.name] = value
+
+
+class ValidDataProvider(BaseDescriptor):
+    """
+    Descriptor for DataProvider
+    """
+
+    def __set__(self, instance, value):
+
+        # Avoid circular dependency imports
+        from gordo_components.config_elements.data_provider import DataProvider
+
+        if not isinstance(value, DataProvider):
+            raise TypeError(
+                f"Expected value to be an instance of DataProvider config element, "
+                f"found {value} "
+            )
+        instance.__dict__[self.name] = value
+
+
+class ValidMachineRuntime(BaseDescriptor):
+    """
+    Descriptor for runtime dict in a machine object. Must be a valid runtime, but also
+    must contain server.resources.limits/requests.memory/cpu to be valid.
+    """
+
+    def __set__(self, instance, value):
+        if not isinstance(value, dict):
+            raise ValueError(f"Runtime must be an instance of dict")
+        required_fields = {
+            "server": {
+                "resources": {
+                    "requests": {"memory": 750, "cpu": 100},
+                    "limits": {"memory": 1500, "cpu": 8000},
+                }
+            }
+        }
+        diff = list(dictdiffer.diff(required_fields, value))
+        missing_required_fields = [(d, s) for (t, d, s) in diff if t == "remove"]
+        if missing_required_fields:
+            raise ValueError(
+                f"Runtime misses required fields, {missing_required_fields}"
+            )
+        value = fix_runtime(value)
+        instance.__dict__[self.name] = value
+
+
+def fix_runtime(runtime_dict):
+    """A valid runtime description must satisfy that any resource
+    description must have that limit >= requests. This function will bump any limits
+    that is too low."""
+    runtime_dict = copy.deepcopy(runtime_dict)
+    # We must also limit/request errors
+
+    for key, val in runtime_dict.items():
+        if isinstance(val, collections.Mapping):
+            resource = val.get("resources")
+            if resource:
+                runtime_dict[key]["resources"] = fix_resource_limits(resource)
+    return runtime_dict
+
+
+def fix_resource_limits(resources: dict) -> dict:
+    """
+    Resource limitations must be higher or equal to resource requests, if they are
+    both specified. This bumps any limits to the corresponding request if they are both
+    set.
+
+    Parameters
+    ----------
+    resources: dict
+        Dictionary with possible requests/limits
+
+    Examples
+    --------
+    >>> fix_resource_limits({"requests": {"cpu": 10}, "limits":{"cpu":9}})
+    {'requests': {'cpu': 10}, 'limits': {'cpu': 10}}
+    >>> fix_resource_limits({"requests": {"cpu": 10}})
+    {'requests': {'cpu': 10}}
+
+
+    Returns
+    -------
+    dict:
+        A copy of `resource_dict` with the any limits bumped to the corresponding request if
+        they are both set.
+    """
+    resources = copy.deepcopy(resources)
+    requests = resources.get("requests", dict())
+    limits = resources.get("limits", dict())
+    request_memory = requests.get("memory")
+    limits_memory = limits.get("memory")
+    requests_cpu = requests.get("cpu")
+    limits_cpu = limits.get("cpu")
+
+    for r in [request_memory, limits_memory, requests_cpu, limits_cpu]:
+        if r is not None and not isinstance(r, int):
+            raise ValueError(
+                f"Resource descriptions must be integers, and '{r}' is not."
+            )
+    if (
+        limits_memory is not None
+        and request_memory is not None
+        and request_memory > limits_memory
+    ):
+        logger.warning(
+            f"Memory limit {limits_memory} can not be smaller than memory "
+            f"request {request_memory}, increasing memory limit to be equal"
+            f" to request. "
+        )
+        limits["memory"] = request_memory
+    if (
+        limits_cpu is not None
+        and requests_cpu is not None
+        and requests_cpu > limits_cpu
+    ):
+        logger.warning(
+            f"CPU limit {limits.get('cpu')} can not be smaller than cpu request"
+            f" {requests.get('cpu')}, increasing cpu limit to be equal to request."
+        )
+        limits["cpu"] = requests_cpu
+    return resources
+
+
+class ValidDatetime(BaseDescriptor):
+    """
+    Descriptor for attributes requiring valid datetime.datetime attribute
+    """
+
+    def __set__(self, instance, value):
+        datetime_value = None
+        if isinstance(value, datetime.datetime):
+            datetime_value = value
+        elif isinstance(value, str):
+            datetime_value = dateutil.parser.isoparse(value)
+        else:
+            raise ValueError(
+                f"'{value}' is not a valid datetime.datetime object or string!"
+            )
+
+        if datetime_value.tzinfo is None:
+            raise ValueError(f"Provide timezone to timestamp '{value}'")
+
+        instance.__dict__[self.name] = datetime_value
+
+
+class ValidTagList(BaseDescriptor):
+    """
+    Descriptor for attributes requiring a non-empty list of strings
+    """
+
+    def __set__(self, instance, value):
+        if (
+            len(value) == 0
+            or not isinstance(value, list)
+            or not isinstance(value[0], str)
+        ):
+            raise ValueError(f"Requires setting a non-empty list of strings")
+        instance.__dict__[self.name] = value
+
+
+class ValidUrlString(BaseDescriptor):
+    """
+    Descriptor for use in objects which require valid URL values.
+    Where 'valid URL values' is Gordo's version: alphanumeric with dashes.
+
+    Use:
+
+    class MySpecialClass:
+
+        url_attribute = ValidUrlString()
+
+        ...
+
+    myspecialclass = MySpecialClass()
+
+    myspecialclass.url_attribute = 'this-is-ok'
+    myspecialclass.url_attribute = 'this will r@ise a ValueError'
+    """
+
+    def __set__(self, instance, value):
+        if not self.valid_url_string(value):
+            raise ValueError(
+                f"'{value}' is not a valid Gordo url value. Only lower-case alphanumeric with dashes allowed.'"
+            )
+        if len(value) > 63:
+            raise ValueError(
+                f"'{value}' should be less than 63 chars, as required by Kubernetes/AKS DNS requirements."
+            )
+        instance.__dict__[self.name] = value
+
+    @staticmethod
+    def valid_url_string(string: str) -> bool:
+        """
+        What we (Gordo) deem to be a suitable URL is the same as kubernetes
+        lowercase alphanumeric with dashes but not ending or starting with a dash
+
+        Parameters
+        ----------
+            string: str - String to check
+
+        Returns
+        -------
+            bool
+        """
+        return re.match(  # type: ignore
+            r"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$",
+            string,
+        )

--- a/gordo_components/workflow_generator/helpers.py
+++ b/gordo_components/workflow_generator/helpers.py
@@ -1,0 +1,34 @@
+import dictdiffer
+
+
+def patch_dict(original_dict: dict, patch_dictionary: dict) -> dict:
+    """Patches a dict with another. Patching means that any path defines in the
+    patch is either added (if it does not exist), or replaces the existing value (if
+    it exists). Nothing is removed from the original dict, only added/replaced.
+
+    Parameters
+    ----------
+    original_dict : dict
+        Base dictionary which will get paths added/changed
+    patch_dictionary: dict
+        Dictionary which will be overlaid on top of original_dict
+
+    Examples
+    --------
+    >>> patch_dict({"highKey":{"lowkey1":1, "lowkey2":2}}, {"highKey":{"lowkey1":10}})
+    {'highKey': {'lowkey1': 10, 'lowkey2': 2}}
+    >>> patch_dict({"highKey":{"lowkey1":1, "lowkey2":2}}, {"highKey":{"lowkey3":3}})
+    {'highKey': {'lowkey1': 1, 'lowkey2': 2, 'lowkey3': 3}}
+    >>> patch_dict({"highKey":{"lowkey1":1, "lowkey2":2}}, {"highKey2":4})
+    {'highKey': {'lowkey1': 1, 'lowkey2': 2}, 'highKey2': 4}
+
+    Returns
+    -------
+    dict
+        A new dictionary which is the result of overlaying `patch_dictionary` on top of
+        `original_dict`
+
+    """
+    diff = dictdiffer.diff(original_dict, patch_dictionary)
+    adds_and_mods = [(f, d, s) for (f, d, s) in diff if f != "remove"]
+    return dictdiffer.patch(adds_and_mods, original_dict)

--- a/gordo_components/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow_generator/resources/argo-workflow.yml.template
@@ -1,0 +1,1241 @@
+# Requires the following variables to render properly
+# tag_fetcher_version: version of tag fetcher, e.g. latest
+# model_builder_version: -||-
+# model_server_version:  -||-
+# cleanup_version: -||-
+# project_name: Name of the project this workflow is linked up to (e.g. "Grane")
+# project_version: Current version of this project, e.g. the git commit-sha.
+# containing start and end dates (if tags are shared across machines the earliest train start date and latest train end date is taken)
+# model_builder_resources_requests_memory: Memory requests of the model builder in unit `M`
+# model_builder_resources_requests_cpu: CPU requests of the model builder in unit `m`
+# model_builder_resources_limits_memory: Memory limit of the model builder in unit `M`
+# model_builder_resources_limits_cpu: CPU limit of the model builder in unit `m`
+
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: {{project_name}}-{{project_version}}-
+  annotations:
+    gordo-models: '{{ machines|map(attribute="name")|list|tojson|safe }}'
+  labels:
+    app.kubernetes.io/managed-by: gordo
+    applications.gordo.equinor.com/project-name: "{{project_name}}"
+    applications.gordo.equinor.com/project-version: "{{project_version}}"
+  {% if owner_references is defined %}
+  ownerReferences: {{owner_references}}
+  {% endif %}
+spec:
+  ttlSecondsAfterFinished: 115200 # 32 hours
+  entrypoint: do-all
+  onExit: sql-and-cleanup
+  volumes:
+  - name: azurefile
+    persistentVolumeClaim:
+      claimName: azurefile
+  - name: datalake-access-token
+    secret:
+      secretName: datalake-access-token # Must be saved
+  templates:
+  - name: ensure-single-workflow
+    # Ensures that only one version of workflows for a given project runs at the same time.
+    # Deletes any workflows for the same project of different version
+    retryStrategy:
+      limit: 5
+    metadata:
+      labels:
+        app: ensure-single-workflow
+        applications.gordo.equinor.com/project-name: "{{project_name}}"
+        applications.gordo.equinor.com/project-version: "{{project_version}}"
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Ensuring that no other versions of workflows for this project is running at the same time"
+        # This fetches all the workflows of the same version as me, and finds the one of them with the earliest start-time
+        export MY_CREATION_TIME=$(kubectl get workflows -l applications.gordo.equinor.com/project-name="$GORDO_PROJECT_NAME",applications.gordo.equinor.com/project-version=="$GORDO_PROJECT_VERSION",workflows.argoproj.io/phase=Running -o json | jq -r "[.items[] | {name: .metadata.name, startTime: .metadata.creationTimestamp | fromdate }] | sort_by(.startTime) |.[0]" | jq -r ".startTime")
+
+        echo "Found that my creationTime was $MY_CREATION_TIME"
+        # This function finds all running workflows of the same project but different version AND created earlier than $MY_CREATION_TIME
+        function find_older_running_workflows {
+            export RUNNING_WORKFLOWS=$(kubectl get workflows -l applications.gordo.equinor.com/project-name="$GORDO_PROJECT_NAME",applications.gordo.equinor.com/project-version!="$GORDO_PROJECT_VERSION",workflows.argoproj.io/phase=Running -o json | jq -r "[.items[] | {name: .metadata.name, startTime: .metadata.creationTimestamp | fromdate } | select(.startTime < $MY_CREATION_TIME)]" | jq -r ".[].name")
+            echo "Running workflows:"
+            echo "$RUNNING_WORKFLOWS"
+        }
+        find_older_running_workflows
+
+        while [[ $RUNNING_WORKFLOWS != "" ]]; do
+            echo "Deleting and checking again"
+            kubectl delete --wait=True workflows $RUNNING_WORKFLOWS
+            sleep 10
+            find_older_running_workflows
+        done
+        echo "No other versions of workflows for this project found, exiting successfully"
+
+      resources:
+        requests:
+          memory: "100M"
+          cpu: "2m"
+        limits:
+          memory: "200M"
+          cpu: "100m"
+      env:
+      - name: GORDO_PROJECT_NAME
+        value: "{{project_name}}"
+      - name: GORDO_PROJECT_VERSION
+        value: "{{project_version}}"
+
+
+  - name: gordo-influx-service
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      manifest: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: gordo-influx-{{project_name}}
+          labels:
+            app: gordo-influx-{{project_name}}
+            app.kubernetes.io/name: influx
+            app.kubernetes.io/component: service
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+         {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+        {% endif %}
+        spec:
+          selector:
+            app: gordo-influx-{{project_name}}
+          ports:
+          - port: 8086
+            name: api
+            targetPort: 8086
+  - name: gordo-influx-statefulset
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      successCondition: status.readyReplicas > 0
+      manifest: |
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: gordo-influx-{{project_name}}
+          labels:
+            app: gordo-influx-{{project_name}}
+            app.kubernetes.io/name: influxd-deployment
+            app.kubernetes.io/component: influxdb
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+        {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+        {% endif %}
+        spec:
+          serviceName: gordo-influx-{{project_name}}
+          volumeClaimTemplates:
+            - metadata:
+                name: influx-storage-{{project_version}}
+                labels:
+                  applications.gordo.equinor.com/project-name: "{{project_name}}"
+                  applications.gordo.equinor.com/project-version: "{{project_version}}"
+                  app.kubernetes.io/part-of: gordo
+                  app.kubernetes.io/managed-by: gordo
+                annotations:
+                  applications.gordo.equinor.com/project-name: "{{project_name}}"
+                  applications.gordo.equinor.com/project-version: "{{project_version}}"
+                {% if owner_references is defined %}
+                ownerReferences: {{owner_references}}
+                {% endif %}
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: "managed-premium"
+                resources:
+                  requests:
+                    storage: 28Gi
+          selector:
+            matchLabels:
+              app: gordo-influx-{{project_name}}
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                app: gordo-influx-{{project_name}}
+              {% if owner_references is defined %}
+              ownerReferences: {{owner_references}}
+              {% endif %}
+            spec:
+              containers:
+              - image: "influxdb:1.7.6-alpine"
+                imagePullPolicy: "IfNotPresent"
+                name: gordo-influx-{{project_name}}
+                volumeMounts:
+                  - name: influx-storage-{{project_version}}
+                    mountPath: /var/lib/influxdb
+                ports:
+                  - name: api
+                    containerPort: 8086
+                resources:
+                  requests:
+                    memory: "{{ influx_resources_requests_memory }}M"
+                    cpu: "{{ influx_resources_requests_cpu }}m"
+                  limits:
+                    memory: "{{ influx_resources_limits_memory }}M"
+                    cpu: "{{ influx_resources_limits_cpu }}m"
+                livenessProbe:
+                  httpGet:
+                    path: /ping
+                    port: api
+                  initialDelaySeconds: 30
+                  timeoutSeconds: 5
+                readinessProbe:
+                  httpGet:
+                    path: /ping
+                    port: api
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 1
+
+  - name: gordo-influx-database-creator
+    retryStrategy:
+      limit: 5
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Creating feeder database for influx for project {{project_name}}" \
+        && curl -i -XPOST http://gordo-influx-{{project_name}}:8086/query --data-urlencode "q=CREATE DATABASE feeder"
+      resources:
+        requests:
+          memory: 50M
+          cpu: 10m
+        limits:
+          memory: 1G
+
+
+  - name: gordo-influx
+    steps:
+    - - name: gordo-influx-statefulset
+        template: gordo-influx-statefulset
+    - - name: gordo-influx-service
+        template: gordo-influx-service
+    - - name: gordo-influx-database-creator
+        template: gordo-influx-database-creator
+
+  - name: gordo-grafana-service
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      manifest: |
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: gordo-grafana-{{project_name}}
+          labels:
+            app: gordo-grafana-{{project_name}}
+            app.kubernetes.io/name: grafana
+            app.kubernetes.io/component: service
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          selector:
+            app: gordo-grafana-{{project_name}}
+          ports:
+          - port: 3000
+            name: api
+            targetPort: 3000
+
+  - name: gordo-grafana-statefulset
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      successCondition: status.readyReplicas > 0
+      manifest: |
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: gordo-grafana-{{project_name}}
+          labels:
+            app: gordo-grafana-{{project_name}}
+            app.kubernetes.io/name: grafanad-deployment
+            app.kubernetes.io/component: grafanadb
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          serviceName: gordo-grafana-{{project_name}}
+          selector:
+            matchLabels:
+              app: gordo-grafana-{{project_name}}
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                app: gordo-grafana-{{project_name}}
+              {% if owner_references is defined %}
+              ownerReferences: {{owner_references}}
+              {% endif %}
+            spec:
+              containers:
+              - image: "grafana/grafana:6.1.4"
+                env:
+                - name: GF_INSTALL_PLUGINS
+                  value: "grafana-worldmap-panel,flant-statusmap-panel,vonage-status-panel"
+                - name: GF_AUTH_ANONYMOUS_ENABLED
+                  value: "true"
+                - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+                  value: "Admin"
+                - name: GF_AUTH_DISABLE_LOGIN_FORM
+                  value: "true"
+                - name: GF_AUTH_BASIC_ENABLED
+                  value: "false"
+                - name: SERVER_ENABLE_GZIP
+                  value: "true"
+                imagePullPolicy: "IfNotPresent"
+                name: gordo-grafana-{{project_name}}
+                ports:
+                  - name: api
+                    containerPort: 3000
+                resources:
+                  requests:
+                    memory: 1G
+                    cpu: 500m
+                readinessProbe:
+                  httpGet:
+                    path: /login
+                    port: api
+                  initialDelaySeconds: 5
+                  timeoutSeconds: 1
+
+  - name: gordo-grafana-datasource-creator
+    retryStrategy:
+      limit: 5
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Creating grafana influxdb and postgres datasources for project {{project_name}}" \
+        && curl -XPOST -H 'Content-Type: application/json' -d '{"name":"InfluxDB", "type":"influxdb", "url":"http://gordo-influx-{{project_name}}:8086", "access":"proxy", "database": "feeder", "isDefault":true, "password": "", "user": "", "basicAuth": false}' http://gordo-grafana-{{project_name}}:3000/api/datasources \
+        && curl -XPOST -H 'Content-Type: application/json' -d '{"name": "Postgres-metadata","type": "postgres","url": "gordo-postgres-{{project_name}}","access": "proxy","database": "postgres","isDefault": false,"user": "postgres","jsonData": {"sslmode": "disable","postgresVersion": 1000,"timescaledb": false}}' http://gordo-grafana-{{project_name}}:3000/api/datasources \
+        && echo "Uploading grafana dashboard for project {{project_name}}" \
+        && curl -XPOST -d @/code/resources/grafana/dashboards/machines.json -H "Content-Type: application/json"  http://gordo-grafana-{{project_name}}:3000/api/dashboards/db
+      resources:
+        requests:
+          memory: 50M
+          cpu: 10m
+        limits:
+          memory: 1G
+
+
+  - name: gordo-grafana
+    steps:
+    - - name: gordo-grafana-service
+        template: gordo-grafana-service
+    - - name: gordo-grafana-statefulset
+        template: gordo-grafana-statefulset
+    - - name: gordo-grafana-datasource-creator
+        template: gordo-grafana-datasource-creator
+
+
+  - name: gordo-postgres-service
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      manifest: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: gordo-postgres-{{project_name}}
+          labels:
+            app: gordo-postgres-{{project_name}}
+            app.kubernetes.io/name: postgres
+            app.kubernetes.io/component: service
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          selector:
+            app: gordo-postgres-{{project_name}}
+          ports:
+          - port: 5432
+            name: api
+            targetPort: 5432
+  - name: gordo-postgres-statefulset
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      successCondition: status.readyReplicas > 0
+      manifest: |
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: gordo-postgres-{{project_name}}
+          labels:
+            app: gordo-postgres-{{project_name}}
+            app.kubernetes.io/name: postgresd-deployment
+            app.kubernetes.io/component: postgresdb
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          serviceName: gordo-postgres-{{project_name}}
+          volumeClaimTemplates:
+            - metadata:
+                name: postgres-storage-{{project_version}}
+                annotations:
+                  applications.gordo.equinor.com/project-name: "{{project_name}}"
+                  applications.gordo.equinor.com/project-version: "{{project_version}}"
+                labels:
+                  applications.gordo.equinor.com/project-name: "{{project_name}}"
+                  applications.gordo.equinor.com/project-version: "{{project_version}}"
+                  app.kubernetes.io/part-of: gordo
+                  app.kubernetes.io/managed-by: gordo
+                {% if owner_references is defined %}
+                ownerReferences: {{owner_references}}
+                {% endif %}
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: "default"
+                resources:
+                  requests:
+                    storage: 1Gi
+          selector:
+            matchLabels:
+              app: gordo-postgres-{{project_name}}
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                app: gordo-postgres-{{project_name}}
+              {% if owner_references is defined %}
+              ownerReferences: {{owner_references}}
+              {% endif %}
+            spec:
+              terminationGracePeriodSeconds: 10
+              containers:
+              - image: "postgres:11.2"
+                imagePullPolicy: "IfNotPresent"
+                name: gordo-postgres-{{project_name}}
+                volumeMounts:
+                  - name: postgres-storage-{{project_version}}
+                    mountPath: /var/lib/postgresql/data/pgdata
+                    subPath: postgres-db
+                ports:
+                  - name: api
+                    containerPort: 5432
+                resources:
+                  requests:
+                    memory: 256Mi
+                    cpu: 50m
+                env:
+                  - name: POSTGRES_USER
+                    value: postgres
+                  - name: PGUSER
+                    value: postgres
+                  - name: POSTGRES_DB
+                    value: postgres
+                  - name: PGDATA
+                    value: /var/lib/postgresql/data/pgdata
+                  - name: POD_IP
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: status.podIP
+                livenessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - exec pg_isready --host $POD_IP
+                  failureThreshold: 6
+                  initialDelaySeconds: 60
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                readinessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - exec pg_isready --host $POD_IP
+                  failureThreshold: 3
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  successThreshold: 1
+                  timeoutSeconds: 3
+
+
+  - name: gordo-postgres
+    steps:
+    - - name: gordo-postgres-statefulset
+        template: gordo-postgres-statefulset
+    - - name: gordo-postgres-service
+        template: gordo-postgres-service
+
+
+
+
+  - name: gordo-watchman-to-postgres
+    retryStrategy:
+      limit: 5
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Feeding sql with metadata for project {{project_name}} using source ur http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/ and postgres url gordo-postgres-$PROJECT_NAME " \
+        && watchman-to-sql --watchman-address "http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/" --sql-host "gordo-postgres-$PROJECT_NAME"
+      env:
+        - name: PROJECT_NAME
+          value: "{{project_name}}"
+        - name: AMBASSADOR_HOST
+          value: "ambassador.{{ambassador_namespace}}"
+      resources:
+        requests:
+          memory: 50M
+          cpu: 10m
+        limits:
+          memory: 1G
+
+
+
+
+  - name: model-builder
+    retryStrategy:
+      limit: 5
+    metadata:
+      labels:
+        app: gordo-model-builder
+        applications.gordo.equinor.com/project-name: {{project_name}}
+        applications.gordo.equinor.com/project-version: "{{project_version}}"
+    inputs:
+      parameters:
+      - name: model-name
+      - name: metadata
+      - name: model-config
+      - name: data-config
+      - name: data-provider
+    container:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-model-builder:{{model_builder_version}}
+      env:
+      - name: OUTPUT_DIR
+        value: "/gordo/models/{{project_name}}/{{project_version}}/{{'{{inputs.parameters.model-name}}'}}"
+      - name: MODEL_REGISTER_DIR
+        value: "/gordo/models/{{project_name}}/model_register"
+      - name: MODEL_NAME
+        value: {{ '"{{inputs.parameters.model-name}}" '}}
+      - name: METADATA
+        value: {{ '"{{inputs.parameters.metadata}}"' }}
+      - name: MODEL_CONFIG
+        value: {{ '"{{inputs.parameters.model-config}}"' }}
+      - name: DL_SERVICE_AUTH_STR
+        valueFrom:
+          secretKeyRef:
+            name: dlserviceauth
+            key: tenant_id_secret
+      - name: DATA_CONFIG
+        value: {{ '"{{inputs.parameters.data-config}}"' }}
+      - name: DATA_PROVIDER
+        value: {{ '"{{inputs.parameters.data-provider}}"' }}
+      volumeMounts:
+      - name: azurefile
+        mountPath: /gordo
+      resources:
+        requests:
+          memory: "{{ model_builder_resources_requests_memory }}M"
+          cpu: "{{ model_builder_resources_requests_cpu }}m"
+        limits:
+          memory: "{{ model_builder_resources_limits_memory }}M"
+          cpu: "{{ model_builder_resources_limits_cpu }}m"
+
+    outputs:
+      parameters:
+      - name: model-location #name of output parameter
+        valueFrom:
+          path: /tmp/model-location.txt #set the value of model-location to the contents of this file
+
+
+  - name: gordo-server-hpa
+    retryStrategy:
+      limit: 5
+    inputs:
+      parameters:
+      - name: model-name
+      - name: model-host
+    resource:
+      action: apply
+      manifest: |
+        ---
+        apiVersion: autoscaling/v1
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: "gordoserver-scaler-{{project_name}}-{{'{{inputs.parameters.model-name}}'}}"
+          labels:
+            app: "{{'{{inputs.parameters.model-host}}'}}"
+            app.kubernetes.io/name: model-server
+            app.kubernetes.io/component: service
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+            applications.gordo.equinor.com/model-name: "{{'{{inputs.parameters.model-name}}'}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: "{{'{{inputs.parameters.model-host}}'}}"
+          minReplicas: 1
+          maxReplicas: 11
+          targetCPUUtilizationPercentage: 50
+
+
+  - name: gordo-server-svc
+    retryStrategy:
+      limit: 5
+    inputs:
+      parameters:
+      - name: model-name
+      - name: model-host
+    resource:
+      action: apply
+      manifest: |
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: "{{'{{inputs.parameters.model-host}}'}}"
+          annotations:
+            getambassador.io/config: |
+              ---
+              apiVersion: ambassador/v0
+              kind:  Mapping
+              name:  "{{'{{inputs.parameters.model-host}}'}}"
+              prefix: "/gordo/v0/{{project_name}}/{{'{{inputs.parameters.model-name}}'}}/"
+              service: "{{'{{inputs.parameters.model-host}}'}}.{{namespace}}"
+              timeout_ms: 600000  # 10 mins
+          labels:
+            app: "{{'{{inputs.parameters.model-host}}'}}"
+            app.kubernetes.io/name: model-server
+            app.kubernetes.io/component: service
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+            applications.gordo.equinor.com/model-name: "{{'{{inputs.parameters.model-name}}'}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          selector:
+            app: "{{'{{inputs.parameters.model-host}}'}}"
+          ports:
+          - port: 80
+            name: http-gordo
+            targetPort: http-api
+
+
+  - name: gordo-server-deployment
+    retryStrategy:
+      limit: 5
+    inputs:
+      parameters:
+      - name: model-location
+      - name: model-name
+      - name: model-host
+      - name: resources-requests-memory
+      - name: resources-requests-cpu
+      - name: resources-limits-memory
+      - name: resources-limits-cpu
+    resource:
+      action: apply
+      successCondition: status.readyReplicas > 0
+      manifest: |
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: "{{'{{inputs.parameters.model-host}}'}}"
+          labels:
+            app: "{{'{{inputs.parameters.model-host}}'}}"
+            app.kubernetes.io/name: model-server-deployment
+            app.kubernetes.io/component: server
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+            applications.gordo.equinor.com/model-name: "{{'{{inputs.parameters.model-name}}'}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: "{{'{{inputs.parameters.model-host}}'}}"
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                app: "{{'{{inputs.parameters.model-host}}'}}"
+            spec:
+              containers:
+                 - image: "auroradevacr.azurecr.io/gordo-components/gordo-model-server:{{model_server_version}}"
+                   imagePullPolicy: "IfNotPresent"
+                   name: "gordoserver-{{'{{inputs.parameters.model-name}}'}}"
+                   volumeMounts:
+                     - mountPath: "/gordo"
+                       name: gstor
+                   ports:
+                     - name: http-api
+                       containerPort: 5555
+                   livenessProbe:
+                     httpGet:
+                       path: /healthcheck
+                       port: http-api
+                     initialDelaySeconds: 600 # We give it a lot of time to load the model and start up
+                     timeoutSeconds: 2
+                   readinessProbe:
+                     httpGet:
+                       path: /healthcheck
+                       port: http-api
+                     initialDelaySeconds: 5
+                     timeoutSeconds: 2
+                   env:
+                     - name: MODEL_LOCATION
+                       value: {{ '"{{inputs.parameters.model-location}}" '}}
+
+                     # Source influx credentials
+                     - name: SRC_INFLUXDB_HOST
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: host
+
+                     - name: SRC_INFLUXDB_USERNAME
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: username
+
+                     - name: SRC_INFLUXDB_PASSWORD
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: password
+
+                     - name: SRC_INFLUXDB_DATABASE
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: database
+
+                     - name: SRC_INFLUXDB_PORT
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: port
+
+                     - name: SRC_INFLUXDB_PATH
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: path
+
+                     - name: SRC_INFLUXDB_MEASUREMENT
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: measurement
+
+                     - name: SRC_INFLUXDB_API_KEY
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: api-key
+
+                     - name: SRC_INFLUXDB_API_KEY_HEADER
+                       valueFrom:
+                         secretKeyRef:
+                           name: src-influx-credentials
+                           key: api-key-header
+
+                   resources:
+                     requests:
+                       memory: "{{ '{{inputs.parameters.resources-requests-memory}}'}}M"
+                       cpu: "{{ '{{inputs.parameters.resources-requests-cpu}}'}}m"
+                     limits:
+                       memory: "{{ '{{inputs.parameters.resources-limits-memory}}'}}M"
+                       cpu: "{{ '{{inputs.parameters.resources-limits-cpu}}'}}m"
+              terminationGracePeriodSeconds: 1
+              volumes:
+                - name: gstor
+                  persistentVolumeClaim:
+                    claimName: "azurefile"
+
+  - name: gordo-server
+    inputs:
+      parameters:
+      - name: model-location
+      - name: model-name
+      - name: model-host
+      - name: resources-requests-memory
+      - name: resources-requests-cpu
+      - name: resources-limits-memory
+      - name: resources-limits-cpu
+    steps:
+    - - name: gordo-server-deployment
+        template: gordo-server-deployment
+        arguments:
+          parameters: [{name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }}  },
+                       {name: model-host, value: {{ '"{{inputs.parameters.model-host}}"' }}  },
+                       {name: model-location, value: {{ '"{{inputs.parameters.model-location}}"' }} },
+                       {name: resources-requests-memory, value: {{ '"{{inputs.parameters.resources-requests-memory}}"' }}},
+                       {name: resources-requests-cpu, value: {{ '"{{inputs.parameters.resources-requests-cpu}}"' }}},
+                       {name: resources-limits-memory, value: {{ '"{{inputs.parameters.resources-limits-memory}}"' }}},
+                       {name: resources-limits-cpu, value: {{ '"{{inputs.parameters.resources-limits-cpu}}"' }}}
+
+                      ]
+    - - name: gordo-server-hpa
+        template: gordo-server-hpa
+        arguments:
+          parameters: [{name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }}  },
+                       {name: model-host, value: {{ '"{{inputs.parameters.model-host}}"' }}  }
+                      ]
+      - name: gordo-server-svc
+        template: gordo-server-svc
+        arguments:
+          parameters: [{name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }}  },
+                       {name: model-host, value: {{ '"{{inputs.parameters.model-host}}"' }}  }
+                      ]
+
+
+  - name: gordo-client-para-limited # Runs gordo client, but with limited parallelization
+    inputs:
+      parameters:
+      - name: model-name
+      - name: train-start-date
+    steps:
+    - - name: gordo-client-waiter
+        template: gordo-client-waiter
+    - - name: gordo-client
+        template: gordo-client
+        arguments:
+          parameters: [{name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }}  },
+                       {name: train-start-date, value: {{ '"{{inputs.parameters.train-start-date}}"' }}}
+                      ]
+
+  - name: gordo-client-waiter
+    retryStrategy:
+      limit: 5
+    metadata:
+      labels:
+        app: gordo-client-waiter
+        applications.gordo.equinor.com/project-name: "{{project_name}}"
+        applications.gordo.equinor.com/project-version: "{{project_version}}"
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Waiting until there is less than $GORDO_MAX_CLIENTS instances of gordo client for project_name: $GORDO_PROJECT_NAME, project-version=$GORDO_PROJECT_VERSION"
+        function find_running_pods {
+          export RUNNING_PODS=$(kubectl  get pods -l app=gordo-client,applications.gordo.equinor.com/project-name="$GORDO_PROJECT_NAME",applications.gordo.equinor.com/project-version="$GORDO_PROJECT_VERSION" --field-selector status.phase!=Succeeded,status.phase!=Failed)
+          export NR_OF_RUNNING_PODS=$(echo "$RUNNING_PODS" | wc -l)
+          let NR_OF_RUNNING_PODS=$NR_OF_RUNNING_PODS-1 # remove the header from the count
+        }
+
+        if [ $GORDO_MAX_CLIENTS -ge $GORDO_TOTAL_NR_OF_CLIENTS ]
+        then
+            echo "Found that total number of clients is less than the max number of parallel clients, so exiting successfully."
+            exit 0
+        fi
+        let CHECK_INTERVAL_LENGTH=($GORDO_TOTAL_NR_OF_CLIENTS*5)+30
+        sleep $[ ( $RANDOM % $CHECK_INTERVAL_LENGTH )  + 1 ]s
+        find_running_pods
+        echo "Found $NR_OF_RUNNING_PODS"
+        while [ $NR_OF_RUNNING_PODS -ge $GORDO_MAX_CLIENTS ]; do
+           sleep $CHECK_INTERVAL_LENGTH
+           echo "."
+           find_running_pods
+        done
+        echo "Found that there are now less than $GORDO_MAX_CLIENTS running pods, exiting successfully."
+
+
+      resources:
+        requests:
+          memory: "100M"
+          cpu: "2m"
+        limits:
+          memory: "200M"
+          cpu: "100m"
+      env:
+      - name: GORDO_PROJECT_NAME
+        value: "{{project_name}}"
+      - name: GORDO_PROJECT_VERSION
+        value: "{{project_version}}"
+      - name: GORDO_MAX_CLIENTS
+        value: "{{client_max_instances}}"
+      - name : GORDO_TOTAL_NR_OF_CLIENTS
+        value: "{{client_total_instances}}"
+
+  - name: gordo-client
+    retryStrategy:
+      limit: 5 # Maybe the server is not up yet
+    inputs:
+      parameters:
+      - name: model-name
+      - name: train-start-date
+    metadata:
+      labels:
+        app: gordo-client
+        applications.gordo.equinor.com/project-name: "{{project_name}}"
+        applications.gordo.equinor.com/project-version: "{{project_version}}"
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-model-builder:{{client_version}}
+      command: [bash]
+      source: |
+        echo "Starting client prediction for machine $GORDO_CLIENT_TARGET" \
+        && gordo-components client --project $GORDO_CLIENT_PROJECT --target $GORDO_CLIENT_TARGET --host $GORDO_CLIENT_HOST --port $GORDO_CLIENT_PORT --scheme $GORDO_CLIENT_SCHEME --metadata $GORDO_CLIENT_METADATA predict --data-provider '{"type": "DataLakeProvider"}' --influx-uri $GORDO_CLIENT_PREDICT_INFLUX_URI "$GORDO_TRAIN_START_DATE" $(date --iso-8601=second) --forward-resampled-sensors
+      resources:
+        requests:
+          memory: "{{ client_resources_requests_memory }}M"
+          cpu: "{{ client_resources_requests_cpu }}m"
+        limits:
+          memory: "{{ client_resources_limits_memory }}M"
+          cpu: "{{ client_resources_limits_cpu }}m"
+      env:
+      - name: GORDO_CLIENT_TARGET
+        value: {{ '"{{inputs.parameters.model-name}}" '}}
+      - name: GORDO_TRAIN_START_DATE
+        value: {{ '"{{inputs.parameters.train-start-date}}" '}}
+      - name: GORDO_CLIENT_PROJECT
+        value: "{{project_name}}"
+      - name: GORDO_CLIENT_HOST
+        value: "ambassador.{{ambassador_namespace}}"
+      - name: GORDO_CLIENT_PORT
+        value: "80"
+      - name: GORDO_CLIENT_SCHEME
+        value: "http"
+      - name: GORDO_CLIENT_PREDICT_INFLUX_URI
+        value: ":@gordo-influx-{{project_name}}:8086//feeder"
+      - name: GORDO_CLIENT_INFLUX_RECREATE_DB
+        value: "true"
+      - name: GORDO_CLIENT_METADATA
+        value: "version,{{project_version}}"
+      - name: DL_SERVICE_AUTH_STR
+        valueFrom:
+          secretKeyRef:
+            name: dlserviceauth
+            key: tenant_id_secret
+
+  - name: gordo-watchman-svc
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      manifest: |
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: "gordo-watchman-{{project_name}}"
+          annotations:
+            getambassador.io/config: |
+              ---
+              apiVersion: ambassador/v0
+              kind:  Mapping
+              name:  "gordo-watchman-{{project_name}}"
+              prefix: "/gordo/v0/{{project_name}}/"
+              service: "gordo-watchman-{{project_name}}.{{namespace}}"
+              timeout_ms: 600000  # 10 mins
+          labels:
+            app: "gordo-watchman-{{project_name}}"
+            app.kubernetes.io/name: watchman
+            app.kubernetes.io/component: service
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          selector:
+            app: "gordo-watchman-{{project_name}}"
+          ports:
+          - port: 80
+            name: http-gordo
+            targetPort: http-api
+
+
+  - name: gordo-watchman-deployment
+    retryStrategy:
+      limit: 5
+    resource:
+      action: apply
+      successCondition: status.readyReplicas > 0
+      manifest: |
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: "gordo-watchman-{{project_name}}"
+          labels:
+            app: "gordo-watchman-{{project_name}}"
+            app.kubernetes.io/name: watchman-deployment
+            app.kubernetes.io/component: watchman
+            app.kubernetes.io/part-of: gordo
+            app.kubernetes.io/managed-by: gordo
+            applications.gordo.equinor.com/project-name: "{{project_name}}"
+            applications.gordo.equinor.com/project-version: "{{project_version}}"
+          {% if owner_references is defined %}
+          ownerReferences: {{owner_references}}
+          {% endif %}
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: "gordo-watchman-{{project_name}}"
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                app: "gordo-watchman-{{project_name}}"
+            spec:
+              containers:
+                 - image: "auroradevacr.azurecr.io/gordo-components/gordo-watchman:{{watchman_version}}"
+                   imagePullPolicy: "IfNotPresent"
+                   name: "gordo-watchman-{{project_name}}"
+                   ports:
+                     - name: http-api
+                       containerPort: 5556
+                   readinessProbe:
+                     httpGet:
+                       path: /healthcheck
+                       port: http-api
+                     initialDelaySeconds: 5
+                     timeoutSeconds: 2
+                   env:
+                     - name: TARGET_NAMES
+                       value: "{{target_names}}"
+                     - name: PROJECT_NAME
+                       value: {{project_name}}
+                     - name: PROJECT_VERSION
+                       value: "{{project_version}}"
+                     - name: AMBASSADOR_NAMESPACE
+                       value: "{{ambassador_namespace}}"
+                   resources:
+                     requests:
+                       memory: 500M
+                       cpu: 10m
+                     limits:
+                       memory: 1G
+                       cpu: 1
+              terminationGracePeriodSeconds: 1
+
+
+  - name: gordo-watchman
+    steps:
+    - - name: gordo-watchman-deployment
+        template: gordo-watchman-deployment
+    - - name: gordo-watchman-svc
+        template: gordo-watchman-svc
+
+  - name: influx-cleanup
+    activeDeadlineSeconds: 300
+    retryStrategy:
+      limit: 5
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Deleting influx, grafana and PVC for {{project_name}} different than {{project_version}}" \
+         && kubectl delete statefulset -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}} \
+         && kubectl delete svc -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}},app.kubernetes.io/name=influx \
+         && kubectl delete svc -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}},app.kubernetes.io/name=grafana \
+         && kubectl delete $(kubectl get pvc -l app=gordo-influx-{{project_name}} -o name | grep -v influx-storage-{{project_version}}  ) || : \
+         && sleep 5
+      resources:
+        requests:
+          memory: 50M
+          cpu: 10m
+        limits:
+          memory: 1G
+
+  - name: postgres-cleanup
+    activeDeadlineSeconds: 300
+    retryStrategy:
+      limit: 5
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Deleting postgres PVC for {{project_name}} different than {{project_version}}" \
+         && kubectl delete svc -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}},app.kubernetes.io/name=postgres \
+         && kubectl delete $(kubectl get pvc -l app=gordo-postgres-{{project_name}} -o name | grep -v postgres-storage-{{project_version}} ) || : \
+         && sleep 5
+      resources:
+        requests:
+          memory: 50M
+          cpu: 10m
+        limits:
+          memory: 1G
+
+  - name: cleanup
+    retryStrategy:
+      limit: 5
+    script:
+      image: auroradevacr.azurecr.io/gordo-components/gordo-deploy:{{cleanup_version}}
+      command: [bash]
+      source: |
+        echo "Deleting gordo deployments and services for project {{project_name}} different than {{project_version}}" \
+         && kubectl delete deployments -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}} \
+         && kubectl delete svc -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}} \
+         && kubectl delete hpa -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}}
+      resources:
+        requests:
+          memory: 50M
+          cpu: 10m
+        limits:
+          memory: 1G
+
+
+  - name: sql-and-cleanup
+    steps:
+    - - name: cleanup
+        template: cleanup
+        {%if enable_influx %}
+      - name: gordo-watchman-to-postgres
+        template: gordo-watchman-to-postgres
+        {% endif %}
+
+
+
+  - name: build-and-serve-single-machine
+    inputs:
+      parameters:
+      - name: model-name
+      - name: model-host
+      - name: model-config
+      - name: metadata
+      - name: data-config
+      - name: data-provider
+      - name: server-resources-requests-memory
+      - name: server-resources-requests-cpu
+      - name: server-resources-limits-memory
+      - name: server-resources-limits-cpu
+    steps:
+    -  - name: build-model
+         template: model-builder
+         arguments:
+          parameters: [{name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }}  },
+                       {name: model-config, value: {{ '"{{inputs.parameters.model-config}}"' }} },
+                       {name: metadata, value: {{'"{{inputs.parameters.metadata}}"'}} },
+                       {name: data-config, value: {{ '"{{inputs.parameters.data-config}}"' }}},
+                       {name: data-provider, value: {{ '"{{inputs.parameters.data-provider}}"' }}}
+          ]
+
+    -  - name: serve-model
+         template: gordo-server
+         arguments:
+           parameters: [{name: model-location, value: {{ '"{{steps.build-model.outputs.parameters.model-location}}"' }} },
+                        {name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }} },
+                        {name: model-host, value: {{ '"{{inputs.parameters.model-host}}"' }} },
+                        {name: resources-requests-memory, value: {{ '"{{inputs.parameters.server-resources-requests-memory}}"' }}},
+                        {name: resources-requests-cpu, value: {{ '"{{inputs.parameters.server-resources-requests-cpu}}"' }}},
+                        {name: resources-limits-memory, value: {{ '"{{inputs.parameters.server-resources-limits-memory}}"' }}},
+                        {name: resources-limits-cpu, value: {{ '"{{inputs.parameters.server-resources-limits-cpu}}"' }}}
+                       ]
+
+  - name: do-all
+    dag:
+      tasks:
+        - name: ensure-single-workflow
+          template: ensure-single-workflow
+        - name: watchman
+          template: gordo-watchman
+          dependencies:
+            - ensure-single-workflow
+        {% for machine in machines %}
+        - name: model-builder-{{ machine.name }}
+          template: build-and-serve-single-machine
+          arguments:
+            parameters: [{name: model-name, value: "{{ machine.name }}"},
+                         {name: model-host, value: "{{ machine.host }}"},
+                         {name: model-config, value: "{{ machine.model }}"},
+                         {name: metadata, value: "{{ machine.metadata }}"},
+                         {name: data-config, value: "{{ machine.dataset.to_dict() }}"},
+                         {name: data-provider, value: "{{ machine.data_provider.to_dict() }}"},
+                         {name: server-resources-requests-memory, value: {{ machine.runtime.server.resources.requests.memory }}},
+                         {name: server-resources-requests-cpu, value: {{ machine.runtime.server.resources.requests.cpu }}},
+                         {name: server-resources-limits-memory, value: {{ machine.runtime.server.resources.limits.memory }}},
+                         {name: server-resources-limits-cpu, value: {{ machine.runtime.server.resources.limits.cpu }} }
+            ]
+          dependencies:
+            - watchman
+        {% endfor %}
+        - name: postgres-cleanup
+          template: postgres-cleanup
+          dependencies:
+            - ensure-single-workflow
+        - name: influx-cleanup
+          template: influx-cleanup
+          dependencies:
+            - ensure-single-workflow
+        {%if enable_influx %}
+        - name: gordo-postgres
+          template: gordo-postgres
+          dependencies:
+            - postgres-cleanup
+        - name: gordo-influx
+          template: gordo-influx
+          dependencies:
+            - influx-cleanup
+        - name: gordo-grafana
+          template: gordo-grafana
+          dependencies:
+            - influx-cleanup
+        {% for machine in machines %}
+        {% if machine.runtime["influx"]["enable"] %}
+        - name: gordo-client-{{machine.name}}
+          template: gordo-client-para-limited
+          arguments:
+            parameters:
+              - name: model-name
+                value: "{{ machine.name}}"
+              - name: train-start-date
+                value: "{{ machine.dataset.train_start_date }}"
+          dependencies:
+            - gordo-influx
+            - model-builder-{{ machine.name }}
+        {% endif %}
+        {% endfor %}
+        {% endif %}

--- a/gordo_components/workflow_generator/workflow_generator.py
+++ b/gordo_components/workflow_generator/workflow_generator.py
@@ -1,0 +1,384 @@
+import argparse
+import json
+import os
+import yaml
+import dateutil.parser
+import logging
+import configargparse
+import jinja2
+import time
+import pkg_resources
+import io
+
+from typing import Union
+
+from gordo_components.config_elements.normalized_config import NormalizedConfig
+from gordo_components import __version__
+
+logger = logging.getLogger(__name__)
+
+
+def _docker_friendly_version(version):
+    """
+    Some untagged versions may have a '+' in which case is not a valid
+    docker tag
+    """
+    return version.replace("+", "_")
+
+
+def _valid_owner_ref(owner_reference_str: str):
+    """Validates that the parameter can be loaded (as yaml) into a non-empty list of
+    valid owner-references.
+
+    A valid owner reference is a dict containing at least the keys 'uid', 'name',
+    'kind', and 'apiVersion'. Raises `argparse.ArgumentTypeError` if not, or returns
+    the list of owner references if they seem valid.
+
+    Parameters
+    ----------
+    owner_reference_str: str
+        String representation of the list of owner-references, should be parsable as
+        yaml/json
+
+    Returns
+    -------
+    list[dict]
+        The list of owner-references
+
+    """
+    owner_ref = yaml.safe_load(owner_reference_str)
+    if not type(owner_ref) == list or len(owner_ref) < 1:
+        raise argparse.ArgumentTypeError(
+            "Owner-references must be a list with at least one element"
+        )
+    for oref in owner_ref:
+        if (
+            "uid" not in oref
+            or "name" not in oref
+            or "kind" not in oref
+            or "apiVersion" not in oref
+        ):
+            raise argparse.ArgumentTypeError(
+                "All elements in owner-references must contain a uid, name, kind, "
+                "and apiVersion key "
+            )
+    return owner_ref
+
+
+def create_argparse():
+    parser = configargparse.ArgumentParser(
+        description="Machine Configuration to Argo Workflow",
+        add_env_var_help=True,
+        auto_env_var_prefix="WORKFLOW_GENERATOR_",
+    )
+    default_components_version = __version__
+
+    parser.add_argument(
+        "--machine-config", type=str, required=True, help="Machine configuration file"
+    )
+    parser.add_argument(
+        "--workflow-template", type=str, required=False, help="Template to expand"
+    )
+    parser.add_argument(
+        "--owner-references",
+        type=_valid_owner_ref,
+        required=False,
+        default=None,
+        help="Kubernetes owner references to inject into all created resources. "
+        "Should be a nonempty yaml/json list of owner-references, each owner-reference "
+        "a dict containing at least the keys 'uid', 'name', 'kind', and 'apiVersion'",
+    )
+    parser.add_argument(
+        "--model-builder-version",
+        type=str,
+        required=False,
+        default=default_components_version,
+        help="Version of model-builder",
+    )
+    parser.add_argument(
+        "--model-server-version",
+        type=str,
+        required=False,
+        default=default_components_version,
+        help="Version of server-version",
+    )
+    parser.add_argument(
+        "--watchman-version",
+        type=str,
+        required=False,
+        default=default_components_version,
+        help="Version of watchman",
+    )
+    parser.add_argument(
+        "--client-version",
+        type=str,
+        required=False,
+        default=default_components_version,
+        help="Version of prediction client",
+    )
+    parser.add_argument(
+        "--cleanup-version",
+        type=str,
+        required=False,
+        default=_docker_friendly_version(__version__),
+        help="Version of cleanup image (gordo-deploy)",
+    )
+    parser.add_argument(
+        "--project-name",
+        type=str,
+        required=True,
+        help="Name of the project which own the workflow.",
+    )
+    parser.add_argument(
+        "--project-version",
+        type=str,
+        required=False,
+        default=int(time.time() * 1000),  # unix time milliseconds
+        help="Version of the project which own the workflow.",
+    )
+    parser.add_argument(
+        "--output-file", type=str, required=False, help="Optional file to render to"
+    )
+    parser.add_argument(
+        "--namespace",
+        type=str,
+        required=False,
+        default="kubeflow",
+        help="Which namespace to deploy services into",
+    )
+    parser.add_argument(
+        "--ambassador-namespace",
+        type=str,
+        required=False,
+        default="ambassador",
+        help="Namespace we should expect to find the Ambassador service in.",
+    )
+    parser.add_argument(
+        "--split-workflows",
+        type=int,
+        required=False,
+        default=50,
+        help="Split workflows containg more than this number of models into several "
+        "workflows, where each workflow contains at most this nr of models. The "
+        "workflows are outputted sequentially with '---' in between, which allows "
+        "kubectl to apply them all at once.",
+    )
+
+    return parser
+
+
+def _timestamp_constructor(_loader, node):
+    parsed_date = dateutil.parser.isoparse(node.value)
+    if parsed_date.tzinfo is None:
+        raise ValueError(
+            "Provide timezone to timestamp {}."
+            " Example: for UTC timezone use {} or {} ".format(
+                node.value, node.value + "Z", node.value + "+00:00"
+            )
+        )
+    return parsed_date
+
+
+def get_dict_from_yaml(config_file: Union[str, io.StringIO]):
+    """
+    Read a config file or file like object of YAML into a dict
+    """
+    # We must override the default constructor for timestamp to ensure the result
+    # has tzinfo. Yaml loader never adds tzinfo, but converts to UTC.
+    yaml.FullLoader.add_constructor(
+        tag="tag:yaml.org,2002:timestamp", constructor=_timestamp_constructor
+    )
+    if hasattr(config_file, "read"):
+        return yaml.load(config_file, Loader=yaml.FullLoader)
+    try:
+        path_to_config_file = os.path.abspath(config_file)  # type: ignore
+        with open(path_to_config_file, "r") as yamlfile:  # type: ignore
+            yaml_content = yaml.load(yamlfile, Loader=yaml.FullLoader)
+            return yaml_content
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            "Unable to find config file <{}>".format(path_to_config_file)
+        )
+
+
+def load_workflow_template(workflow_template: str) -> jinja2.Template:
+    """
+    Loads the Jinja2 Template from a specified path
+
+    Parameters
+    ----------
+    workflow_template: str
+        Path to a workflow template
+
+    Returns
+    -------
+    jinja2.Template
+        Loaded but non-rendered jinja2 template for the workflow
+    """
+    path_to_workflow_template = os.path.abspath(workflow_template)
+    template_dir = os.path.dirname(path_to_workflow_template)
+
+    templateEnv = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(template_dir), undefined=jinja2.StrictUndefined
+    )
+    return templateEnv.get_template(os.path.basename(workflow_template))
+
+
+def create_argparse_for_taglist():
+    parser = configargparse.ArgumentParser(
+        description="Print unique tags from machine configuration file to stdout"
+        "or output file if parameter output-file-tag-list is provided",
+        add_env_var_help=True,
+        auto_env_var_prefix="UNIQUE_TAGS_",
+    )
+
+    parser.add_argument(
+        "--machine-config", type=str, required=True, help="Machine configuration file"
+    )
+
+    parser.add_argument(
+        "--output-file-tag-list",
+        type=str,
+        required=False,
+        help="Optional file to dump list of unique tags",
+    )
+    return parser
+
+
+def main_tag_list(args=None):
+    """
+    Creates a parser to extract list of unique tags from gordo config file
+    """
+
+    parser = create_argparse_for_taglist()
+
+    if args is None:
+        args, data = parser.parse_known_args()
+    else:
+        args = parser.parse_args(args)
+
+    yaml_content = get_dict_from_yaml(args.machine_config)
+
+    machines = NormalizedConfig(yaml_content, project_name="test-proj-name").machines
+
+    tag_list = set(tag for machine in machines for tag in machine.dataset.tags)
+    if args.output_file_tag_list:
+        with open(args.output_file_tag_list, "w") as output_file:
+            for item in tag_list:
+                output_file.write("%s\n" % item)
+    else:
+        for tag in tag_list:
+            print(tag)
+
+
+def main(args=None):
+    parser = create_argparse()
+
+    if args is None:
+        args, data = parser.parse_known_args()
+    else:
+        args = parser.parse_args(args)
+
+    context = dict()
+
+    yaml_content = get_dict_from_yaml(args.machine_config)
+
+    # Context directly from args.
+    context["model_builder_version"] = args.model_builder_version
+    context["model_server_version"] = args.model_server_version
+    context["watchman_version"] = args.watchman_version
+    context["client_version"] = args.client_version
+    context["cleanup_version"] = args.cleanup_version
+    context["project_name"] = args.project_name
+    context["project_version"] = args.project_version
+    context["namespace"] = args.namespace
+    context["ambassador_namespace"] = args.ambassador_namespace
+    # Create normalized config
+
+    config = NormalizedConfig(yaml_content, project_name=args.project_name)
+
+    context["machines"] = config.machines
+
+    # We know these exist since we set them in the default globals
+    builder_resources = config.globals["runtime"]["builder"]["resources"]
+    context["model_builder_resources_requests_memory"] = builder_resources["requests"][
+        "memory"
+    ]
+    context["model_builder_resources_requests_cpu"] = builder_resources["requests"][
+        "cpu"
+    ]
+    context["model_builder_resources_limits_memory"] = builder_resources["limits"][
+        "memory"
+    ]
+    context["model_builder_resources_limits_cpu"] = builder_resources["limits"]["cpu"]
+
+    # These are also set in the default globals, and guaranteed to exist
+    client_resources = config.globals["runtime"]["client"]["resources"]
+    context["client_resources_requests_memory"] = client_resources["requests"]["memory"]
+    context["client_resources_requests_cpu"] = client_resources["requests"]["cpu"]
+    context["client_resources_limits_memory"] = client_resources["limits"]["memory"]
+    context["client_resources_limits_cpu"] = client_resources["limits"]["cpu"]
+
+    context["client_max_instances"] = config.globals["runtime"]["client"][
+        "max_instances"
+    ]
+
+    influx_resources = config.globals["runtime"]["influx"]["resources"]
+    context["influx_resources_requests_memory"] = influx_resources["requests"]["memory"]
+    context["influx_resources_requests_cpu"] = influx_resources["requests"]["cpu"]
+    context["influx_resources_limits_memory"] = influx_resources["limits"]["memory"]
+    context["influx_resources_limits_cpu"] = influx_resources["limits"]["cpu"]
+
+    nr_of_models_with_clients = len(
+        [
+            machine
+            for machine in config.machines
+            if machine.runtime.get("influx", {}).get("enable", True)
+        ]
+    )
+    context["client_total_instances"] = nr_of_models_with_clients
+
+    # Should we start up influx/grafana at all, i.e. is there at least one request
+    # for it?"
+    context["enable_influx"] = nr_of_models_with_clients > 0
+
+    # Context requiring pre-processing
+    context["target_names"] = [machine.name for machine in config.machines]
+
+    if args.owner_references:
+        context["owner_references"] = json.dumps(args.owner_references)
+
+    if args.workflow_template:
+        workflow_template = args.workflow_template
+        template = load_workflow_template(workflow_template)
+    else:
+        workflow_template = pkg_resources.resource_filename(
+            "gordo_components.workflow_generator.resources",
+            "argo-workflow.yml.template",
+        )
+        template = load_workflow_template(workflow_template)
+
+    # Clear output file
+    if args.output_file:
+        open(args.output_file, "w").close()
+    for i in range(0, len(config.machines), args.split_workflows):
+        logger.info(
+            f"Generating workflow for machines {i} to {i + args.split_workflows}"
+        )
+        context["machines"] = config.machines[i : i + args.split_workflows]
+
+        if args.output_file:
+            s = template.stream(**context)
+            with open(args.output_file, "a") as f:
+                if i != 0:
+                    f.write("\n---\n")
+                s.dump(f)
+        else:
+            output = template.render(**context)
+            if i != 0:
+                print("\n---\n")
+            print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,4 @@ flakes-ignore =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
-timeout = 100
+timeout = 300

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,8 @@
 apscheduler~=3.6
 Click~=7.0
 cachetools~=3.1
+configargparse~=0.13.0
+dictdiffer
 h5py~=2.8
 influxdb~=5.2
 jinja2~=2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,10 @@ certifi==2019.6.16        # via kubernetes, requests
 cffi==1.12.3              # via azure-datalake-store, cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.0
+configargparse==0.13.0
 coverage==4.5.4
 cryptography==2.7         # via adal
+dictdiffer==0.8.0
 flask-restplus==0.13.0
 flask==1.1.1
 gast==0.2.2               # via tensorflow

--- a/resources/grafana/dashboards/how_to_modify_dashboard.md
+++ b/resources/grafana/dashboards/how_to_modify_dashboard.md
@@ -1,0 +1,5 @@
+To change the dashboard:
+
+1. Export the changed dashboard as json from grafana.
+2. Place the content of the exported json-file inside the "dashboard" key in machines.json.
+3. Find the "id" key inside the value of "dashboard", and change it to null.

--- a/resources/grafana/dashboards/machines.json
+++ b/resources/grafana/dashboards/machines.json
@@ -1,0 +1,1109 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "limit": 100,
+          "name": "Annotations & Alerts",
+          "showIn": 0,
+          "type": "dashboard"
+        },
+        {
+          "datasource": "Postgres-metadata",
+          "enable": true,
+          "hide": false,
+          "iconColor": "rgba(255, 96, 96, 1)",
+          "limit": 100,
+          "name": "Training start-date",
+          "rawQuery": "SELECT train_start_date as time, 'Training start-date' as text FROM machine WHERE name='$Machine' and $__timeFilter(train_start_date)",
+          "showIn": 0,
+          "tags": [],
+          "type": "tags"
+        },
+        {
+          "datasource": "Postgres-metadata",
+          "enable": true,
+          "hide": false,
+          "iconColor": "#FADE2A",
+          "limit": 100,
+          "name": "Training end-date",
+          "rawQuery": "SELECT train_end_date as time, 'Training end-date' as text FROM machine WHERE name='$Machine' and $__timeFilter(train_end_date)",
+          "showIn": 0,
+          "tags": [],
+          "type": "tags"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "id": null,
+    "iteration": 1566813225630,
+    "links": [],
+    "panels": [
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "Postgres-metadata",
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 4,
+          "x": 0,
+          "y": 0
+        },
+        "id": 10,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "?column?",
+        "targets": [
+          {
+            "format": "table",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "SELECT metadata->'endpoint-metadata'->'metadata'->'dataset'->>'resolution' FROM machine where name='$Machine';",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "id"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "table": "machine",
+            "timeColumn": "id",
+            "timeColumnType": "int4",
+            "where": [
+              {
+                "name": "$__unixEpochFilter",
+                "params": [],
+                "type": "macro"
+              }
+            ]
+          }
+        ],
+        "thresholds": "",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Training time resolution",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "cacheTimeout": null,
+        "columns": [],
+        "datasource": "Postgres-metadata",
+        "fontSize": "100%",
+        "gridPos": {
+          "h": 4,
+          "w": 20,
+          "x": 4,
+          "y": 0
+        },
+        "id": 16,
+        "links": [],
+        "pageSize": null,
+        "scroll": true,
+        "showHeader": true,
+        "sort": {
+          "col": 0,
+          "desc": true
+        },
+        "styles": [
+          {
+            "alias": "Time",
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "pattern": "Time",
+            "type": "date"
+          },
+          {
+            "alias": "",
+            "colorMode": null,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "decimals": 2,
+            "pattern": "/.*/",
+            "thresholds": [],
+            "type": "number",
+            "unit": "short"
+          }
+        ],
+        "targets": [
+          {
+            "format": "table",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "select machine.metadata->'endpoint-metadata'->'metadata'->'model'->'model-config' as Configuration from machine where name='$Machine'",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "timeColumn": "time",
+            "where": [
+              {
+                "name": "$__timeFilter",
+                "params": [],
+                "type": "macro"
+              }
+            ]
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Model config",
+        "transform": "table",
+        "type": "table"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "Postgres-metadata",
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 4,
+          "x": 0,
+          "y": 2
+        },
+        "id": 13,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "?column?",
+        "targets": [
+          {
+            "format": "table",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "SELECT metadata->'endpoint-metadata'->'metadata'->'dataset'->>'filter' FROM machine where name='$Machine';",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "id"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "table": "machine",
+            "timeColumn": "id",
+            "timeColumnType": "int4",
+            "where": [
+              {
+                "name": "$__unixEpochFilter",
+                "params": [],
+                "type": "macro"
+              }
+            ]
+          }
+        ],
+        "thresholds": "",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Training filter",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "Postgres-metadata",
+        "format": "s",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 4,
+          "x": 0,
+          "y": 4
+        },
+        "id": 14,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "date_part",
+        "targets": [
+          {
+            "format": "table",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "SELECT extract( epoch from train_end_date-train_start_date) FROM machine where name='$Machine';",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "id"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "table": "machine",
+            "timeColumn": "id",
+            "timeColumnType": "int4",
+            "where": [
+              {
+                "name": "$__unixEpochFilter",
+                "params": [],
+                "type": "macro"
+              }
+            ]
+          }
+        ],
+        "thresholds": "",
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Training duration",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "cacheTimeout": null,
+        "columns": [],
+        "datasource": "Postgres-metadata",
+        "fontSize": "100%",
+        "gridPos": {
+          "h": 6,
+          "w": 20,
+          "x": 4,
+          "y": 4
+        },
+        "id": 12,
+        "links": [],
+        "pageSize": null,
+        "scroll": true,
+        "showHeader": true,
+        "sort": {
+          "col": 0,
+          "desc": false
+        },
+        "styles": [
+          {
+            "alias": "Time",
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "pattern": "Time",
+            "type": "date"
+          },
+          {
+            "alias": "",
+            "colorMode": null,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "decimals": 2,
+            "pattern": "/.*/",
+            "thresholds": [],
+            "type": "number",
+            "unit": "short"
+          }
+        ],
+        "targets": [
+          {
+            "format": "table",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "select jsonb_each.key as metric, jsonb_each.value as scores from machine, jsonb_each(machine.metadata->'endpoint-metadata'->'metadata'->'model'->'cross-validation'->'scores'->'explained-variance') where name='$Machine'",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "timeColumn": "time",
+            "where": [
+              {
+                "name": "$__timeFilter",
+                "params": [],
+                "type": "macro"
+              }
+            ]
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Metric scores - Explained variance",
+        "transform": "table",
+        "type": "table"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 10
+        },
+        "id": 4,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 0.5,
+        "points": true,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "alias": "",
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "measurement": "model-input",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT mean(/^$Sensor$/) FROM \"model-input\" WHERE (\"machine\" =~ /^$Machine$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+            "rawQuery": true,
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "*"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "machine",
+                "operator": "=~",
+                "value": "/^$Machine$/"
+              }
+            ]
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Model Input",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 12,
+          "y": 10
+        },
+        "id": 17,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 0.5,
+        "points": true,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "measurement": "model-output",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT mean(/^$Sensor$/)  FROM \"model-output\" WHERE (\"machine\" =~ /^$Machine$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+            "rawQuery": true,
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "*"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "machine",
+                "operator": "=~",
+                "value": "/^$Machine$/"
+              }
+            ]
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Model Output",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "InfluxDB",
+        "fill": 0,
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 22
+        },
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "hideEmpty": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 1,
+        "points": true,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "alias": "$col",
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "measurement": "tag-anomaly",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT mean(/^$Sensor$/)  FROM \"tag-anomaly\" WHERE (\"machine\" =~ /^$Machine$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+            "rawQuery": true,
+            "refId": "B",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "*"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "machine",
+                "operator": "=~",
+                "value": "/^$Machine$/"
+              }
+            ]
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Tag Anomaly",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "InfluxDB",
+        "fill": 0,
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 12,
+          "y": 22
+        },
+        "id": 18,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "hideEmpty": true,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 1,
+        "points": true,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "alias": "$col",
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "measurement": "total-anomaly",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT mean(/^$Sensor$/) as \"field\" FROM \"original-input\" WHERE (\"machine\" =~ /^$Machine$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+            "rawQuery": false,
+            "refId": "B",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "*"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": [
+              {
+                "key": "machine",
+                "operator": "=~",
+                "value": "/^$Machine$/"
+              }
+            ]
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Total Anomaly",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [
+      "machine"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "sfb-asset-key-needed",
+            "value": "sfb-asset-key-needed"
+          },
+          "datasource": "InfluxDB",
+          "definition": "",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "Machine",
+          "options": [],
+          "query": "SHOW TAG VALUES WITH KEY = \"machine\" ",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "InfluxDB",
+          "definition": "SHOW FIELD KEYS from \"model-input\"",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": true,
+          "name": "Sensor",
+          "options": [],
+          "query": "SHOW FIELD KEYS from \"model-input\"",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "2018-06-20T02:41:38.411Z",
+      "to": "2019-05-28T12:14:18.285Z"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Machine details",
+    "uid": "Lg4VHfEiz",
+    "version": 5
+  }
+}

--- a/run_workflow_and_argo.sh
+++ b/run_workflow_and_argo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+if [[ -z "${MACHINE_CONFIG}" && -z "${GORDO_NAME}" ]]; then
+    cp /code/config.yml /tmp/config.yml
+elif [[ -z "${MACHINE_CONFIG}" ]]; then
+    # $GORDO_NAME is set
+    kubectl get gordos ${GORDO_NAME} -o json  | jq ".spec.config" > /tmp/config.yml
+else
+    echo "$MACHINE_CONFIG" > /tmp/config.yml
+fi
+
+workflow_generator --machine-config /tmp/config.yml --output-file /tmp/generated-config.yml
+argo lint /tmp/generated-config.yml
+if [ "$ARGO_SUBMIT" = true ] ; then
+    argo submit /tmp/generated-config.yml
+fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,14 @@ testdocker       = pytest --addopts "-m 'dockertest'"
 testbuilder      = pytest --addopts "tests/gordo_components/builder"
 testcli          = pytest --addopts "tests/gordo_components/cli"
 testclient       = pytest --addopts "tests/gordo_components/client"
+testconfig_elements = pytest --addopts "tests/gordo_components/config_elements"
 testdataprovider = pytest --addopts "tests/gordo_components/data_provider"
 testdataset      = pytest --addopts "tests/gordo_components/dataset"
 testmodel        = pytest --addopts "tests/gordo_components/model"
 testserializer   = pytest --addopts "tests/gordo_components/serializer"
 testserver       = pytest --addopts "tests/gordo_components/server"
 testutil         = pytest --addopts "tests/gordo_components/util"
+testworkflow_generator  = pytest --addopts "tests/gordo_components/workflow_generator"
 testwatchman     = pytest --addopts "tests/gordo_components/watchman"
 
 # Black formatting
@@ -29,12 +31,14 @@ testallelse     = pytest --addopts
     "--ignore tests/gordo_components/builder
     --ignore tests/gordo_components/cli
     --ignore tests/gordo_components/client
+    --ignore tests/gordo_components/config_elements
     --ignore tests/gordo_components/data_provider
     --ignore tests/gordo_components/dataset
     --ignore tests/gordo_components/model
     --ignore tests/gordo_components/serializer
     --ignore tests/gordo_components/server
     --ignore tests/gordo_components/util
+    --ignore tests/gordo_components/workflow_generator
     --ignore tests/gordo_components/watchman
     --ignore tests/test_formatting.py"
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,14 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     description="Train and build models for Argo / Kubernetes",
-    entry_points={"console_scripts": ["gordo-components=gordo_components.cli:gordo"]},
+    entry_points={
+        "console_scripts": [
+            "gordo-components=gordo_components.cli:gordo",
+            "workflow_generator = gordo_components.workflow_generator.workflow_generator:main",
+            "unique_tags = gordo_components.workflow_generator.workflow_generator:main_tag_list",
+            "watchman-to-sql=gordo_components.watchman_to_sql.watchman_to_sql:watchman_to_sql_cli",
+        ]
+    },
     install_requires=requirements("requirements.in"),  # Allow flexible deps for install
     license="AGPLv3",
     name="gordo-components",
@@ -33,5 +40,9 @@ setup(
         "write_to": "gordo_components/_version.py",
         "relative_to": __file__,
     },
+    package_data={
+        "": ["gordo_components/workflow_generator/resources/argo-workflow.yml.template"]
+    },
+    include_package_data=True,
     zip_safe=True,
 )

--- a/tests/gordo_components/config_elements/test_config_elements.py
+++ b/tests/gordo_components/config_elements/test_config_elements.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+import ast
+import json
+import logging
+import unittest
+
+from datetime import datetime, timezone
+
+import yaml
+from gordo_components.config_elements.dataset import Dataset
+from gordo_components.config_elements.machine import Machine
+from gordo_components.workflow_generator.workflow_generator import (
+    _timestamp_constructor,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class DatasetConfigElementTestCase(unittest.TestCase):
+    def test_from_config(self):
+        """
+        Test ability to create a Dataset from a config element
+        """
+        element_str = """
+            name: ct-23-0002
+            dataset:
+              resolution: 2T
+              tags:
+                - TAG1
+                - TAG2
+                - TAG3
+              train_start_date: 2011-05-20T01:00:04+02:00
+              train_end_date: 2018-05-10T15:05:50+02:00
+        """
+        yaml.FullLoader.add_constructor(
+            tag="tag:yaml.org,2002:timestamp", constructor=_timestamp_constructor
+        )
+        dataset_config = yaml.load(element_str, Loader=yaml.FullLoader)["dataset"]
+        dataset = Dataset.from_config(dataset_config.copy())
+        dataset_config.update({"type": "TimeSeriesDataset"})
+        dataset_config["train_start_date"] = dataset_config[
+            "train_start_date"
+        ].isoformat()
+        dataset_config["train_end_date"] = dataset_config["train_end_date"].isoformat()
+
+        # target_tag_list wasn't specified, but should default to the 'tags'
+        dataset_config["target_tag_list"] = [
+            "TAG1",
+            "TAG2",
+            "TAG3",
+        ]
+        self.assertEqual(dataset.to_dict(), dataset_config)
+
+    def test_dataset_from_config_checks_dates(self):
+        """
+        A dataset needs to have train_start_date properly before train_end_date
+        """
+        element_str = """
+            dataset:
+              resolution: 2T
+              tags:
+                - TAG1
+                - TAG2
+                - TAG3
+              train_start_date: 2018-05-10T15:05:50+02:00
+              train_end_date: 2018-05-10T15:05:50+02:00
+        """
+        dataset_config = yaml.load(element_str)["dataset"]
+        with self.assertRaises(ValueError):
+            Dataset.from_config(dataset_config)
+
+
+class MachineConfigElementTestCase(unittest.TestCase):
+    default_globals = {
+        "runtime": {
+            "server": {
+                "resources": {
+                    "requests": {"memory": 1, "cpu": 2},
+                    "limits": {"memory": 3, "cpu": 4},
+                }
+            }
+        }
+    }
+
+    def test_from_config(self):
+        """
+        Test ability to create a Machine from a config element.
+        """
+
+        element_str = """
+            name: ct-23-0001-machine
+            data_provider:
+              threads: 10
+            dataset:
+              tags: [TAG1, TAG2, TAG3]
+              target_tag_list: [TAG4]
+              train_start_date: 2018-01-01T09:00:30Z
+              train_end_date: 2018-01-02T09:00:30Z
+            model:
+              sklearn.pipeline.Pipeline:
+                steps:
+                  - sklearn.preprocessing.data.MinMaxScaler
+                  - gordo_components.model.models.KerasAutoEncoder:
+                      kind: feedforward_hourglass
+            metadata:
+              id: special-id
+        """
+        self.maxDiff = None
+        yaml.FullLoader.add_constructor(
+            tag="tag:yaml.org,2002:timestamp", constructor=_timestamp_constructor
+        )
+        element = yaml.load(element_str, Loader=yaml.FullLoader)
+        machine = Machine.from_config(
+            element,
+            project_name="test-project-name",
+            config_globals=self.default_globals,
+        )
+        logger.info(f"{machine}")
+        self.assertIsInstance(machine, Machine)
+        self.assertTrue(len(machine.dataset.tags), 3)
+
+        # The metadata of machine should be json serializable
+        json.dumps(machine.to_dict()["metadata"])
+
+        # The metadata of machine should be ast.literal_eval-able when cast as a str
+        self.assertEqual(
+            ast.literal_eval(str(machine.to_dict()["metadata"])),
+            machine.to_dict()["metadata"],
+        )
+        # dictionary representation of the machine expected:
+        self.assertEqual(
+            machine.to_dict(),
+            {
+                "name": "ct-23-0001-machine",
+                "data_provider": {"type": "DataLakeProvider", "threads": 10},
+                "project_name": "test-project-name",
+                "dataset": {
+                    "type": "TimeSeriesDataset",
+                    "tags": [
+                        "TAG1",
+                        "TAG2",
+                        "TAG3",
+                    ],
+                    "target_tag_list": ["TAG4"],
+                    "train_start_date": datetime(
+                        2018, 1, 1, 9, 0, 30, tzinfo=timezone.utc
+                    ).isoformat(),
+                    "train_end_date": datetime(
+                        2018, 1, 2, 9, 0, 30, tzinfo=timezone.utc
+                    ).isoformat(),
+                },
+                "metadata": {
+                    "global-metadata": {},
+                    "machine-metadata": {"id": "special-id"},
+                },
+                "model": {
+                    "sklearn.pipeline.Pipeline": {
+                        "steps": [
+                            "sklearn.preprocessing.data.MinMaxScaler",
+                            {
+                                "gordo_components.model.models.KerasAutoEncoder": {
+                                    "kind": "feedforward_hourglass"
+                                }
+                            },
+                        ]
+                    }
+                },
+                "runtime": {
+                    "server": {
+                        "resources": {
+                            "requests": {"memory": 1, "cpu": 2},
+                            "limits": {"memory": 3, "cpu": 4},
+                        }
+                    }
+                },
+            },
+        )

--- a/tests/gordo_components/config_elements/test_descriptors.py
+++ b/tests/gordo_components/config_elements/test_descriptors.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import datetime
+
+from gordo_components.config_elements.validators import (
+    ValidUrlString,
+    ValidDatetime,
+    ValidTagList,
+    ValidMetadata,
+    ValidModel,
+    ValidMachineRuntime,
+    fix_resource_limits,
+)
+
+
+class DescriptorsTestCase(unittest.TestCase):
+    def test_valid_model(self):
+        """
+        Verifies a given object is Union[str, dict]
+        """
+
+        class MyClass:
+            value = ValidModel()
+
+        myclass = MyClass()
+
+        # All ok
+        myclass.value = {"KerasModel": {"kind": "symetric"}}
+        myclass.value = "KerasModel"
+
+        # Not ok
+        with self.assertRaises(ValueError):
+            myclass.value = 1
+        with self.assertRaises(ValueError):
+            myclass.value = None
+
+    def test_valid_metadata(self):
+        """
+        Verifies a given object is Optional[dict]
+        """
+
+        class MyClass:
+            value = ValidMetadata()
+
+        myclass = MyClass()
+
+        # All of these are ok
+        myclass.value = dict()
+        myclass.value = {"key": "value"}
+        myclass.value = None
+
+        # This is not
+        with self.assertRaises(ValueError):
+            myclass.value = 1
+        with self.assertRaises(ValueError):
+            myclass.value = "string"
+
+    def test_valid_datetime(self):
+        """
+        Verifies a given object is of datetime.datetime
+        """
+
+        class MyClass:
+            value = ValidDatetime()
+
+        myclass = MyClass()
+
+        myclass.value = datetime.datetime.now(tz=datetime.timezone.utc)
+        # Should raise an error
+        with self.assertRaises(ValueError):
+            myclass.value = datetime.datetime.now()
+
+        # Should raise an error
+        with self.assertRaises(ValueError):
+            myclass.value = "not a datetime object"
+
+    def test_valid_tag_list(self):
+        """
+        Verifies a given object is of a non-empty List[str]
+        """
+
+        class MyClass:
+            value = ValidTagList()
+
+        myclass = MyClass()
+
+        # No problem
+        myclass.value = ["string here", "string there"]
+
+        # Problem.
+        with self.assertRaises(ValueError):
+            myclass.value = "not a list"
+        with self.assertRaises(ValueError):
+            myclass.value = []  # Error with empty list.
+
+    def test_valid_url_string(self):
+        """
+        Verifies that a given string matches what we consider to be a valid
+        url; in this case alphanumeric with dashes.
+        """
+        valid_names = [
+            "valid-name-here",
+            "validnamehere",
+            "also-a-valid-name123",
+            "equally-valid-name",
+            "another-1-2-3",
+        ]
+        for valid_name in valid_names:
+            self.assertTrue(
+                ValidUrlString.valid_url_string(valid_name),
+                msg=f"Expected '{valid_name}' to be valid, but it is not",
+            )
+
+        invalid_names = [
+            "Not_a_valid_name",
+            "C%tainly-not-v@lid",
+            "also not valid with spaces",
+            "couldn't-possibly-valid",
+            "also,-this-is-not-valid",
+            "(this-is-not-either)",
+            "!nor-this",
+            "cannot-have-UpperCase",
+            "-cannot-begin-with-dashes",
+            "cannot-end-with-dashes-",
+        ]
+        for invalid_name in invalid_names:
+            self.assertFalse(
+                ValidUrlString.valid_url_string(invalid_name),
+                msg=f"Expected '{invalid_name}' to be invalid, but it is.",
+            )
+
+        # Test it's a working Descriptor
+        class MyClass:
+            value = ValidUrlString()
+
+        myclass = MyClass()
+
+        myclass.value = "this-should-not-cause-an-error"
+
+        with self.assertRaises(ValueError):
+            myclass.value = (
+                "this-name-is-simply-too-long-that-is-the-only-problem-here-for-sure"
+            )
+
+        with self.assertRaises(ValueError):
+            myclass.value = "but this should!"
+
+    def test_valid_runtime(self):
+        """
+        Verifies that ValidRuntime enforces a server section with resources.requests and
+        resources.limits
+        """
+
+        class MyClass:
+            value = ValidMachineRuntime()
+
+        myclass = MyClass()
+        # test that limits are bumped to at least request:
+        myclass.value = {
+            "server": {
+                "resources": {
+                    "requests": {"memory": 1, "cpu": 5},
+                    "limits": {"memory": 3, "cpu": 4},
+                }
+            },
+            "other": {},
+        }
+        self.assertEqual(myclass.value["server"]["resources"]["limits"]["cpu"], 5)
+
+        # Problem.
+        with self.assertRaises(ValueError):
+            myclass.value = {
+                "server": {"resources": {"requests": {"memory": 1, "cpu": 2}}}
+            }  # Missing limits
+        with self.assertRaises(ValueError):
+            myclass.value = {}  # Missing server
+
+    def test_fix_resource_limits(self):
+        # Bumps cpu limit
+        resource_dict = {
+            "requests": {"memory": 1, "cpu": 5},
+            "limits": {"memory": 3, "cpu": 4},
+        }
+        res = fix_resource_limits(resource_dict)
+        self.assertEqual(res["limits"]["cpu"], 5)
+
+        # Works without requests
+        resource_dict = {"limits": {"memory": 3, "cpu": 4}}
+        res = fix_resource_limits(resource_dict)
+        self.assertEqual(res["limits"]["cpu"], 4)
+        # Works without limits
+        resource_dict = {"requests": {"memory": 1, "cpu": 5}}
+        res = fix_resource_limits(resource_dict)
+        self.assertEqual(res["requests"]["cpu"], 5)
+
+        # Does  nothing if limit>requests
+        resource_dict = {
+            "requests": {"memory": 1, "cpu": 5},
+            "limits": {"memory": 3, "cpu": 6},
+        }
+        res = fix_resource_limits(resource_dict)
+        self.assertEqual(res["limits"]["cpu"], 6)
+
+    def test_fix_resource_limits_checks_ints(self):
+        resource_dict = {
+            "requests": {"memory": "1M", "cpu": 5},
+            "limits": {"memory": 3, "cpu": 4},
+        }
+        with self.assertRaises(ValueError):
+            fix_resource_limits(resource_dict)

--- a/tests/gordo_components/workflow_generator/data/config-test-allowed-timestamps.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-allowed-timestamps.yml
@@ -1,0 +1,36 @@
+machines:
+
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+      train_start_date: "2016-11-07T08:10:31+00:00"
+      train_end_date: "2017-11-07T10:10:01+00:00"
+
+  - name: machine-2
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+      train_start_date: '2016-11-07T08:10:31+00:00'
+      train_end_date: '2017-11-07T11:10:00+00:00'
+
+  - name: machine-3
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+      train_start_date: 2016-11-07T08:10:31+00:00
+      train_end_date: 2017-11-07T11:10:00+00:00
+
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-datasource.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-datasource.yml
@@ -1,0 +1,41 @@
+machines:
+  - name: machine-1 # Should have DataLakeProvider datasource and 20 threads
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 4
+      train_start_date: 2016-11-07T08:10:30+00:00
+      train_end_date: 2017-11-07T10:10:01+00:00
+
+  - name: machine-2
+    data_provider: #Should have custom data_source and 20 threads
+      type: custom
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+        - Tag 4
+      train_start_date: 2016-11-07T09:10:31+01:00
+      train_end_date: 2017-11-07T11:10:00+01:00
+
+  - name: machine-3
+    data_provider: # Should have DataLakeProvider datasource and 10 threads
+      threads: 10
+    dataset:
+      tags:
+        - Tag 3
+        - Tag 5
+      train_start_date: 2016-11-07T09:10:31+01:00
+      train_end_date: 2017-11-07T11:10:00+01:00
+
+globals:
+  data_provider:
+    threads: 20
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-disable-influx.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-disable-influx.yml
@@ -1,0 +1,32 @@
+machines:
+
+  - name: ct-23-0002
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+
+  - name: ct-23-0003
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+# We disable influx globally
+globals:
+  runtime:
+    influx:
+      enable: False
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-empty-tag-list.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-empty-tag-list.yml
@@ -1,0 +1,24 @@
+machines:
+
+  - name: ct-23-0001 #1st machine
+    dataset:
+      tags: #empty tag list for 1st machine
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+  - name: ct-23-0002 #2nd machine
+    dataset:
+      tags: #list of tags for 2nd machine
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-failing-resource-format.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-failing-resource-format.yml
@@ -1,0 +1,24 @@
+machines:
+
+  - name: ct-23-0002
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+globals:
+  runtime: #ERROR: This should fail because the resources should be ints, not strings
+    influx:
+      resources:
+        requests:
+          memory: 321M
+
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-missing-timezone-quoted.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-missing-timezone-quoted.yml
@@ -1,0 +1,8 @@
+machines:
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+      train_start_date: "2016-11-07T08:10:31+00:00"
+      train_end_date: "2017-11-07T10:10:01"

--- a/tests/gordo_components/workflow_generator/data/config-test-missing-timezone.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-missing-timezone.yml
@@ -1,0 +1,8 @@
+machines:
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+      train_start_date: 2016-11-07T08:10:31+00:00
+      train_end_date: 2017-11-07T10:10:01

--- a/tests/gordo_components/workflow_generator/data/config-test-runtime-resource.yaml
+++ b/tests/gordo_components/workflow_generator/data/config-test-runtime-resource.yaml
@@ -1,0 +1,61 @@
+machines:
+
+  - name: ct-23-0002 #Uses defaults of everything
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+
+  - name: ct-23-0003 #Modifies server.resources.requests.memory
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+    runtime:
+      server:
+        resources:
+          requests:
+            memory: 201
+
+globals:
+  runtime: #We request some different resources for the server, but not change limit
+    server:
+      resources:
+        requests:
+          memory: 111
+          cpu: 112
+    builder: # We want different builder settings
+      resources:
+        requests:
+          memory: 121
+        limits:
+          memory: 120 # This is illegal since it is smaller than request, and will be bumped to 121
+    client:
+      resources:
+        requests:
+          memory: 221
+        limits:
+          memory: 220 # This is illegal since it is smaller than request, and will be bumped to 221
+      max_instances: 10
+
+    influx:
+      resources:
+        requests:
+          memory: 321
+        limits:
+          memory: 320 # This is illegal since it is smaller than request, and will be bumped to 321
+
+
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-selective-influx.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-selective-influx.yml
@@ -1,0 +1,30 @@
+machines:
+
+  - name: ct-23-0002 #Influx should start up by default for this one
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+
+  - name: ct-23-0003 # Dont want influx for this one
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+    runtime:
+      influx:
+        enable: False
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-tag-list.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-tag-list.yml
@@ -1,0 +1,35 @@
+machines:
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 4
+      train_start_date: 2016-11-07T08:10:30+00:00
+      train_end_date: 2017-11-07T10:10:01+00:00
+
+  - name: machine-2
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+        - Tag 4
+      train_start_date: 2016-11-07T09:10:31+01:00
+      train_end_date: 2017-11-07T11:10:00+01:00
+
+  - name: machine-3
+    dataset:
+      tags:
+        - Tag 3
+        - Tag 5
+      train_start_date: 2016-11-07T09:10:31+01:00
+      train_end_date: 2017-11-07T11:10:00+01:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-timestamp-1.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-timestamp-1.yml
@@ -1,0 +1,26 @@
+machines:
+
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+      train_start_date: 2016-11-07T08:10:30+00:00
+      train_end_date: 2017-11-07T10:10:01+00:00
+
+  - name: machine-2
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+      train_start_date: 2016-11-07T09:10:31+01:00
+      train_end_date: 2017-11-07T11:10:00+01:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-timestamp-2.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-timestamp-2.yml
@@ -1,0 +1,26 @@
+machines:
+
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+      train_start_date: 2016-11-07T08:10:30+00:00
+      train_end_date: 2017-11-07T10:10:01+00:00
+
+  - name: machine-2
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+      train_start_date: 2016-11-07T08:10:31+00:00
+      train_end_date: 2017-11-07T10:10:00+00:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-timestamp-3.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-timestamp-3.yml
@@ -1,0 +1,26 @@
+machines:
+
+  - name: machine-1
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+      train_start_date: 2016-11-07T08:10:30+00:00
+      train_end_date: 2017-11-07T10:10:00+00:00
+
+  - name: machine-2
+    dataset:
+      tags:
+        - Tag 1
+        - Tag 2
+        - Tag 3
+      train_start_date: 2016-11-07T09:10:30+02:00
+      train_end_date: 2017-11-07T11:10:00+02:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/data/config-test-with-models.yml
+++ b/tests/gordo_components/workflow_generator/data/config-test-with-models.yml
@@ -1,0 +1,26 @@
+machines:
+
+  - name: ct-23-0001 #1st machine
+    dataset:
+      tags: #list of tags for 1st machine
+        - GRA-TE  -23-0733.PV
+        - GRA-TT  -23-0719.PV
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+  - name: ct-23-0002 #2nd machine
+    dataset:
+      tags: #list of tags for 2nd machine
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo_components/workflow_generator/test_workflow_generator.py
+++ b/tests/gordo_components/workflow_generator/test_workflow_generator.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+import sys
+import unittest
+
+from contextlib import contextmanager
+from io import StringIO
+from unittest.mock import patch
+
+import docker
+import pytest
+import yaml
+
+from gordo_components.workflow_generator import workflow_generator as wg
+from gordo_components.config_elements.normalized_config import NormalizedConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def capture_stdout():
+    new_out = StringIO()
+    old_out = sys.stdout
+    try:
+        sys.stdout = new_out
+        yield sys.stdout
+    finally:
+        sys.stdout = old_out
+
+
+def _generate_test_workflow_str(
+    path_to_config_files, config_filename, project_name="test-proj-name"
+):
+    """ Reads a test-config file with workflow_generator, and returns the string
+    content of the generated workflow"""
+    config_file = os.path.join(path_to_config_files, config_filename)
+    args = ["--machine-config", config_file, "--project-name", project_name]
+    with patch("sys.argv", args), capture_stdout() as output:
+        wg.main(sys.argv)
+        getvalue = output.getvalue()
+    return getvalue
+
+
+def _get_env_for_machine_build_serve_task(machine, expanded_template):
+    templates = expanded_template["spec"]["templates"]
+    do_all = [task for task in templates if task["name"] == "do-all"][0]
+    model_builder_machine = [
+        task
+        for task in do_all["dag"]["tasks"]
+        if task["name"] == f"model-builder-{machine}"
+    ][0]
+    model_builder_machine_env = {
+        e["name"]: e["value"] for e in model_builder_machine["arguments"]["parameters"]
+    }
+    return model_builder_machine_env
+
+
+class WorkflowGeneratorTestCase(unittest.TestCase):
+
+    path_to_config_files = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "data"
+    )
+
+    def _generate_test_workflow_yaml(
+        self, config_filename, project_name="test-proj-name"
+    ):
+        """ Reads a test-config file with workflow_generator, and returns the parsed
+        yaml of the generated workflow """
+        getvalue = _generate_test_workflow_str(
+            self.path_to_config_files, config_filename, project_name=project_name
+        )
+        expanded_template = yaml.load(getvalue, Loader=yaml.FullLoader)
+        return expanded_template
+
+    @pytest.mark.slowtest
+    def test_argo_lint(self):
+        """
+        Test the our example config file, assumed to be valid, produces a valid workflow via `argo lint`
+        """
+        client = docker.from_env()
+
+        # Build the argo dockerfile
+        repo_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        file = os.path.join(repo_dir, "Dockerfile-argo")
+
+        logger.info("Building Argo docker image...")
+        img, _ = client.images.build(
+            path=repo_dir,
+            dockerfile=file,
+            tag="temp-argo",
+            use_config_proxy=True,
+            buildargs={"HTTPS_PROXY": ""},
+        )
+
+        logger.info(
+            "Running workflow generator and argo lint on examples/config.yaml..."
+        )
+        result = client.containers.run(
+            img.id,
+            command="bash -c 'workflow_generator "
+            "--project-name some-project "
+            "--machine-config /code/examples/config.yaml "
+            "--output-file /tmp/out.yaml "
+            "&& argo lint /tmp/out.yaml'",
+            auto_remove=True,
+            stderr=True,
+            stdout=True,
+            detach=False,
+            volumes={repo_dir: {"bind": "/code", "mode": "ro"}},
+        )
+        self.assertEqual(
+            result.decode().strip().split("\n")[-1], "Workflow manifests validated"
+        )
+        client.images.remove(img.id, force=True)
+
+    def test_basic_generation(self):
+
+        """ model must be included in the config file """
+        """ start/end dates ...always included? or default to specific dates if not included?"""
+
+        project_name = "some-fancy-project-name"
+        model_config = (
+            "{'sklearn.pipeline.Pipeline': {'steps': ['sklearn.preprocessing.data.MinMaxScaler',"
+            " {'gordo_components.model.models.KerasAutoEncoder': {'kind': 'feedforward_hourglass'}}]}}"
+        )
+
+        config_filename = "config-test-with-models.yml"
+        expanded_template = _generate_test_workflow_str(
+            self.path_to_config_files, config_filename, project_name=project_name
+        )
+
+        self.assertTrue(
+            project_name in expanded_template,
+            msg=f"Expected to find project name: {project_name} "
+            f"in output: {expanded_template}",
+        )
+        self.assertTrue(
+            model_config in expanded_template,
+            msg=f"Expected to find model config: {model_config} "
+            f"in output: {expanded_template}",
+        )
+
+        yaml_content = wg.get_dict_from_yaml(
+            os.path.join(self.path_to_config_files, config_filename)
+        )
+        machines = NormalizedConfig(yaml_content, project_name=project_name).machines
+        self.assertTrue(len(machines) == 2)
+
+    def test_runtime_overrides_server(self):
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-runtime-resource.yaml"
+        )
+
+        model_builder_ct_23_0002_env = _get_env_for_machine_build_serve_task(
+            "ct-23-0002", expanded_template
+        )
+
+        model_builder_ct_23_0003_env = _get_env_for_machine_build_serve_task(
+            "ct-23-0003", expanded_template
+        )
+
+        # ct_23_0002 uses the global overriden requests, but default limits
+        self.assertEqual(
+            model_builder_ct_23_0002_env["server-resources-requests-memory"], 111
+        )
+
+        # This value must be changed if we change the default values
+        self.assertEqual(
+            model_builder_ct_23_0002_env["server-resources-limits-cpu"], 1000
+        )
+
+        # ct_23_0003 uses locally overriden request memory
+        self.assertEqual(
+            model_builder_ct_23_0003_env["server-resources-requests-memory"], 201
+        )
+
+    def test_overrides_builder_datasource(self):
+
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-datasource.yml"
+        )
+
+        model_builder_machine_1_env = _get_env_for_machine_build_serve_task(
+            "machine-1", expanded_template
+        )
+        model_builder_machine_2_env = _get_env_for_machine_build_serve_task(
+            "machine-2", expanded_template
+        )
+        model_builder_machine_3_env = _get_env_for_machine_build_serve_task(
+            "machine-3", expanded_template
+        )
+
+        # ct_23_0002 uses the global overriden requests, but default limits
+        self.assertEqual(
+            "{'type': 'DataLakeProvider', 'threads': 20}",
+            model_builder_machine_1_env["data-provider"],
+        )
+
+        # This value must be changed if we change the default values
+        self.assertEqual(
+            "{'type': 'custom', 'threads': 20}",
+            model_builder_machine_2_env["data-provider"],
+        )
+
+        # ct_23_0003 uses locally overriden request memory
+        self.assertEqual(
+            "{'type': 'DataLakeProvider', 'threads': 10}",
+            model_builder_machine_3_env["data-provider"],
+        )
+
+    def test_runtime_overrides_builder(self):
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-runtime-resource.yaml"
+        )
+        templates = expanded_template["spec"]["templates"]
+        model_builder_task = [
+            task for task in templates if task["name"] == "model-builder"
+        ][0]
+        model_builder_resource = model_builder_task["container"]["resources"]
+
+        # We use yaml overriden memory (both request and limits).
+        self.assertEqual(model_builder_resource["requests"]["memory"], "121M")
+
+        # This was specified to 120 in the config file, but is bumped to match the
+        # request
+        self.assertEqual(model_builder_resource["limits"]["memory"], "121M")
+        # requests.cpu is all default
+        self.assertEqual(model_builder_resource["requests"]["cpu"], "500m")
+
+    def test_runtime_overrides_client_para(self):
+        """It is possible to override the parallelization of the client
+        through the globals-section of the config file"""
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-runtime-resource.yaml"
+        )
+        templates = expanded_template["spec"]["templates"]
+        client_task = [
+            task for task in templates if task["name"] == "gordo-client-waiter"
+        ][0]
+
+        client_env = {e["name"]: e["value"] for e in client_task["script"]["env"]}
+
+        self.assertEqual(client_env["GORDO_MAX_CLIENTS"], "10")
+
+    def test_runtime_overrides_client(self):
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-runtime-resource.yaml"
+        )
+        templates = expanded_template["spec"]["templates"]
+        model_client_task = [
+            task for task in templates if task["name"] == "gordo-client"
+        ][0]
+        model_client_resource = model_client_task["script"]["resources"]
+
+        # We use yaml overriden memory (both request and limits).
+        self.assertEqual(model_client_resource["requests"]["memory"], "221M")
+
+        # This was specified to 120 in the config file, but is bumped to match the
+        # request
+        self.assertEqual(model_client_resource["limits"]["memory"], "221M")
+        # requests.cpu is all default
+        self.assertEqual(model_client_resource["requests"]["cpu"], "100m")
+
+    def test_runtime_overrides_influx(self):
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-runtime-resource.yaml"
+        )
+        templates = expanded_template["spec"]["templates"]
+        influx_task = [
+            task for task in templates if task["name"] == "gordo-influx-statefulset"
+        ][0]
+        influx_statefulset_definition = yaml.load(
+            influx_task["resource"]["manifest"], Loader=yaml.FullLoader
+        )
+        influx_resource = influx_statefulset_definition["spec"]["template"]["spec"][
+            "containers"
+        ][0]["resources"]
+        # We use yaml overriden memory (both request and limits).
+        self.assertEqual(influx_resource["requests"]["memory"], "321M")
+
+        # This was specified to 120 in the config file, but is bumped to match the
+        # request
+        self.assertEqual(influx_resource["limits"]["memory"], "321M")
+        # requests.cpu is default
+        self.assertEqual(influx_resource["requests"]["cpu"], "520m")
+        self.assertEqual(influx_resource["limits"]["cpu"], "10040m")
+
+    def test_disable_influx(self):
+        """It works to disable influx globally"""
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-disable-influx.yml"
+        )
+        templates = expanded_template["spec"]["templates"]
+        do_all = [task for task in templates if task["name"] == "do-all"][0]
+        influx_tasks = [
+            task["name"] for task in do_all["dag"]["tasks"] if "influx" in task["name"]
+        ]
+        client_tasks = [
+            task["name"] for task in do_all["dag"]["tasks"] if "client" in task["name"]
+        ]
+
+        # The cleanup should be the only influx-related task
+        self.assertEqual(influx_tasks, ["influx-cleanup"])
+        self.assertEqual(client_tasks, [])
+
+    def test_selective_influx(self):
+        """It works to enable/disable influx per machine"""
+        expanded_template = self._generate_test_workflow_yaml(
+            "config-test-selective-influx.yml"
+        )
+        templates = expanded_template["spec"]["templates"]
+        do_all = [task for task in templates if task["name"] == "do-all"][0]
+        influx_tasks = [
+            task["name"] for task in do_all["dag"]["tasks"] if "influx" in task["name"]
+        ]
+        client_tasks = [
+            task["name"] for task in do_all["dag"]["tasks"] if "client" in task["name"]
+        ]
+
+        # Now we should have both influx and influx-cleanup
+        self.assertEqual(influx_tasks, ["influx-cleanup", "gordo-influx"])
+
+        # And we have a single client task for the one client we want running
+        self.assertEqual(client_tasks, ["gordo-client-ct-23-0002"])
+
+    def test_main_tag_list(self):
+        config_file = os.path.join(
+            self.path_to_config_files, "config-test-tag-list.yml"
+        )
+        args = ["--machine-config", config_file]
+
+        with patch("sys.argv", args), capture_stdout() as output:
+            wg.main_tag_list(sys.argv)
+            output_tags = output.getvalue()
+
+        output_tags = set(output_tags.split(sep="\n")[:-1])
+        expected_output_tags = {"Tag 1", "Tag 2", "Tag 3", "Tag 4", "Tag 5"}
+
+        self.assertTrue(
+            output_tags == expected_output_tags,
+            msg=f"Expected to find: {expected_output_tags}, outputted "
+            f"{output_tags}",
+        )
+
+    def test_valid_dateformats(self):
+        output_workflow = _generate_test_workflow_str(
+            self.path_to_config_files, "config-test-allowed-timestamps.yml"
+        )
+
+        self.assertEqual(
+            output_workflow.count("2016-11-07"), 6
+        )  # Three from the dataset and three from the start for tag fetching
+        self.assertEqual(output_workflow.count("2017-11-07"), 3)
+
+    def test_model_names_embedded(self):
+        """Tests that the generated workflow contains the names of the machines
+        it builds a workflow for in the metadata/annotation as a yaml-parsable structure
+        """
+        output_workflow = self._generate_test_workflow_yaml(
+            "config-test-allowed-timestamps.yml"
+        )
+        parsed_machines = yaml.load(
+            output_workflow["metadata"]["annotations"]["gordo-models"]
+        )
+        self.assertEqual(parsed_machines, ["machine-1", "machine-2", "machine-3"])
+
+    def test_missing_timezone(self):
+        with self.assertRaises(ValueError):
+            self._generate_test_workflow_yaml("config-test-missing-timezone.yml")
+
+        with self.assertRaises(ValueError):
+            self._generate_test_workflow_yaml("config-test-missing-timezone-quoted.yml")
+
+    def test_validates_resource_format(self):
+        """We validate that resources are integers"""
+        with self.assertRaises(ValueError):
+            _generate_test_workflow_str(
+                self.path_to_config_files, "config-test-failing-resource-format.yml"
+            )


### PR DESCRIPTION
Problem :carrot: 
-----
We've talked about it before, workflow generator, generally fitting as a component itself to the "gordo" workflow. It's also a cost to explain to data scientists / power users, that if they want to trial gordo-components, they'd have to update multiple versions here and there, vs only concerning themselves with the version of gordo-components they're working with.

Solution :cake: 
---
Move `workflow_generator` and `config_elements` into components.