### PR TITLE
Optionally use parquet format in client and server

### DIFF
--- a/gordo_components/cli/client.py
+++ b/gordo_components/cli/client.py
@@ -93,7 +93,7 @@ def client(ctx: click.Context, *args, **kwargs):
 )
 @click.option(
     "--compress/--no-compress",
-    help="Use pyarrow serialization when sending and receiving data from server",
+    help="Use arrow/parquet serialization when sending and receiving data from server",
     default=True,
 )
 @click.pass_context
@@ -120,7 +120,7 @@ def predict(
             "forward_resampled_sensors": forward_resampled_sensors,
             "ignore_unhealthy_targets": ignore_unhealthy_targets,
             "n_retries": n_retries,
-            "use_pyarrow": compress,
+            "use_arrow": compress,
         }
     )
 

--- a/gordo_components/cli/client.py
+++ b/gordo_components/cli/client.py
@@ -91,6 +91,11 @@ def client(ctx: click.Context, *args, **kwargs):
     type=int,
     default=5,
 )
+@click.option(
+    "--compress/--no-compress",
+    help="Use pyarrow serialization when sending and receiving data from server",
+    default=True,
+)
 @click.pass_context
 def predict(
     ctx: click.Context,
@@ -104,6 +109,7 @@ def predict(
     forward_resampled_sensors: bool,
     ignore_unhealthy_targets: bool,
     n_retries: int,
+    compress: bool,
 ):
     """
     Run some predictions against the target
@@ -114,6 +120,7 @@ def predict(
             "forward_resampled_sensors": forward_resampled_sensors,
             "ignore_unhealthy_targets": ignore_unhealthy_targets,
             "n_retries": n_retries,
+            "use_pyarrow": compress,
         }
     )
 

--- a/gordo_components/cli/client.py
+++ b/gordo_components/cli/client.py
@@ -92,8 +92,8 @@ def client(ctx: click.Context, *args, **kwargs):
     default=5,
 )
 @click.option(
-    "--compress/--no-compress",
-    help="Use arrow/parquet serialization when sending and receiving data from server",
+    "--parquet/--no-parquet",
+    help="Use parquet serialization when sending and receiving data from server",
     default=True,
 )
 @click.pass_context
@@ -109,7 +109,7 @@ def predict(
     forward_resampled_sensors: bool,
     ignore_unhealthy_targets: bool,
     n_retries: int,
-    compress: bool,
+    parquet: bool,
 ):
     """
     Run some predictions against the target
@@ -120,7 +120,7 @@ def predict(
             "forward_resampled_sensors": forward_resampled_sensors,
             "ignore_unhealthy_targets": ignore_unhealthy_targets,
             "n_retries": n_retries,
-            "use_arrow": compress,
+            "use_parquet": parquet,
         }
     )
 

--- a/gordo_components/client/forwarders.py
+++ b/gordo_components/client/forwarders.py
@@ -151,6 +151,9 @@ class ForwardPredictionsIntoInflux(PredictionForwarder):
             # this is a 'regular' non-stacked column dataframe
             sub_df = predictions[top_lvl_name]
 
+            if isinstance(sub_df, pd.Series):
+                sub_df = pd.DataFrame(sub_df)
+
             # Set the sub df's column names equal to the name of the tags if
             # they match the length of the tag list.
             if len(sub_df.columns) == len(endpoint.tag_list):

--- a/gordo_components/client/io.py
+++ b/gordo_components/client/io.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Optional
+from typing import Optional, Union
 
 import aiohttp
 from werkzeug.exceptions import BadRequest
@@ -16,7 +16,7 @@ class HttpUnprocessableEntity(BaseException):
     pass
 
 
-async def fetch_json(
+async def get(
     url: str, *args, session: Optional[aiohttp.ClientSession] = None, **kwargs
 ) -> dict:
     """
@@ -35,18 +35,18 @@ async def fetch_json(
         The JSON response from the endpoint
     """
 
-    async def fetch(session):
+    async def _get(session):
         async with session.get(url, *args, **kwargs) as resp:  # type: ignore
-            return await _handle_json(resp)
+            return await _handle_response(resp)
 
     if session is None:  # We have to create a session which will be closed
         async with aiohttp.ClientSession() as session:
-            return await fetch(session)
+            return await _get(session)
     else:
-        return await fetch(session)
+        return await _get(session)
 
 
-async def post_json(
+async def post(
     url: str, *args, session: Optional[aiohttp.ClientSession] = None, **kwargs
 ) -> dict:
     """
@@ -65,20 +65,24 @@ async def post_json(
         The JSON response from the endpoint
     """
 
-    async def post(session):
+    async def _post(session):
         async with session.post(url, *args, **kwargs) as resp:
-            return await _handle_json(resp)
+            return await _handle_response(resp)
 
     if session is None:  # We have to create a session which will be closed
         async with aiohttp.ClientSession() as session:
-            return await post(session)
+            return await _post(session)
     else:
-        return await post(session)
+        return await _post(session)
 
 
-async def _handle_json(resp: aiohttp.ClientResponse) -> dict:
+async def _handle_response(resp: aiohttp.ClientResponse) -> Union[dict, bytes]:
     if 200 <= resp.status <= 299:
-        return await resp.json()
+        if resp.content_type == "application/json":
+            return await resp.json()  # Opt to return JSON
+        else:
+            return await resp.content.read()  # Fall back: return the raw bytes
+
     else:
         content = await resp.content.read()
         msg = f"Failed to get JSON with status code: {resp.status}: {content}"

--- a/gordo_components/client/io.py
+++ b/gordo_components/client/io.py
@@ -82,7 +82,7 @@ async def _handle_response(resp: aiohttp.ClientResponse) -> Union[dict, bytes]:
         return await (resp.json() if is_json else resp.content.read())
     else:
         content = await resp.content.read()
-        msg = f"Failed to get JSON with status code: {resp.status}: {content}"
+        msg = f"Failed to get response with status code: {resp.status}: {content}"
         if resp.status == 422:
             raise HttpUnprocessableEntity()
         elif 400 <= resp.status <= 499:

--- a/gordo_components/client/io.py
+++ b/gordo_components/client/io.py
@@ -78,15 +78,11 @@ async def post(
 
 async def _handle_response(resp: aiohttp.ClientResponse) -> Union[dict, bytes]:
     if 200 <= resp.status <= 299:
-        if resp.content_type == "application/json":
-            return await resp.json()  # Opt to return JSON
-        else:
-            return await resp.content.read()  # Fall back: return the raw bytes
-
+        is_json = resp.content_type == "application/json"
+        return await (resp.json() if is_json else resp.content.read())
     else:
         content = await resp.content.read()
         msg = f"Failed to get JSON with status code: {resp.status}: {content}"
-
         if resp.status == 422:
             raise HttpUnprocessableEntity()
         elif 400 <= resp.status <= 499:

--- a/gordo_components/server/utils.py
+++ b/gordo_components/server/utils.py
@@ -283,14 +283,14 @@ def extract_X_y(method):
 
             # Convert X and (maybe) y into dataframes.
             if isinstance(X, FileStorage):
-                X = pa.deserialize_pandas(X.read())
+                X = dataframe_from_parquet_bytes(X.read())
             else:
                 X = dataframe_from_dict(X)
             X = _verify_dataframe(X, [t.name for t in self.tags])
 
             # Y is ok to be None for BaseView, view(s) like Anomaly might require it.
             if isinstance(y, FileStorage):
-                y = pa.deserialize_pandas(y.read())
+                y = dataframe_from_parquet_bytes(y.read())
             elif any(isinstance(y, Class) for Class in (dict, list)):
                 y = dataframe_from_dict(y)
 

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -158,7 +158,7 @@ class AnomalyView(BaseModelView):
             }
             return make_response(jsonify(msg), 422)  # 422 Unprocessable Entity
 
-        if request.args.get("format") == "pyarrow":
+        if request.args.get("format") == "arrow":
             return send_file(
                 io.BytesIO(pa.serialize_pandas(anomaly_df).to_pybytes()),
                 mimetype="application/octet-stream",

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import io
 import logging
 import timeit
 import typing
 
-from flask import Blueprint, make_response, jsonify, g
+import pyarrow as pa
+from flask import Blueprint, make_response, jsonify, g, request, send_file
 from flask_restplus import fields
 
 from gordo_components import __version__
@@ -156,10 +158,16 @@ class AnomalyView(BaseModelView):
             }
             return make_response(jsonify(msg), 422)  # 422 Unprocessable Entity
 
-        context: typing.Dict[typing.Any, typing.Any] = dict()
-        context["data"] = utils.dataframe_to_dict(anomaly_df)
-        context["time-seconds"] = f"{timeit.default_timer() - start_time:.4f}"
-        return make_response(jsonify(context), context.pop("status-code", 200))
+        if request.args.get("format") == "pyarrow":
+            return send_file(
+                io.BytesIO(pa.serialize_pandas(anomaly_df).to_pybytes()),
+                mimetype="application/octet-stream",
+            )
+        else:
+            context: typing.Dict[typing.Any, typing.Any] = dict()
+            context["data"] = utils.dataframe_to_dict(anomaly_df)
+            context["time-seconds"] = f"{timeit.default_timer() - start_time:.4f}"
+            return make_response(jsonify(context), context.pop("status-code", 200))
 
 
 api.add_resource(

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -5,7 +5,6 @@ import logging
 import timeit
 import typing
 
-import pyarrow as pa
 from flask import Blueprint, make_response, jsonify, g, request, send_file
 from flask_restplus import fields
 
@@ -158,9 +157,9 @@ class AnomalyView(BaseModelView):
             }
             return make_response(jsonify(msg), 422)  # 422 Unprocessable Entity
 
-        if request.args.get("format") == "arrow":
+        if request.args.get("format") == "parquet":
             return send_file(
-                io.BytesIO(pa.serialize_pandas(anomaly_df).to_pybytes()),
+                io.BytesIO(utils.dataframe_into_parquet_bytes(anomaly_df)),
                 mimetype="application/octet-stream",
             )
         else:

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -205,7 +205,7 @@ class BaseModelView(Resource):
                 target_tag_list=self.target_tags,
                 index=X.index,
             )
-            if request.args.get("format") == "pyarrow":
+            if request.args.get("format") == "arrow":
                 return send_file(
                     io.BytesIO(pa.serialize_pandas(data).to_pybytes()),
                     mimetype="application/octet-stream",

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -8,8 +8,9 @@ import timeit
 import typing
 
 import pandas as pd
+import pyarrow as pa
 
-from flask import Blueprint, current_app, g, send_file, make_response, jsonify
+from flask import Blueprint, current_app, g, send_file, make_response, jsonify, request
 from flask_restplus import Resource, fields
 
 from gordo_components import __version__, serializer
@@ -204,8 +205,16 @@ class BaseModelView(Resource):
                 target_tag_list=self.target_tags,
                 index=X.index,
             )
-            context["data"] = server_utils.dataframe_to_dict(data)
-            return make_response((jsonify(context), context.pop("status-code", 200)))
+            if request.args.get("format") == "pyarrow":
+                return send_file(
+                    io.BytesIO(pa.serialize_pandas(data).to_pybytes()),
+                    mimetype="application/octet-stream",
+                )
+            else:
+                context["data"] = server_utils.dataframe_to_dict(data)
+                return make_response(
+                    (jsonify(context), context.pop("status-code", 200))
+                )
 
 
 class MetaDataView(Resource):

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -8,7 +8,6 @@ import timeit
 import typing
 
 import pandas as pd
-import pyarrow as pa
 
 from flask import Blueprint, current_app, g, send_file, make_response, jsonify, request
 from flask_restplus import Resource, fields
@@ -205,9 +204,9 @@ class BaseModelView(Resource):
                 target_tag_list=self.target_tags,
                 index=X.index,
             )
-            if request.args.get("format") == "arrow":
+            if request.args.get("format") == "parquet":
                 return send_file(
-                    io.BytesIO(pa.serialize_pandas(data).to_pybytes()),
+                    io.BytesIO(server_utils.dataframe_into_parquet_bytes(data)),
                     mimetype="application/octet-stream",
                 )
             else:

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ influxdb~=5.2
 jinja2~=2.10
 joblib~=0.13
 Keras~=2.2
+pyarrow~=0.14
 numpy~=1.15
 pandas~=0.24
 numexpr>=2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ oauthlib==3.1.0           # via requests-oauthlib
 pandas==0.25.1
 pip-tools==3.9.0
 protobuf==3.9.1
+pyarrow==0.14.1
 pyasn1-modules==0.2.6     # via google-auth
 pyasn1==0.4.7             # via pyasn1-modules, rsa
 pycares==3.0.0            # via aiodns
@@ -65,7 +66,7 @@ rsa==4.0                  # via google-auth
 scikit-learn==0.21.3
 scipy==1.3.1              # via keras, scikit-learn
 simplejson==3.16.0
-six==1.12.0               # via absl-py, apscheduler, cryptography, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras, keras-preprocessing, kubernetes, pip-tools, protobuf, pyrsistent, python-dateutil, tensorboard, tensorflow, websocket-client
+six==1.12.0               # via absl-py, apscheduler, cryptography, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras, keras-preprocessing, kubernetes, pip-tools, protobuf, pyarrow, pyrsistent, python-dateutil, tensorboard, tensorflow, websocket-client
 tensorboard==1.14.0       # via tensorflow
 tensorflow-estimator==1.14.0  # via tensorflow
 tensorflow==1.14.0

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -6,7 +6,6 @@ import pytest
 import logging
 import tempfile
 
-import jinja2
 from click.testing import CliRunner
 
 from gordo_components import cli

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -7,9 +7,7 @@ import logging
 import typing
 from dateutil.parser import isoparse  # type: ignore
 import asyncio
-import time
 
-import aiohttp
 import pytest
 import pandas as pd
 import numpy as np
@@ -19,7 +17,6 @@ from mock import patch, call
 
 from gordo_components.client import Client, utils as client_utils
 from gordo_components.client.utils import EndpointMetadata
-from gordo_components.client import io as client_io
 from gordo_components.client.forwarders import ForwardPredictionsIntoInflux
 from gordo_components.data_provider import providers
 from gordo_components.server import utils as server_utils
@@ -63,9 +60,9 @@ def test_client_download_model(watchman_service):
 
 @pytest.mark.parametrize("batch_size", (10, 100))
 @pytest.mark.parametrize("use_data_provider", (False, True))
-@pytest.mark.parametrize("use_arrow", (True, False))
+@pytest.mark.parametrize("use_parquet", (True, False))
 def test_client_predictions_diff_batch_sizes_and_toggle_data_provider(
-    influxdb, watchman_service, use_data_provider: bool, batch_size: int, use_arrow
+    influxdb, watchman_service, use_data_provider: bool, batch_size: int, use_parquet
 ):
     """
     Run the prediction client with different batch-sizes and whether to use
@@ -110,7 +107,7 @@ def test_client_predictions_diff_batch_sizes_and_toggle_data_provider(
             destination_influx_uri=tu.INFLUXDB_URI
         ),
         batch_size=batch_size,
-        use_arrow=use_arrow,
+        use_parquet=use_parquet,
     )
 
     # Should have discovered machine-1
@@ -246,7 +243,7 @@ def test_client_cli_download_model(watchman_service):
 )
 @pytest.mark.parametrize("output_dir", [tempfile.TemporaryDirectory(), None])
 @pytest.mark.parametrize("data_provider", [providers.RandomDataProvider(), None])
-@pytest.mark.parametrize("use_arrow", (True, False))
+@pytest.mark.parametrize("use_parquet", (True, False))
 def test_client_cli_predict(
     influxdb,
     gordo_name,
@@ -255,7 +252,7 @@ def test_client_cli_predict(
     output_dir,
     data_provider,
     trained_model_directory,
-    use_arrow,
+    use_parquet,
 ):
     """
     Test ability for client to get predictions via CLI
@@ -269,7 +266,7 @@ def test_client_cli_predict(
         "--project",
         tu.GORDO_PROJECT,
         "predict",
-        "--compress" if use_arrow else "--no-compress",
+        "--parquet" if use_parquet else "--no-parquet",
         "2016-01-01T00:00:00Z",
         "2016-01-01T01:00:00Z",
     ]

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -63,9 +63,9 @@ def test_client_download_model(watchman_service):
 
 @pytest.mark.parametrize("batch_size", (10, 100))
 @pytest.mark.parametrize("use_data_provider", (False, True))
-@pytest.mark.parametrize("use_pyarrow", (True, False))
+@pytest.mark.parametrize("use_arrow", (True, False))
 def test_client_predictions_diff_batch_sizes_and_toggle_data_provider(
-    influxdb, watchman_service, use_data_provider: bool, batch_size: int, use_pyarrow
+    influxdb, watchman_service, use_data_provider: bool, batch_size: int, use_arrow
 ):
     """
     Run the prediction client with different batch-sizes and whether to use
@@ -110,7 +110,7 @@ def test_client_predictions_diff_batch_sizes_and_toggle_data_provider(
             destination_influx_uri=tu.INFLUXDB_URI
         ),
         batch_size=batch_size,
-        use_pyarrow=use_pyarrow,
+        use_arrow=use_arrow,
     )
 
     # Should have discovered machine-1
@@ -246,7 +246,7 @@ def test_client_cli_download_model(watchman_service):
 )
 @pytest.mark.parametrize("output_dir", [tempfile.TemporaryDirectory(), None])
 @pytest.mark.parametrize("data_provider", [providers.RandomDataProvider(), None])
-@pytest.mark.parametrize("use_pyarrow", (True, False))
+@pytest.mark.parametrize("use_arrow", (True, False))
 def test_client_cli_predict(
     influxdb,
     gordo_name,
@@ -255,7 +255,7 @@ def test_client_cli_predict(
     output_dir,
     data_provider,
     trained_model_directory,
-    use_pyarrow,
+    use_arrow,
 ):
     """
     Test ability for client to get predictions via CLI
@@ -269,7 +269,7 @@ def test_client_cli_predict(
         "--project",
         tu.GORDO_PROJECT,
         "predict",
-        "--compress" if use_pyarrow else "--no-compress",
+        "--compress" if use_arrow else "--no-compress",
         "2016-01-01T00:00:00Z",
         "2016-01-01T01:00:00Z",
     ]

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -509,22 +509,23 @@ def test_exponential_sleep_time(watchman_service):
         isoparse("2016-01-01T12:00:00+00:00"),
     )
 
-    with patch(
-        "gordo_components.client.client.time.sleep", return_value=None
-    ) as time_sleep:
-        client = Client(project=tu.GORDO_PROJECT)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(
-            client._process_post_prediction_task(
-                X=pd.DataFrame([123]),
-                y=None,
-                chunk=slice(0, 1),
-                endpoint=endpoint,
-                start=start,
-                end=end,
+    with caplog.at_level(logging.CRITICAL):
+        with patch(
+            "gordo_components.client.client.time.sleep", return_value=None
+        ) as time_sleep:
+            client = Client(project=tu.GORDO_PROJECT)
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(
+                client._process_post_prediction_task(
+                    X=pd.DataFrame([123]),
+                    y=None,
+                    chunk=slice(0, 1),
+                    endpoint=endpoint,
+                    start=start,
+                    end=end,
+                )
             )
-        )
-        loop.close()
+            loop.close()
 
     expected_calls = [call(8), call(16), call(32), call(64), call(128)]
     time_sleep.assert_has_calls(expected_calls)

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -62,7 +62,11 @@ def test_client_download_model(watchman_service):
 @pytest.mark.parametrize("use_data_provider", (False, True))
 @pytest.mark.parametrize("use_parquet", (True, False))
 def test_client_predictions_diff_batch_sizes_and_toggle_data_provider(
-    influxdb, watchman_service, use_data_provider: bool, batch_size: int, use_parquet
+    influxdb,
+    watchman_service,
+    use_data_provider: bool,
+    batch_size: int,
+    use_parquet: bool,
 ):
     """
     Run the prediction client with different batch-sizes and whether to use

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -23,7 +23,7 @@ import tests.utils as tu
         None,  # No data, use GET
     ],
 )
-@pytest.mark.parametrize("resp_format", ("json", "pyarrow", None))
+@pytest.mark.parametrize("resp_format", ("json", "arrow", None))
 def test_anomaly_prediction_endpoint(
     base_route, influxdb, gordo_ml_server_client, data_to_post, sensors, resp_format
 ):

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -2,8 +2,6 @@
 
 import pytest
 import numpy as np
-import pandas as pd
-import pyarrow as pa
 
 from gordo_components.server import utils as server_utils
 import tests.utils as tu
@@ -23,7 +21,7 @@ import tests.utils as tu
         None,  # No data, use GET
     ],
 )
-@pytest.mark.parametrize("resp_format", ("json", "arrow", None))
+@pytest.mark.parametrize("resp_format", ("json", "parquet", None))
 def test_anomaly_prediction_endpoint(
     base_route, influxdb, gordo_ml_server_client, data_to_post, sensors, resp_format
 ):
@@ -50,7 +48,7 @@ def test_anomaly_prediction_endpoint(
         assert "data" in resp.json
         data = server_utils.dataframe_from_dict(resp.json["data"])
     else:
-        data = pa.deserialize_pandas(resp.data)
+        data = server_utils.dataframe_from_parquet_bytes(resp.data)
 
     # Only different between POST and GET is POST will return None for
     # start and end dates, because the server can't know what those are

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -2,6 +2,8 @@
 
 import pytest
 import numpy as np
+import pandas as pd
+import pyarrow as pa
 
 from gordo_components.server import utils as server_utils
 import tests.utils as tu
@@ -21,13 +23,16 @@ import tests.utils as tu
         None,  # No data, use GET
     ],
 )
+@pytest.mark.parametrize("resp_format", ("json", "pyarrow", None))
 def test_anomaly_prediction_endpoint(
-    base_route, influxdb, gordo_ml_server_client, data_to_post, sensors
+    base_route, influxdb, gordo_ml_server_client, data_to_post, sensors, resp_format
 ):
     """
     Anomaly GET and POST responses are the same
     """
     endpoint = f"{base_route}/anomaly/prediction"
+    if resp_format is not None:
+        endpoint += f"?format={resp_format}"
     if data_to_post is None:
         resp = gordo_ml_server_client.get(
             endpoint,
@@ -41,10 +46,11 @@ def test_anomaly_prediction_endpoint(
 
     # From here, the response should be (pretty much) the same format from GET or POST
     assert resp.status_code == 200
-    assert "data" in resp.json
-
-    # Load data into dataframe
-    data = server_utils.dataframe_from_dict(resp.json["data"])
+    if resp_format in (None, "json"):
+        assert "data" in resp.json
+        data = server_utils.dataframe_from_dict(resp.json["data"])
+    else:
+        data = pa.deserialize_pandas(resp.data)
 
     # Only different between POST and GET is POST will return None for
     # start and end dates, because the server can't know what those are

--- a/tests/gordo_components/server/test_base_view.py
+++ b/tests/gordo_components/server/test_base_view.py
@@ -31,25 +31,25 @@ import tests.utils as tu
         ).to_dict("dict"),
     ],
 )
-@pytest.mark.parametrize("resp_format", ("json", "pyarrow", None))
-@pytest.mark.parametrize("send_as_pyarrow", (True, False))
+@pytest.mark.parametrize("resp_format", ("json", "arrow", None))
+@pytest.mark.parametrize("send_as_arrow", (True, False))
 def test_prediction_endpoint_post_ok(
     base_route,
     sensors,
     gordo_ml_server_client,
     data_to_post,
     resp_format,
-    send_as_pyarrow,
+    send_as_arrow,
 ):
     """
     Test the expected successful data posts, by sending a variety of valid
-    JSON formats of a dataframe, as well as pyarrow serializations.
+    JSON formats of a dataframe, as well as arrow serializations.
     """
     endpoint = f"{base_route}/prediction"
     if resp_format is not None:
         endpoint += f"?format={resp_format}"
 
-    if send_as_pyarrow:
+    if send_as_arrow:
         X = pd.DataFrame.from_dict(data_to_post)
         kwargs = dict(
             data={"X": (io.BytesIO(pa.serialize_pandas(X).to_pybytes()), "X")}

--- a/tests/gordo_components/server/test_utils.py
+++ b/tests/gordo_components/server/test_utils.py
@@ -9,6 +9,29 @@ from gordo_components.server import utils as server_utils
 
 @pytest.mark.parametrize(
     "df",
+    (
+        pd.DataFrame(np.random.random((10, 10))),
+        pd.DataFrame(
+            np.random.random((10, 10)),
+            index=pd.date_range(start="2016-01-01", end="2016-01-02", periods=10),
+        ),
+        pd.DataFrame(
+            np.random.random((10, 4)),
+            columns=pd.MultiIndex.from_product((("col1", "col2"), ("ft1", "ft2"))),
+        ),
+    ),
+)
+def test_dataframe_parquet_serializers(df):
+    """The (de)serialization functions should be interoperable"""
+    serialized = server_utils.dataframe_into_parquet_bytes(df.copy())
+    df_clone = server_utils.dataframe_from_parquet_bytes(serialized)
+    assert df.columns.tolist() == df_clone.columns.tolist()
+    assert df.index.tolist() == df_clone.index.tolist()
+    assert np.allclose(df.values, df_clone.values)
+
+
+@pytest.mark.parametrize(
+    "df",
     [
         # Multi-column
         pd.DataFrame(


### PR DESCRIPTION
Situation :mushroom: 
---
Serving models from a single server means we can/need to improve efficiency of asking for predictions, especially from our client interactions

Solution :tulip: 
---
Support accepting and returning compressed data via `pyarrow`. 

- The client (and CLI) has a parameter `use_parquet` and `--parquet/--no-parquet`, respectively. Which is set as the default. So the client will compress the dataframe before sending.
- The server accepts either format, still having `X` and `y` and separate files, and can return compressed dataframes with `?format=parquet` URL arg.