### PR TITLE
Expose evaluation from config in model builder

### DIFF
--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -573,9 +573,10 @@ def test_provide_saved_model_caching(
 
 
 @pytest.mark.parametrize(
-    "should_be_equal,cv_mode", [(True, "full_build"), (False, "cross_val_only")]
+    "should_be_equal,evaluation_config",
+    [(True, {"cv_mode": "full_build"}), (False, {"cv_mode": "cross_val_only"})],
 )
-def test_model_builder_cv_scores_only(should_be_equal: bool, cv_mode: str):
+def test_model_builder_cv_scores_only(should_be_equal: bool, evaluation_config: dict):
     """
     Test checks that the model is None if cross_val_only is used as the cv_mode.
     If the default mode ('full_build') is used, the model should not be None.
@@ -584,8 +585,8 @@ def test_model_builder_cv_scores_only(should_be_equal: bool, cv_mode: str):
     ----------
     should_be_equal: bool
         Refers to whether or not the cv_mode should be equal to full (default) or cross_val only.
-    cv_mode: str
-        The mode which is tested, is either full or cross_val_only
+    evaluation_config: dict
+        The mode which is tested from within the evaluation_config, is either full or cross_val_only
 
     """
 
@@ -597,7 +598,7 @@ def test_model_builder_cv_scores_only(should_be_equal: bool, cv_mode: str):
         model_config=model_config,
         data_config=data_config,
         metadata={},
-        cv_mode=cv_mode,
+        evaluation_config=evaluation_config,
     )
     if should_be_equal:
         assert model is not None

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -224,7 +224,8 @@ class CliTestCase(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
-    "should_save_model, cv_mode", [(True, "full_build"), (False, "cross_val_only")]
+    "should_save_model, cv_mode",
+    [(True, {"cv_mode": "full_build"}), (False, {"cv_mode": "cross_val_only"})],
 )
 def test_build_cv_mode(
     should_save_model: bool, cv_mode: str, tmp_dir: tempfile.TemporaryDirectory
@@ -245,7 +246,7 @@ def test_build_cv_mode(
         MODEL_CONFIG=json.dumps(MODEL_CONFIG_WITH_PREDICT),
     ):
         result = runner.invoke(
-            cli.gordo, ["build", "--print-cv-scores", f"--cv-mode={cv_mode}"]
+            cli.gordo, ["build", "--print-cv-scores", f"--evaluation-config={cv_mode}"]
         )
         # Checks that the file is empty or not depending on the mode.
         if should_save_model:
@@ -263,8 +264,8 @@ def test_build_cv_mode(
 @pytest.mark.parametrize(
     "should_be_equal,cv_mode_1, cv_mode_2",
     [
-        (True, "full_build", "cross_val_only"),
-        (False, "cross_val_only", "cross_val_only"),
+        (True, {"cv_mode": "full_build"}, {"cv_mode": "cross_val_only"}),
+        (False, {"cv_mode": "cross_val_only"}, {"cv_mode": "cross_val_only"}),
     ],
 )
 def test_build_cv_mode_cross_val_cache(
@@ -292,8 +293,8 @@ def test_build_cv_mode_cross_val_cache(
         MODEL_REGISTER_DIR=model_register_dir,
     ):
 
-        runner.invoke(cli.gordo, ["build", f"--cv-mode={cv_mode_1}"])
-        runner.invoke(cli.gordo, ["build", f"--cv-mode={cv_mode_2}"])
+        runner.invoke(cli.gordo, ["build", f"--evaluation-config={cv_mode_1}"])
+        runner.invoke(cli.gordo, ["build", f"--evaluation-config={cv_mode_2}"])
 
         if should_be_equal:
             assert os.path.exists(model_register_dir)
@@ -320,7 +321,9 @@ def test_build_cv_mode_build_only(tmp_dir: tempfile.TemporaryDirectory):
     ):
 
         metadata_file = f"{os.path.join(tmp_dir.name, 'metadata.json')}"
-        runner.invoke(cli.gordo, ["build", "--cv-mode=build_only"])
+        runner.invoke(
+            cli.gordo, ["build", '--evaluation-config={"cv_mode": "build_only"}']
+        )
 
         # A model has been saved
         assert len(os.listdir(tmp_dir.name)) != 0


### PR DESCRIPTION
Let the user specify the evaluation key in the config file to change ```cv_mode``` and have the possibility to add more parameters.