### PR TITLE
Add more explicit docs about resolution strings

### DIFF
--- a/gordo_components/dataset/base.py
+++ b/gordo_components/dataset/base.py
@@ -37,25 +37,21 @@ class GordoBaseDataset:
 
         Parameters
         ----------
-        series_iterable
+        series_iterable: Iterable[pd.Series]
             An iterator supplying series with time index
-
-        resampling_startpoint
+        resampling_startpoint: datetime.datetime
             The starting point for resampling. Most data frames will not have this
             in their datetime index, and it will be inserted with a NaN as the value.
             The resulting NaNs will be removed, so the only important requirement for this is
             that this resampling_startpoint datetime must be before or equal to the first
             (earliest) datetime in the data to be resampled.
-
-        resampling_endpoint
+        resampling_endpoint: datetime.datetime
             The end point for resampling. This datetime must be equal to or after the last datetime in the
             data to be resampled.
-
-
-        resolution
+        resolution: str
             The bucket size for grouping all incoming time data (e.g. "10T")
-
-        aggregation_methods
+            Available strings come from https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
+        aggregation_methods: Union[str, List[str], Callable]
             Aggregation method(s) to use for the resampled buckets. If a single
             resample method is provided then the resulting dataframe will have names
             identical to the names of the series it got in. If several

--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -52,6 +52,7 @@ class TimeSeriesDataset(GordoBaseDataset):
             into the y return from ``.get_data()``
         resolution: str
             The bucket size for grouping all incoming time data (e.g. "10T").
+            Available strings come from https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
         row_filter: str
             Filter on the rows. Only rows satisfying the filter will be in the dataset.
             See :func:`gordo_components.dataset.filter_rows.pandas_filter_rows` for


### PR DESCRIPTION
Problem :alarm_clock: 
---
Our current documentation about `resolution` is pretty obscure; what is the format of these magical strings?

Solution :unicorn: 
---
Add link to where/what strings are valid.