### PR TITLE
Remove docs from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 /venv
 /.eggs
 /gordo_components.egg-info
-/docs
 /htmlcov
 /.coverage
 /dist


### PR DESCRIPTION
Before it did not get copied in to the docker builder image, which
caused git inside there to report the wrong version number,
causing the built images to report a bogus version number. Anything
which is tracked by git must be copied in (i.e. not be present in
.dockerignore)