### PR TITLE
Fix client.io post kwarg 'files' -> 'data'

### DIFF
--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -405,7 +405,7 @@ class Client:
 
         # We're going to serialize the data as either JSON or Arrow
         if self.use_parquet:
-            kwargs["files"] = {
+            kwargs["data"] = {
                 "X": server_utils.dataframe_into_parquet_bytes(X.iloc[chunk]),
                 "y": server_utils.dataframe_into_parquet_bytes(y.iloc[chunk])
                 if y is not None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,7 +88,13 @@ def wait_for_influx(max_wait=30, influx_host="localhost:8086"):
 
 
 def _post_patch(*args, **kwargs):
-    resp = requests.post(*args, **{k: v for k, v in kwargs.items() if k != "session"})
+    kwargs = {k: v for k, v in kwargs.items() if k != "session"}
+
+    # Warning, ugly; aiohttp.Session.post calls request's version of 'files' 'data'
+    if "data" in kwargs:
+        kwargs["files"] = kwargs.pop("data")
+
+    resp = requests.post(*args, **kwargs)
     if resp.headers["Content-Type"] == "application/json":
         return resp.json()
     else:


### PR DESCRIPTION
Problem :cloud_with_lightning: 
---
`requests.post` has parameter `files`, where aiohttp calls the equivalent `data`. aiohttp is what we use in prod, where requests is what we use in our patched tests.

Solution :partly_sunny: 
---
Change the kwarg to `data` and in the patched function, rename that to `files`; albeit, not the prettiest.