### PR TITLE
Fix docstring in get_metrics_dict

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -188,7 +188,7 @@ def get_metrics_dict(metrics_list: list, y: pd.DataFrame) -> dict:
 
     Parameters
     ----------
-    metrics: list
+    metrics_list: list
         List of sklearn score functions
     y: pd.DataFrame
         Target data


### PR DESCRIPTION
Input parameter ```metrics_list``` was changed to ```metrics``` in the docstring. Changed docstring to ```metrics_list```. 