### PR TITLE
Use CNTK for tests, and workflow models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,11 @@ version: 2.1
 executors:
   python-executor:
     working_directory: ~/code
+    environment:
+      KERAS_BACKEND: cntk
     machine:
       docker_layer_caching: true
-      image: "circleci/classic:201808-01"
+      image: "ubuntu-1604:201903-01"
 
 commands:
   save-eggs-cache:
@@ -45,6 +47,13 @@ commands:
       - checkout
       - restore-venv-cache
       - restore-eggs-cache
+      - run:
+          name: Install CNTK
+          command: |
+            sudo killall -9 apt-get || true
+            sudo add-apt-repository ppa:deadsnakes/ppa
+            sudo apt-get update
+            sudo apt-get install -y python3.6-dev openmpi-bin
       - run:
           name: Test
           command: |

--- a/Dockerfile-ModelBuilder
+++ b/Dockerfile-ModelBuilder
@@ -10,7 +10,19 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
-FROM python:3.6.9-slim-stretch
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+  apt-get install -y software-properties-common && \
+  add-apt-repository ppa:jonathonf/python-3.6
+RUN apt-get update
+
+RUN apt-get install -y build-essential python3.6 python3-pip python3.6-dev
+
+# update pip
+RUN ln -s $(which python3.6) /usr/bin/python
+RUN python -m pip install pip --upgrade
+RUN python -m pip install wheel
 
 # Install requirements separately for improved docker caching
 COPY requirements.txt /code/
@@ -21,6 +33,13 @@ COPY --from=builder /code/dist/gordo-components-packed.tar.gz .
 
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 RUN pip install ./gordo-components-packed.tar.gz
+
+# Setup CNTK
+RUN apt install openmpi-bin -y
+RUN pip install cntk
+ENV KERAS_BACKEND=cntk
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 ADD build.sh /code/build.sh
 

--- a/Dockerfile-ModelServer
+++ b/Dockerfile-ModelServer
@@ -10,7 +10,19 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
-FROM python:3.6.9-slim-stretch
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+  apt-get install -y software-properties-common && \
+  add-apt-repository ppa:jonathonf/python-3.6
+RUN apt-get update
+
+RUN apt-get install -y build-essential python3.6 python3-pip python3.6-dev
+
+# update pip
+RUN ln -s $(which python3.6) /usr/bin/python
+RUN python -m pip install pip --upgrade
+RUN python -m pip install wheel
 
 # Install requirements separately for improved docker caching
 COPY requirements.txt /code/
@@ -21,5 +33,12 @@ COPY --from=builder /code/dist/gordo-components-packed.tar.gz .
 
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 RUN pip install ./gordo-components-packed.tar.gz
+
+# Setup CNTK
+RUN apt install openmpi-bin -y
+RUN pip install cntk
+ENV KERAS_BACKEND=cntk
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 CMD ["gordo-components", "run-server", "--host", "0.0.0.0", "--port", "5555"]

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -7,10 +7,8 @@ from typing import Union, Callable, Dict, Any, Optional
 from os import path
 import pickle
 from abc import ABCMeta
-from contextlib import contextmanager
 
 import keras.models
-import keras.backend as K
 from keras.preprocessing.sequence import pad_sequences, TimeseriesGenerator
 from keras.wrappers.scikit_learn import BaseWrapper
 from keras.models import load_model
@@ -29,33 +27,6 @@ from gordo_components.model.register import register_model_builder
 
 
 logger = logging.getLogger(__name__)
-
-
-@contextmanager
-def possible_tf_mgmt(keras_model):
-    """
-    Decorator - When serving a Keras model backed by tensorflow, the object is expected
-    to have ``_tf_graph`` and ``_tf_session`` stored attrs. Which will be used as the
-    default when calling the Keras model
-
-    Notes
-    -----
-    Should only be needed by those developing new Keras models wrapped to behave like
-    Scikit-Learn Esitmators
-
-    Parameters
-    ----------
-    keras_model: KerasBaseEstimator
-        An instance of a `KerasBaseEstimator` which can potentially have a tensorflow
-        backend
-    """
-    logger.info(f"Keras backend: {K.backend()}")
-    if K.backend() == "tensorflow":
-        logger.debug(f"Using keras_model {keras_model} local TF Graph and Session")
-        with keras_model._tf_graph.as_default(), keras_model._tf_session.as_default():
-            yield
-    else:
-        yield
 
 
 class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
@@ -84,17 +55,6 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
             building function and/or any additional args to be passed
             to Keras' fit() method
         """
-        # Tensorflow requires managed graph/session as to not default to global
-        if K.backend() == "tensorflow":
-            logger.info(f"Keras backend detected as tensorflow, keeping local graph")
-            import tensorflow as tf
-
-            self._tf_graph = tf.Graph()
-            self._tf_session = tf.Session(graph=self._tf_graph)
-        else:
-            logger.info(f"Keras backend detected as NOT tensorflow, but: {K.backend()}")
-            self._tf_session = None
-            self._tf_graph = None
 
         self.build_fn = None
         self.kwargs = kwargs
@@ -149,8 +109,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         # for LSTM based models
         if len(X.shape) == 3:
             self.kwargs.update({"n_features": X.shape[2]})
-        with possible_tf_mgmt(self):
-            super().fit(X, y, sample_weight=None, **kwargs)
+        super().fit(X, y, sample_weight=None, **kwargs)
         return self
 
     def predict(self, X: np.ndarray, **kwargs) -> np.ndarray:
@@ -169,8 +128,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         results:
             np.ndarray
         """
-        with possible_tf_mgmt(self):
-            return self.model.predict(X, **kwargs)
+        return self.model.predict(X, **kwargs)
 
     def get_params(self, **params):
         """
@@ -194,20 +152,18 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
 
     def __call__(self):
         build_fn = register_model_builder.factories[self.__class__.__name__][self.kind]
-        with possible_tf_mgmt(self):
-            return build_fn(**self.sk_params)
+        return build_fn(**self.sk_params)
 
     def save_to_dir(self, directory: str):
         params = self.get_params()
         with open(path.join(directory, "params.json"), "w") as f:
             json.dump(params, f)
         if hasattr(self, "model") and self.model is not None:
-            with possible_tf_mgmt(self):
-                self.model.save(path.join(directory, "model.h5"))
-                if hasattr(self.model, "history") and self.model.history is not None:
-                    f_name = path.join(directory, "history.pkl")
-                    with open(f_name, "wb") as history_file:
-                        pickle.dump(self.model.history, history_file)
+            self.model.save(path.join(directory, "model.h5"))
+            if hasattr(self.model, "history") and self.model.history is not None:
+                f_name = path.join(directory, "history.pkl")
+                with open(f_name, "wb") as history_file:
+                    pickle.dump(self.model.history, history_file)
 
     @classmethod
     def load_from_dir(cls, directory: str):
@@ -229,13 +185,11 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         obj = cls(**params)
         model_file = path.join(directory, "model.h5")
         if path.isfile(model_file):
-            with possible_tf_mgmt(obj):
-                K.set_learning_phase(0)
-                obj.model = load_model(model_file)
-                history_file = path.join(directory, "history.pkl")
-                if path.isfile(history_file):
-                    with open(history_file, "rb") as hist_f:
-                        obj.model.history = pickle.load(hist_f)
+            obj.model = load_model(model_file)
+            history_file = path.join(directory, "history.pkl")
+            if path.isfile(history_file):
+                with open(history_file, "rb") as hist_f:
+                    obj.model.history = pickle.load(hist_f)
 
         return obj
 
@@ -298,8 +252,7 @@ class KerasAutoEncoder(KerasBaseEstimator, TransformerMixin):
                 f"This {self.__class__.__name__} has not been fitted yet."
             )
 
-        with possible_tf_mgmt(self):
-            out = self.model.predict(X)
+        out = self.model.predict(X)
 
         return explained_variance_score(y, out)
 
@@ -436,10 +389,9 @@ class KerasLSTMAutoEncoder(KerasLSTMBaseEstimator):
             for k, v in {**self.kwargs, **kwargs}.items()
             if k in self.fit_generator_params
         }
-        with possible_tf_mgmt(self):
-            # shuffle is set to False since we are dealing with time series data and
-            # so training data will not be shuffled before each epoch.
-            self.model.fit_generator(tsg, shuffle=False, **gen_kwargs)
+        # shuffle is set to False since we are dealing with time series data and
+        # so training data will not be shuffled before each epoch.
+        self.model.fit_generator(tsg, shuffle=False, **gen_kwargs)
         return self
 
     def predict(self, X: np.ndarray, **kwargs) -> np.ndarray:
@@ -465,19 +417,8 @@ class KerasLSTMAutoEncoder(KerasLSTMBaseEstimator):
         Example
         -------
         >>> import numpy as np
-        >>> import tensorflow as tf
-        >>> import random as rn
-        >>> from keras import backend as K
         >>> from gordo_components.model.factories.lstm_autoencoder import lstm_model
         >>> from gordo_components.model.models import KerasLSTMAutoEncoder
-        >>> #Setting seeds to get reproducible results
-        >>> session_conf = tf.ConfigProto(intra_op_parallelism_threads=1,
-        ...                               inter_op_parallelism_threads=1)
-        >>> sess = tf.Session(graph=tf.get_default_graph(), config=session_conf)
-        >>> K.set_session(sess)
-        >>> np.random.seed(42)
-        >>> rn.seed(12345)
-        >>> tf.set_random_seed(1234)
         >>> #Define train/test data
         >>> X_train = np.array([[1, 1], [2, 3], [0.5, 0.6], [0.3, 1], [0.6, 0.7]])
         >>> X_test = np.array([[2, 3], [1, 1], [0.1, 1], [0.5, 2]])
@@ -503,8 +444,7 @@ class KerasLSTMAutoEncoder(KerasLSTMBaseEstimator):
             lookback_window=self.lookback_window,
             lookahead=0,
         )
-        with possible_tf_mgmt(self):
-            return self.model.predict_generator(tsg, **kwargs)
+        return self.model.predict_generator(tsg, **kwargs)
 
     def score(
         self,
@@ -625,10 +565,9 @@ class KerasLSTMForecast(KerasLSTMBaseEstimator):
             if k in self.fit_generator_params
         }
 
-        with possible_tf_mgmt(self):
-            # shuffle is set to False since we are dealing with time series data and
-            # so training data will not be shuffled before each epoch.
-            self.model.fit_generator(tsg, shuffle=False, **gen_kwargs)
+        # shuffle is set to False since we are dealing with time series data and
+        # so training data will not be shuffled before each epoch.
+        self.model.fit_generator(tsg, shuffle=False, **gen_kwargs)
         return self
 
     def predict(self, X: np.ndarray, **kwargs) -> np.ndarray:
@@ -652,19 +591,8 @@ class KerasLSTMForecast(KerasLSTMBaseEstimator):
         Example
         -------
         >>> import numpy as np
-        >>> import tensorflow as tf
-        >>> import random as rn
-        >>> from keras import backend as K
         >>> from gordo_components.model.factories.lstm_autoencoder import lstm_model
         >>> from gordo_components.model.models import KerasLSTMForecast
-        >>> #Setting seeds to get reproducible results
-        >>> session_conf = tf.ConfigProto(intra_op_parallelism_threads=1,
-        ...                               inter_op_parallelism_threads=1)
-        >>> sess = tf.Session(graph=tf.get_default_graph(), config=session_conf)
-        >>> K.set_session(sess)
-        >>> np.random.seed(42)
-        >>> rn.seed(12345)
-        >>> tf.set_random_seed(1234)
         >>> #Define train/test data
         >>> X_train = np.array([[1, 1], [2, 3], [0.5, 0.6], [0.3, 1], [0.6, 0.7]])
         >>> X_test = np.array([[2, 3], [1, 1], [0.1, 1], [0.5, 2]])
@@ -687,8 +615,7 @@ class KerasLSTMForecast(KerasLSTMBaseEstimator):
             lookback_window=self.lookback_window,
             lookahead=1,
         )
-        with possible_tf_mgmt(self):
-            return self.model.predict_generator(tsg)
+        return self.model.predict_generator(tsg)
 
     def score(
         self,

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 apscheduler~=3.6
 Click~=7.0
+cntk~=2.7
 cachetools~=3.1
 h5py~=2.8
 influxdb~=5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ certifi==2019.6.16        # via kubernetes, requests
 cffi==1.12.3              # via azure-datalake-store, cryptography, pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.0
+cntk==2.7
 coverage==4.5.4
 cryptography==2.7         # via adal
 flask-restplus==0.13.0
@@ -63,7 +64,7 @@ requests-oauthlib==1.2.0  # via kubernetes
 requests==2.22.0
 rsa==4.0                  # via google-auth
 scikit-learn==0.21.3
-scipy==1.3.1              # via keras, scikit-learn
+scipy==1.3.1              # via cntk, keras, scikit-learn
 simplejson==3.16.0
 six==1.12.0               # via absl-py, apscheduler, cryptography, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras, keras-preprocessing, kubernetes, pip-tools, protobuf, pyrsistent, python-dateutil, tensorboard, tensorflow, websocket-client
 tensorboard==1.14.0       # via tensorflow


### PR DESCRIPTION
Problem :timer_clock: 
---
It takes _forever_ to test the `module` component, and now that we are serving models from a single (albeit HPA) server, the LSTMs and Keras models in general, when using tensorflow backend takes  a very long time to respond.

Solution :checkered_flag: 
---
Trial using CNTK