### PR TITLE
Make ML Server serve multiple models

### DIFF
--- a/gordo_components/server/server.py
+++ b/gordo_components/server/server.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 class Config:
     """Server config"""
 
-    MODEL_LOCATION_ENV_VAR = "MODEL_LOCATION"
     MODEL_COLLECTION_DIR_ENV_VAR = "MODEL_COLLECTION_DIR"
 
 

--- a/gordo_components/server/server.py
+++ b/gordo_components/server/server.py
@@ -122,6 +122,10 @@ def build_app(data_provider: typing.Optional[GordoBaseDataProvider] = None):
         response.headers["Server-Timing"] = f"request_walltime_s;dur={runtime_s}"
         return response
 
+    @app.route('/healthcheck')
+    def base_healthcheck():
+        return '', 200
+
     return app
 
 

--- a/gordo_components/server/server.py
+++ b/gordo_components/server/server.py
@@ -122,9 +122,9 @@ def build_app(data_provider: typing.Optional[GordoBaseDataProvider] = None):
         response.headers["Server-Timing"] = f"request_walltime_s;dur={runtime_s}"
         return response
 
-    @app.route('/healthcheck')
+    @app.route("/healthcheck")
     def base_healthcheck():
-        return '', 200
+        return "", 200
 
     return app
 

--- a/gordo_components/server/utils.py
+++ b/gordo_components/server/utils.py
@@ -352,7 +352,7 @@ def model_required(f):
     """
 
     @wraps(f)
-    def wrapper(*args: tuple, gordo_name: str, **kwargs: dict):
+    def wrapper(*args: tuple, gordo_project: str, gordo_name: str, **kwargs: dict):
         collection_dir = os.environ[current_app.config["MODEL_COLLECTION_DIR_ENV_VAR"]]
         model, metadata = load_model_n_metadata(
             directory=collection_dir, name=gordo_name

--- a/gordo_components/server/utils.py
+++ b/gordo_components/server/utils.py
@@ -6,7 +6,7 @@ import os
 import timeit
 import dateutil
 from datetime import datetime
-from typing import Union, List, Tuple
+from typing import Union, List
 
 import pandas as pd
 from flask import request, g, jsonify, make_response, Response, current_app

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -4,7 +4,7 @@ import logging
 import timeit
 import typing
 
-from flask import Blueprint, make_response, jsonify, current_app, g
+from flask import Blueprint, make_response, jsonify, g
 from flask_restplus import fields
 
 from gordo_components import __version__
@@ -15,7 +15,9 @@ from gordo_components.server import utils
 
 logger = logging.getLogger(__name__)
 
-anomaly_blueprint = Blueprint("ioc_anomaly_blueprint", __name__, url_prefix="/anomaly")
+anomaly_blueprint = Blueprint(
+    "ioc_anomaly_blueprint", __name__, url_prefix="/<gordo_name>/anomaly"
+)
 
 api = Api(
     app=anomaly_blueprint,
@@ -99,6 +101,7 @@ class AnomalyView(BaseModelView):
             "X": "Nested list of samples to predict, or single list considered as one sample"
         }
     )
+    @utils.model_required
     @utils.extract_X_y
     def post(self):
         start_time = timeit.default_timer()
@@ -111,6 +114,7 @@ class AnomalyView(BaseModelView):
             "end": "An ISO formatted datetime with timezone info string indicating prediction range end",
         }
     )
+    @utils.model_required
     @utils.extract_X_y
     def get(self):
         start_time = timeit.default_timer()
@@ -147,10 +151,10 @@ class AnomalyView(BaseModelView):
 
         # Now create an anomaly dataframe from the base response dataframe
         try:
-            anomaly_df = current_app.model.anomaly(g.X, g.y, frequency=self.frequency)
+            anomaly_df = g.model.anomaly(g.X, g.y, frequency=self.frequency)
         except AttributeError:
             msg = {
-                "message": f"Model is not an AnomalyDetector, it is of type: {type(current_app.model)}"
+                "message": f"Model is not an AnomalyDetector, it is of type: {type(g.model)}"
             }
             return make_response(jsonify(msg), 422)  # 422 Unprocessable Entity
 

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -15,9 +15,7 @@ from gordo_components.server import utils
 
 logger = logging.getLogger(__name__)
 
-anomaly_blueprint = Blueprint(
-    "ioc_anomaly_blueprint", __name__,
-)
+anomaly_blueprint = Blueprint("ioc_anomaly_blueprint", __name__)
 
 api = Api(
     app=anomaly_blueprint,
@@ -164,4 +162,6 @@ class AnomalyView(BaseModelView):
         return make_response(jsonify(context), context.pop("status-code", 200))
 
 
-api.add_resource(AnomalyView, "/gordo/v0/<gordo_project>/<gordo_name>/anomaly/prediction")
+api.add_resource(
+    AnomalyView, "/gordo/v0/<gordo_project>/<gordo_name>/anomaly/prediction"
+)

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -16,7 +16,7 @@ from gordo_components.server import utils
 logger = logging.getLogger(__name__)
 
 anomaly_blueprint = Blueprint(
-    "ioc_anomaly_blueprint", __name__, url_prefix="/<gordo_name>/anomaly"
+    "ioc_anomaly_blueprint", __name__,
 )
 
 api = Api(
@@ -164,4 +164,4 @@ class AnomalyView(BaseModelView):
         return make_response(jsonify(context), context.pop("status-code", 200))
 
 
-api.add_resource(AnomalyView, "/prediction")
+api.add_resource(AnomalyView, "/gordo/v0/<gordo_project>/<gordo_name>/anomaly/prediction")

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -213,7 +213,7 @@ class MetaDataView(Resource):
     Serve model / server metadata
     """
 
-    @server_utils.model_required
+    @server_utils.metadata_required
     def get(self):
         """
         Get metadata about this endpoint, also serves as /healthcheck endpoint

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -22,7 +22,7 @@ from gordo_components.server import model_io
 
 logger = logging.getLogger(__name__)
 
-base_blueprint = Blueprint("base_model_view", __name__, url_prefix="/<gordo_name>")
+base_blueprint = Blueprint("base_model_view", __name__)
 
 api = Api(
     app=base_blueprint,
@@ -251,6 +251,6 @@ class DownloadModel(Resource):
         return send_file(buff, attachment_filename="model.tar.gz")
 
 
-api.add_resource(BaseModelView, "/prediction")
-api.add_resource(MetaDataView, "/metadata", "/healthcheck")
-api.add_resource(DownloadModel, "/download-model")
+api.add_resource(BaseModelView, "/gordo/v0/<gordo_project>/<gordo_name>/prediction")
+api.add_resource(MetaDataView, "/gordo/v0/<gordo_project>/<gordo_name>/metadata", "/gordo/v0/<gordo_project>/<gordo_name>/healthcheck")
+api.add_resource(DownloadModel, "/gordo/v0/<gordo_project>/<gordo_name>/download-model")

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -218,11 +218,11 @@ class MetaDataView(Resource):
         """
         Get metadata about this endpoint, also serves as /healthcheck endpoint
         """
-        model_location_env_var = current_app.config["MODEL_LOCATION_ENV_VAR"]
+        model_collection_env_var = current_app.config["MODEL_COLLECTION_DIR_ENV_VAR"]
         return {
             "gordo-server-version": __version__,
             "metadata": g.metadata,
-            "env": {model_location_env_var: os.environ.get(model_location_env_var)},
+            "env": {model_collection_env_var: os.environ.get(model_collection_env_var)},
         }
 
 

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -252,5 +252,9 @@ class DownloadModel(Resource):
 
 
 api.add_resource(BaseModelView, "/gordo/v0/<gordo_project>/<gordo_name>/prediction")
-api.add_resource(MetaDataView, "/gordo/v0/<gordo_project>/<gordo_name>/metadata", "/gordo/v0/<gordo_project>/<gordo_name>/healthcheck")
+api.add_resource(
+    MetaDataView,
+    "/gordo/v0/<gordo_project>/<gordo_name>/metadata",
+    "/gordo/v0/<gordo_project>/<gordo_name>/healthcheck",
+)
 api.add_resource(DownloadModel, "/gordo/v0/<gordo_project>/<gordo_name>/download-model")

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 test             = pytest --addopts "-n auto -m 'not dockertest'"
 
 # Test _everything_
-testall          = pytest
+testall          = pytest --addopts "--ignore benchmarks"
 
 # Only run tests which use docker
 testdocker       = pytest --addopts "-m 'dockertest'"
@@ -36,6 +36,7 @@ testallelse     = pytest --addopts
     --ignore tests/gordo_components/server
     --ignore tests/gordo_components/util
     --ignore tests/gordo_components/watchman
-    --ignore tests/test_formatting.py"
+    --ignore tests/test_formatting.py
+    --ignore benchmarks"
 
 testbenchmarks   = pytest --addopts "--benchmark-only benchmarks/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,16 @@ def gordo_project():
 
 
 @pytest.fixture(scope="session")
+def api_version():
+    return "v0"
+
+
+@pytest.fixture(scope="session")
+def base_route(api_version, gordo_project, gordo_name):
+    return f"/gordo/{api_version}/{gordo_project}/{gordo_name}"
+
+
+@pytest.fixture(scope="session")
 def trained_model_directory(
     gordo_project: str, gordo_name: str, sensors: List[SensorTag]
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
+import os
 import logging
 import tempfile
 import time
@@ -54,12 +55,33 @@ def tmp_dir():
 
 
 @pytest.fixture(scope="session")
-def trained_model_directory(sensors: List[SensorTag]):
+def gordo_name():
+    # One gordo-target name
+    return tu.GORDO_TARGETS[0]
+
+
+@pytest.fixture(scope="session")
+def gordo_project():
+    return tu.GORDO_PROJECT
+
+
+@pytest.fixture(scope="session")
+def trained_model_directory(
+    gordo_project: str, gordo_name: str, sensors: List[SensorTag]
+):
     """
     Fixture: Train a basic AutoEncoder and save it to a given directory
     will also save some metadata with the model
     """
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.TemporaryDirectory() as model_dir:
+
+        # This is a model collection directory
+        collection_dir = os.path.join(model_dir, gordo_project)
+
+        # Model specific to the model being trained here
+        model_dir = os.path.join(collection_dir, gordo_name)
+        os.makedirs(model_dir, exist_ok=True)
+
         definition = ruamel.yaml.load(
             """
             gordo_components.model.anomaly.diff.DiffBasedAnomalyDetector:
@@ -78,7 +100,7 @@ def trained_model_directory(sensors: List[SensorTag]):
         model.fit(X, X)
         serializer.dump(
             model,
-            tmp_dir,
+            model_dir,
             metadata={
                 "dataset": {
                     "tag_list": sensors,
@@ -90,7 +112,7 @@ def trained_model_directory(sensors: List[SensorTag]):
                 "user-defined": {"model-name": "test-model"},
             },
         )
-        yield tmp_dir
+        yield collection_dir
 
 
 @pytest.fixture(
@@ -107,7 +129,7 @@ def trained_model_directory(sensors: List[SensorTag]):
 )
 def gordo_ml_server_client(request, trained_model_directory):
 
-    with tu.temp_env_vars(MODEL_LOCATION=trained_model_directory):
+    with tu.temp_env_vars(MODEL_COLLECTION_DIR=trained_model_directory):
 
         app = server.build_app(data_provider=request.param)
         app.testing = True

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -245,7 +245,13 @@ def test_client_cli_download_model(watchman_service):
 @pytest.mark.parametrize("output_dir", [tempfile.TemporaryDirectory(), None])
 @pytest.mark.parametrize("data_provider", [providers.RandomDataProvider(), None])
 def test_client_cli_predict(
-    influxdb, watchman_service, forwarder_args, output_dir, data_provider
+    influxdb,
+    gordo_name,
+    watchman_service,
+    forwarder_args,
+    output_dir,
+    data_provider,
+    trained_model_directory,
 ):
     """
     Test ability for client to get predictions via CLI

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -22,21 +22,23 @@ import tests.utils as tu
     ],
 )
 def test_anomaly_prediction_endpoint(
-    influxdb, gordo_ml_server_client, data_to_post, sensors
+    gordo_name, influxdb, gordo_ml_server_client, data_to_post, sensors
 ):
     """
     Anomaly GET and POST responses are the same
     """
     if data_to_post is None:
         resp = gordo_ml_server_client.get(
-            "/anomaly/prediction",
+            f"/{gordo_name}/anomaly/prediction",
             json={
                 "start": "2016-01-01T00:00:00+00:00",
                 "end": "2016-01-01T12:00:00+00:00",
             },
         )
     else:
-        resp = gordo_ml_server_client.post("/anomaly/prediction", json=data_to_post)
+        resp = gordo_ml_server_client.post(
+            f"/{gordo_name}/anomaly/prediction", json=data_to_post
+        )
 
     # From here, the response should be (pretty much) the same format from GET or POST
     assert resp.status_code == 200
@@ -62,23 +64,23 @@ def test_anomaly_prediction_endpoint(
     )
 
 
-def test_more_than_24_hrs(influxdb, gordo_ml_server_client):
+def test_more_than_24_hrs(gordo_name, influxdb, gordo_ml_server_client):
     # Request greater than 1 day should be a bad request
     resp = gordo_ml_server_client.get(
-        "/anomaly/prediction",
+        f"/{gordo_name}/anomaly/prediction",
         json={"start": "2016-01-01T00:00:00+00:00", "end": "2016-01-02T00:00:00+00:00"},
     )
     assert resp.status_code == 400, f"Response content: {resp.data}"
 
     # and for sanity, less than 1 day are ok
     resp = gordo_ml_server_client.get(
-        "/anomaly/prediction",
+        f"/{gordo_name}/anomaly/prediction",
         json={"start": "2016-01-01T00:00:00+00:00", "end": "2016-01-01T01:00:00+00:00"},
     )
     assert resp.status_code == 200, f"Response content: {resp.data}"
 
 
-def test_overlapping_time_buckets(influxdb, gordo_ml_server_client):
+def test_overlapping_time_buckets(gordo_name, influxdb, gordo_ml_server_client):
     """
     Requests for overlapping time sample buckets should only produce
     predictions whose bucket falls completely within the requested
@@ -90,7 +92,7 @@ def test_overlapping_time_buckets(influxdb, gordo_ml_server_client):
     but can give a bucket which contains data before the requested start date.
     """
     resp = gordo_ml_server_client.get(
-        "/anomaly/prediction",
+        f"/{gordo_name}/anomaly/prediction",
         json={"start": "2016-01-01T00:11:00+00:00", "end": "2016-01-01T00:21:00+00:00"},
     )
     assert resp.status_code == 200

--- a/tests/gordo_components/server/test_base_view.py
+++ b/tests/gordo_components/server/test_base_view.py
@@ -35,12 +35,13 @@ import tests.utils as tu
         },
     ],
 )
-def test_prediction_endpoint_post_ok(sensors, gordo_ml_server_client, data_to_post):
+def test_prediction_endpoint_post_ok(
+    gordo_name, sensors, gordo_ml_server_client, data_to_post
+):
     """
     Test the expected successfull data posts
     """
-    resp = gordo_ml_server_client.post("/prediction", json=data_to_post)
-
+    resp = gordo_ml_server_client.post(f"/{gordo_name}/prediction", json=data_to_post)
     assert resp.status_code == 200
 
     data = server_utils.dataframe_from_dict(resp.json["data"])
@@ -58,11 +59,13 @@ def test_prediction_endpoint_post_ok(sensors, gordo_ml_server_client, data_to_po
     ],
 )
 def test_prediction_endpoint_post_fail(
-    caplog, sensors, gordo_ml_server_client, data_to_post
+    caplog, gordo_name, sensors, gordo_ml_server_client, data_to_post
 ):
     """
     Test expected failures when posting certain types of data
     """
     with caplog.at_level(logging.CRITICAL):
-        resp = gordo_ml_server_client.post("/prediction", json=data_to_post)
+        resp = gordo_ml_server_client.post(
+            f"/{gordo_name}/prediction", json=data_to_post
+        )
     assert resp.status_code == 400

--- a/tests/gordo_components/server/test_base_view.py
+++ b/tests/gordo_components/server/test_base_view.py
@@ -36,12 +36,12 @@ import tests.utils as tu
     ],
 )
 def test_prediction_endpoint_post_ok(
-    gordo_name, sensors, gordo_ml_server_client, data_to_post
+    base_route, sensors, gordo_ml_server_client, data_to_post
 ):
     """
     Test the expected successfull data posts
     """
-    resp = gordo_ml_server_client.post(f"/{gordo_name}/prediction", json=data_to_post)
+    resp = gordo_ml_server_client.post(f"{base_route}/prediction", json=data_to_post)
     assert resp.status_code == 200
 
     data = server_utils.dataframe_from_dict(resp.json["data"])
@@ -59,13 +59,13 @@ def test_prediction_endpoint_post_ok(
     ],
 )
 def test_prediction_endpoint_post_fail(
-    caplog, gordo_name, sensors, gordo_ml_server_client, data_to_post
+    caplog, base_route, sensors, gordo_ml_server_client, data_to_post
 ):
     """
     Test expected failures when posting certain types of data
     """
     with caplog.at_level(logging.CRITICAL):
         resp = gordo_ml_server_client.post(
-            f"/{gordo_name}/prediction", json=data_to_post
+            f"{base_route}/prediction", json=data_to_post
         )
     assert resp.status_code == 400

--- a/tests/gordo_components/server/test_gordo_server.py
+++ b/tests/gordo_components/server/test_gordo_server.py
@@ -12,11 +12,11 @@ from tests import utils as tu
 logger = logging.getLogger(__name__)
 
 
-def test_healthcheck_endpoint(gordo_ml_server_client):
+def test_healthcheck_endpoint(gordo_name, gordo_ml_server_client):
     """
-    Test expected behavior of /healthcheck
+    Test expected behavior of /<gordo-name>/healthcheck
     """
-    resp = gordo_ml_server_client.get("/healthcheck")
+    resp = gordo_ml_server_client.get(f"/{gordo_name}/healthcheck")
     assert resp.status_code == 200
 
     data = resp.get_json()
@@ -24,21 +24,21 @@ def test_healthcheck_endpoint(gordo_ml_server_client):
     assert "gordo-server-version" in data
 
 
-def test_response_header_timing(gordo_ml_server_client):
+def test_response_header_timing(gordo_name, gordo_ml_server_client):
     """
     Test that the response contains a `Server-Timing` header
     """
-    resp = gordo_ml_server_client.get("/healthcheck")
+    resp = gordo_ml_server_client.get(f"/{gordo_name}/healthcheck")
     assert resp.status_code == 200
     assert "Server-Timing" in resp.headers
     assert "request_walltime_s" in resp.headers["Server-Timing"]
 
 
-def test_metadata_endpoint(gordo_ml_server_client):
+def test_metadata_endpoint(gordo_name, gordo_ml_server_client):
     """
     Test the expected behavior of /metadata
     """
-    resp = gordo_ml_server_client.get("/metadata")
+    resp = gordo_ml_server_client.get(f"/{gordo_name}/metadata")
     assert resp.status_code == 200
 
     data = resp.get_json()
@@ -46,11 +46,11 @@ def test_metadata_endpoint(gordo_ml_server_client):
     assert data["metadata"]["user-defined"]["model-name"] == "test-model"
 
 
-def test_download_model(gordo_ml_server_client):
+def test_download_model(gordo_name, gordo_ml_server_client):
     """
     Test we can download a model, loadable via serializer.loads()
     """
-    resp = gordo_ml_server_client.get("/download-model")
+    resp = gordo_ml_server_client.get(f"/{gordo_name}/download-model")
 
     serialized_model = resp.get_data()
     model = serializer.loads(serialized_model)

--- a/tests/gordo_components/server/test_gordo_server.py
+++ b/tests/gordo_components/server/test_gordo_server.py
@@ -12,11 +12,15 @@ from tests import utils as tu
 logger = logging.getLogger(__name__)
 
 
-def test_healthcheck_endpoint(gordo_name, gordo_ml_server_client):
+def test_healthcheck_endpoint(base_route, gordo_ml_server_client):
     """
     Test expected behavior of /<gordo-name>/healthcheck
     """
-    resp = gordo_ml_server_client.get(f"/{gordo_name}/healthcheck")
+    # Should also be at the very lowest level as well.
+    resp = gordo_ml_server_client.get(f"/healthcheck")
+    assert resp.status_code == 200
+
+    resp = gordo_ml_server_client.get(f"{base_route}/healthcheck")
     assert resp.status_code == 200
 
     data = resp.get_json()
@@ -24,21 +28,21 @@ def test_healthcheck_endpoint(gordo_name, gordo_ml_server_client):
     assert "gordo-server-version" in data
 
 
-def test_response_header_timing(gordo_name, gordo_ml_server_client):
+def test_response_header_timing(base_route, gordo_ml_server_client):
     """
     Test that the response contains a `Server-Timing` header
     """
-    resp = gordo_ml_server_client.get(f"/{gordo_name}/healthcheck")
+    resp = gordo_ml_server_client.get(f"{base_route}/healthcheck")
     assert resp.status_code == 200
     assert "Server-Timing" in resp.headers
     assert "request_walltime_s" in resp.headers["Server-Timing"]
 
 
-def test_metadata_endpoint(gordo_name, gordo_ml_server_client):
+def test_metadata_endpoint(base_route, gordo_ml_server_client):
     """
     Test the expected behavior of /metadata
     """
-    resp = gordo_ml_server_client.get(f"/{gordo_name}/metadata")
+    resp = gordo_ml_server_client.get(f"{base_route}/metadata")
     assert resp.status_code == 200
 
     data = resp.get_json()
@@ -46,11 +50,11 @@ def test_metadata_endpoint(gordo_name, gordo_ml_server_client):
     assert data["metadata"]["user-defined"]["model-name"] == "test-model"
 
 
-def test_download_model(gordo_name, gordo_ml_server_client):
+def test_download_model(base_route, gordo_ml_server_client):
     """
     Test we can download a model, loadable via serializer.loads()
     """
-    resp = gordo_ml_server_client.get(f"/{gordo_name}/download-model")
+    resp = gordo_ml_server_client.get(f"{base_route}/download-model")
 
     serialized_model = resp.get_data()
     model = serializer.loads(serialized_model)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -134,26 +134,17 @@ def watchman(
             """
             headers = {}
 
-            # last_path is the path to the view as flask knows about it
-            # there is a proxy set before endpoints such as /gordo/vo/project-name/target-name/
-            # of which flask does not know about, but is routed to it via ambassador and is
-            # incorporated in the requests within the lib, since we're forwarding the request
-            # directly to the app itself, we need to strip this prefix
-            # Example:
-            # /gordo/v0/project-name/target-name/metadata -> metadata
-            last_path = "/".join(request.path_url.split("/")[4:])
-
             if request.method == "GET":
                 # we may have json data being passed
                 kwargs = dict()
                 if request.body:
                     kwargs["json"] = json.loads(request.body.decode())
 
-                resp = gordo_server_app.get(f"/{last_path}", **kwargs)
+                resp = gordo_server_app.get(request.path_url, **kwargs)
                 resp = resp.json or resp.data
             elif request.method == "POST":
                 resp = gordo_server_app.post(
-                    f"/{last_path}", json=json.loads(request.body.decode())
+                    request.path_url, json=json.loads(request.body.decode())
                 ).json
             else:
                 raise NotImplementedError(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -118,7 +118,7 @@ def watchman(
     from gordo_components.dataset import datasets
     from gordo_components.server import server as gordo_ml_server
 
-    with temp_env_vars(MODEL_LOCATION=model_location):
+    with temp_env_vars(MODEL_COLLECTION_DIR=model_location):
         # Create gordo ml servers
         gordo_server_app = gordo_ml_server.build_app(
             data_provider=datasets.RandomDataProvider()
@@ -141,7 +141,8 @@ def watchman(
             # directly to the app itself, we need to strip this prefix
             # Example:
             # /gordo/v0/project-name/target-name/metadata -> metadata
-            last_path = "/".join(request.path_url.split("/")[5:])
+            last_path = "/".join(request.path_url.split("/")[4:])
+
             if request.method == "GET":
                 # we may have json data being passed
                 kwargs = dict()


### PR DESCRIPTION
Will closes #453 

Problem :pill: 
---
Scaling to thousands of models will be quite taxing to have all those loaded models served by individual servers.

Solution/Approach :milk_glass: 
---
Will take the gordo-name as a parameter of the url to load the model by request.
ie. `/gordo/v0/gordo-project/gordo-name/predict` would load the model 'gordo-name' and process the request.

Depends on :cow:
---
- https://github.com/equinor/gordo-infrastructure/pull/389