### PR TITLE
Load possible functions defined in definition

### DIFF
--- a/tests/gordo_components/serializer/test_serializer_from_definition.py
+++ b/tests/gordo_components/serializer/test_serializer_from_definition.py
@@ -43,6 +43,16 @@ logger = logging.getLogger(__name__)
                 - sklearn.ensemble.forest.RandomForestRegressor:
                     n_estimators: 20
     """,
+        """
+        sklearn.multioutput.MultiOutputRegressor:
+            estimator: 
+                sklearn.pipeline.Pipeline:
+                    steps:
+                        - sklearn.cluster.FeatureAgglomeration:
+                            n_clusters: 2
+                            pooling_func: numpy.mean
+                        - sklearn.linear_model.LinearRegression
+        """,
     ],
 )
 def test_load_from_definition(definition):


### PR DESCRIPTION
Problem :bomb: 
---
The `serializer.pipeline_into_definition` rightly dumps any function as it's path. ie. `np.mean` becomes the string `numpy.mean`. However `serializer.pipeline_from_definition` only looked at `FunctionTransformer`  specific params as possible functions.

Solution :boom: 
---
Generalize the loading of possible functions when encountering parameters who's value can be loaded as a callable.