### PR TITLE
Remove GET support from ML server

### DIFF
--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -19,7 +19,6 @@ from gordo_components.builder.build_model import (
     calculate_model_key,
     build_model,
 )
-from gordo_components.data_provider.providers import InfluxDataProvider
 from gordo_components.serializer import (
     load_metadata,
     pipeline_into_definition,
@@ -388,61 +387,8 @@ def get_all_score_strings(metadata):
 @click.command("run-server")
 @click.option("--host", type=str, help="The host to run the server on.")
 @click.option("--port", type=int, help="The port to run the server on.")
-@click.option("--src-influx-host", type=str, envvar="SRC_INFLUXDB_HOST")
-@click.option("--src-influx-port", type=int, envvar="SRC_INFLUXDB_PORT")
-@click.option("--src-influx-username", type=str, envvar="SRC_INFLUXDB_USERNAME")
-@click.option("--src-influx-password", type=str, envvar="SRC_INFLUXDB_PASSWORD")
-@click.option("--src-influx-database", type=str, envvar="SRC_INFLUXDB_DATABASE")
-@click.option("--src-influx-path", type=str, envvar="SRC_INFLUXDB_PATH")
-@click.option("--src-influx-measurement", type=str, envvar="SRC_INFLUXDB_MEASUREMENT")
-@click.option(
-    "--src-influx-value", type=str, envvar="SRC_INFLUXDB_VALUE_NAME", default="value"
-)
-@click.option("--src-influx-api-key", type=str, envvar="SRC_INFLUXDB_API_KEY")
-@click.option(
-    "--src-influx-api-key-header", type=str, envvar="SRC_INFLUXDB_API_KEY_HEADER"
-)
-def run_server_cli(
-    host: str,
-    port: int,
-    src_influx_host: str,
-    src_influx_port: int,
-    src_influx_username: str,
-    src_influx_password: str,
-    src_influx_database: str,
-    src_influx_path: str,
-    src_influx_measurement: str,
-    src_influx_value: str,
-    src_influx_api_key: str,
-    src_influx_api_key_header: str,
-):
-
-    # We have have a hostname, then we make a data provider
-    if src_influx_host:
-        influx_config = {
-            "host": src_influx_host,
-            "port": src_influx_port,
-            "username": src_influx_username,
-            "password": src_influx_password,
-            "database": src_influx_database,
-            "proxies": {"http": "", "https": ""},
-            "ssl": True,
-            "path": src_influx_path,
-            "timeout": 20,
-            "retries": 10,
-        }
-
-        provider = InfluxDataProvider(
-            measurement=src_influx_measurement,
-            value_name=src_influx_value,
-            api_key=src_influx_api_key,
-            api_key_header=src_influx_api_key_header,
-            **influx_config,
-        )
-    else:
-        provider = None  # type: ignore
-
-    server.run_server(host, port, data_provider=provider)
+def run_server_cli(host: str, port: int):
+    server.run_server(host, port)
 
 
 @click.command("run-watchman")

--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -290,18 +290,10 @@ class Client:
               1st element is the dataframe of the predictions; complete with a DateTime index.
               2nd element is a list of error messages (if any) for running the predictions
         """
-
-        # Determine which method we'll use to get predictions
-        # If we don't have a data_provider instance, we can't source our own data.
-        if self.data_provider is not None:
-            predict_method = self._predict_via_post
-        else:
-            predict_method = self._predict_via_get
-
         # For every endpoint, start making predictions for the time range
         jobs = asyncio.gather(
             *[
-                predict_method(endpoint=endpoint, start=start, end=end)
+                self._predict(endpoint=endpoint, start=start, end=end)
                 for endpoint in self.endpoints
             ]
         )
@@ -317,7 +309,7 @@ class Client:
             (pr.name, pr.predictions, pr.error_messages) for pr in prediction_results
         ]  # type: ignore
 
-    async def _predict_via_post(
+    async def _predict(
         self, endpoint: EndpointMetadata, start: datetime, end: datetime
     ) -> PredictionResult:
         """
@@ -349,7 +341,7 @@ class Client:
 
             # Chunk over the dataframe by batch_size
             jobs = [
-                self._process_post_prediction_task(
+                self._process_prediction_task(
                     X,
                     y,
                     chunk=slice(i, i + self.batch_size),
@@ -366,7 +358,7 @@ class Client:
             ]
             return await self._accumulate_coroutine_predictions(endpoint, jobs)
 
-    async def _process_post_prediction_task(
+    async def _process_prediction_task(
         self,
         X: pd.DataFrame,
         y: typing.Optional[pd.DataFrame],
@@ -486,100 +478,6 @@ class Client:
                     predictions=predictions,
                     error_messages=[],
                 )
-
-    async def _predict_via_get(
-        self, endpoint: EndpointMetadata, start: datetime, end: datetime
-    ) -> PredictionResult:
-        """
-        Get predictions based on the /prediction GET endpoint of Gordo ML Servers
-
-        Parameters
-        ----------
-        endpoint: EndpointMetadata
-            Named tuple which has 'endpoint' specifying the full url to the base ml server
-        start: datetime
-        end: datetime
-
-        Returns
-        -------
-        dict
-            Prediction response from /prediction GET
-        """
-        start_end_dates = make_date_ranges(start, end, max_interval_days=1, freq="23H")
-
-        async with aiohttp.ClientSession() as session:
-
-            # Create all the jobs which will be done, but don't await them
-            jobs = [
-                self._process_get_prediction_task(endpoint, start, end, session)
-                for start, end in start_end_dates
-            ]
-
-            return await self._accumulate_coroutine_predictions(endpoint, jobs)
-
-    async def _process_get_prediction_task(
-        self,
-        endpoint: EndpointMetadata,
-        start: datetime,
-        end: datetime,
-        session: typing.Optional[aiohttp.ClientSession] = None,
-    ):
-        """
-        Process a single prediction GET request. Will ask /prediction GET endpoint
-        for predictions given start and end dates, and create a dataframe of the
-        returned results and create one PredictionResult for that time span.
-
-        Parameters
-        ----------
-        endpoint: EndpointMetadata
-        start: datetime
-        end: datetime
-
-        Notes
-        -----
-        PredictionResult.predictions may be None if the prediction process fails
-
-        Returns
-        -------
-        PredictionResult
-        """
-        json = {"start": start.isoformat(), "end": end.isoformat()}
-
-        try:
-            try:
-                response = await gordo_io.get(
-                    f"{endpoint.endpoint}{self.prediction_path}{self.query}",
-                    session=session,
-                    json=json,
-                )
-            except HttpUnprocessableEntity:
-                self.prediction_path = "/prediction"
-                response = await gordo_io.get(
-                    f"{endpoint.endpoint}{self.prediction_path}{self.query}",
-                    session=session,
-                    json=json,
-                )
-        except IOError as exc:
-            msg = (
-                f"Failed to get predictions for dates {start} -> {end} "
-                f"for target: {endpoint.target_name} "
-                f"Error: {exc}"
-            )
-            logger.error(msg)
-            return PredictionResult(
-                name=endpoint.target_name, predictions=None, error_messages=[msg]
-            )
-        else:
-            logger.info(f"Processing {start} -> {end}")
-            predictions = self.dataframe_from_response(response)
-
-            if self.prediction_forwarder is not None:
-                await self.prediction_forwarder(
-                    predictions=predictions, endpoint=endpoint, metadata=self.metadata
-                )
-            return PredictionResult(
-                name=endpoint.target_name, predictions=predictions, error_messages=[]
-            )
 
     async def _accumulate_coroutine_predictions(
         self, endpoint: EndpointMetadata, jobs: typing.List[typing.Coroutine]

--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -274,8 +274,7 @@ class Client:
         self, start: datetime, end: datetime
     ) -> typing.Iterable[typing.Tuple[str, pd.DataFrame, typing.List[str]]]:
         """
-        Start the prediction process. Will perform POST prediction workflow if
-        Client has a data_provider instance, otherwise default to GET based predictions
+        Start the prediction process.
 
         Parameters
         ----------

--- a/gordo_components/server/server.py
+++ b/gordo_components/server/server.py
@@ -5,7 +5,6 @@ import typing
 from functools import wraps
 
 from flask import Flask, g
-from gordo_components.data_provider.base import GordoBaseDataProvider
 from gordo_components.server import views
 
 logger = logging.getLogger(__name__)
@@ -93,7 +92,7 @@ def adapt_proxy_deployment(wsgi_app: typing.Callable) -> typing.Callable:
     return wrapper
 
 
-def build_app(data_provider: typing.Optional[GordoBaseDataProvider] = None):
+def build_app():
     """
     Build app and any associated routes
     """
@@ -105,10 +104,6 @@ def build_app(data_provider: typing.Optional[GordoBaseDataProvider] = None):
 
     app.wsgi_app = adapt_proxy_deployment(app.wsgi_app)  # type: ignore
     app.url_map.strict_slashes = False  # /path and /path/ are ok.
-
-    @app.before_request
-    def _reg_data_provider():
-        g.data_provider = data_provider
 
     @app.before_request
     def _start_timer():
@@ -128,13 +123,8 @@ def build_app(data_provider: typing.Optional[GordoBaseDataProvider] = None):
     return app
 
 
-def run_server(
-    host: str = "0.0.0.0",
-    port: int = 5555,
-    debug: bool = False,
-    data_provider: typing.Optional[GordoBaseDataProvider] = None,
-):
-    app = build_app(data_provider=data_provider)
+def run_server(host: str = "0.0.0.0", port: int = 5555, debug: bool = False):
+    app = build_app()
     app.run(host, port, debug=debug)
 
 

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -33,13 +33,6 @@ API_MODEL_INPUT_POST = api.model(
 API_MODEL_OUTPUT_POST = api.model(
     "Prediction - Output from POST", {"output": fields.List(fields.List(fields.Float))}
 )
-
-
-# GET type declarations
-API_MODEL_INPUT_GET = api.model(
-    "Prediction - Time range prediction",
-    {"start": fields.DateTime, "end": fields.DateTime},
-)
 _tags = {
     fields.String: fields.Float
 }  # tags of single prediction record {'tag-name': tag-value}
@@ -49,10 +42,6 @@ _single_prediction_record = {
     "tags": fields.Nested(_tags),
     "total_abnormality": fields.Float,
 }
-API_MODEL_OUTPUT_GET = api.model(
-    "Prediction - Output from GET",
-    {"output": fields.List(fields.Nested(_single_prediction_record))},
-)
 
 
 class AnomalyView(BaseModelView):
@@ -93,6 +82,8 @@ class AnomalyView(BaseModelView):
      'time-seconds': '0.1937'}
     """
 
+    methods = ["POST"]
+
     @api.response(200, "Success", API_MODEL_OUTPUT_POST)
     @api.expect(API_MODEL_INPUT_POST, validate=False)
     @api.doc(
@@ -103,19 +94,6 @@ class AnomalyView(BaseModelView):
     @utils.model_required
     @utils.extract_X_y
     def post(self):
-        start_time = timeit.default_timer()
-        return self._create_anomaly_response(start_time)
-
-    @api.response(200, "Success", API_MODEL_OUTPUT_POST)
-    @api.doc(
-        params={
-            "start": "An ISO formatted datetime with timezone info string indicating prediction range start",
-            "end": "An ISO formatted datetime with timezone info string indicating prediction range end",
-        }
-    )
-    @utils.model_required
-    @utils.extract_X_y
-    def get(self):
         start_time = timeit.default_timer()
         return self._create_anomaly_response(start_time)
 

--- a/gordo_components/server/views/anomaly.py
+++ b/gordo_components/server/views/anomaly.py
@@ -46,11 +46,9 @@ _single_prediction_record = {
 
 class AnomalyView(BaseModelView):
     """
-    Serve model predictions via GET and POST methods
+    Serve model predictions via POST method.
 
-    Will take a ``start`` and ``end`` ISO format datetime string if a GET request
-    or will take the raw input given in a POST request
-    and give back predictions looking something like this
+    Gives back predictions looking something like this
     (depending on anomaly model being served)::
 
         {
@@ -99,9 +97,8 @@ class AnomalyView(BaseModelView):
 
     def _create_anomaly_response(self, start_time: float = None):
         """
-        Process a base response from POST or GET endpoints, where it is expected in
-        the anomaly endpoint that the keys "output", "transformed-model-input" and "inverse-transformed-output"
-        are expected to be present in ``.json`` of the Response.
+        Use the current ``X`` and ``y`` to create an anomaly specific response
+        using the trained ML model's ``.anomaly()`` method.
 
         Parameters
         ----------
@@ -118,8 +115,6 @@ class AnomalyView(BaseModelView):
             start_time = timeit.default_timer()
 
         # To use this endpoint, we need a 'y' to calculate the errors.
-        # It has either come from client providing it in POST or from
-        # Influx during 'GET' part of `..common.extract_X_y` decorator
         if g.y is None:
             message = {
                 "message": "Cannot perform anomaly without 'y' to compare against."

--- a/gordo_components/server/views/base.py
+++ b/gordo_components/server/views/base.py
@@ -39,13 +39,6 @@ API_MODEL_INPUT_POST = api.model(
 API_MODEL_OUTPUT_POST = api.model(
     "Prediction - Output from POST", {"output": fields.List(fields.List(fields.Float))}
 )
-
-
-# GET type declarations
-API_MODEL_INPUT_GET = api.model(
-    "Prediction - Time range prediction",
-    {"start": fields.DateTime, "end": fields.DateTime},
-)
 _tags = {
     fields.String: fields.Float
 }  # tags of single prediction record {'tag-name': tag-value}
@@ -55,10 +48,6 @@ _single_prediction_record = {
     "tags": fields.Nested(_tags),
     "total_abnormality": fields.Float,
 }
-API_MODEL_OUTPUT_GET = api.model(
-    "Prediction - Output from GET",
-    {"output": fields.List(fields.Nested(_single_prediction_record))},
-)
 
 
 class BaseModelView(Resource):
@@ -96,7 +85,7 @@ class BaseModelView(Resource):
      'time-seconds': '0.1937'}
     """
 
-    methods = ["GET", "POST"]
+    methods = ["POST"]
 
     y: pd.DataFrame = None
     X: pd.DataFrame = None
@@ -118,21 +107,6 @@ class BaseModelView(Resource):
             return normalize_sensor_tags(g.metadata["dataset"]["target_tag_list"])
         else:
             return []
-
-    @api.response(200, "Success", API_MODEL_OUTPUT_POST)
-    @api.doc(
-        params={
-            "start": "An ISO formatted datetime with timezone info string indicating prediction range start",
-            "end": "An ISO formatted datetime with timezone info string indicating prediction range end",
-        }
-    )
-    @server_utils.model_required
-    @server_utils.extract_X_y
-    def get(self):
-        """
-        Process a GET request by fetching data ourselves
-        """
-        return self._process_request()
 
     @api.response(200, "Success", API_MODEL_OUTPUT_POST)
     @api.expect(API_MODEL_INPUT_POST, validate=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def gordo_ml_server_client(request, trained_model_directory):
 
     with tu.temp_env_vars(MODEL_COLLECTION_DIR=trained_model_directory):
 
-        app = server.build_app(data_provider=request.param)
+        app = server.build_app()
         app.testing = True
 
         yield app.test_client()

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 import logging
 import tempfile
 
+import mock
 from click.testing import CliRunner
 
 from gordo_components import cli
@@ -330,3 +331,23 @@ def test_build_cv_mode_build_only(tmp_dir: tempfile.TemporaryDirectory):
             metadata_json = json.loads(f.read())
             assert metadata_json["model"]["cross-validation"]["cv-duration-sec"] is None
             assert metadata_json["model"]["cross-validation"]["scores"] == {}
+
+
+@pytest.mark.parametrize("host", (None, "127.0.0.0"))
+@pytest.mark.parametrize("port", (None, 1234))
+def test_start_server_cli(host, port):
+    runner = CliRunner()
+    with mock.patch(
+        "gordo_components.server.server.run_server", mock.MagicMock(return_value=None)
+    ) as m:
+        args = ["run-server"]
+
+        # Add any optional params
+        if host is not None:
+            args.extend(["--host", host])
+        if port is not None:
+            args.extend(["--port", str(port)])
+        result = runner.invoke(cli.gordo, args)
+
+        assert result.exit_code == 0
+        m.assert_called_once_with(host, port)

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -18,7 +18,6 @@ import tests.utils as tu
             "X": np.random.random(size=(1, len(tu.SENSORS_STR_LIST))).tolist(),
             "y": np.random.random(size=(1, len(tu.SENSORS_STR_LIST))).tolist(),
         },  # Single record
-        None,  # No data, use GET
     ],
 )
 @pytest.mark.parametrize("resp_format", ("json", "parquet", None))
@@ -31,16 +30,8 @@ def test_anomaly_prediction_endpoint(
     endpoint = f"{base_route}/anomaly/prediction"
     if resp_format is not None:
         endpoint += f"?format={resp_format}"
-    if data_to_post is None:
-        resp = gordo_ml_server_client.get(
-            endpoint,
-            json={
-                "start": "2016-01-01T00:00:00+00:00",
-                "end": "2016-01-01T12:00:00+00:00",
-            },
-        )
-    else:
-        resp = gordo_ml_server_client.post(endpoint, json=data_to_post)
+
+    resp = gordo_ml_server_client.post(endpoint, json=data_to_post)
 
     # From here, the response should be (pretty much) the same format from GET or POST
     assert resp.status_code == 200
@@ -65,44 +56,3 @@ def test_anomaly_prediction_endpoint(
         key in data
         for key in ("total-anomaly", "tag-anomaly", "model-input", "model-output")
     )
-
-
-def test_more_than_24_hrs(base_route, influxdb, gordo_ml_server_client):
-    endpoint = f"{base_route}/anomaly/prediction"
-
-    # Request greater than 1 day should be a bad request
-    resp = gordo_ml_server_client.get(
-        endpoint,
-        json={"start": "2016-01-01T00:00:00+00:00", "end": "2016-01-02T00:00:00+00:00"},
-    )
-    assert resp.status_code == 400, f"Response content: {resp.data}"
-
-    # and for sanity, less than 1 day are ok
-    resp = gordo_ml_server_client.get(
-        endpoint,
-        json={"start": "2016-01-01T00:00:00+00:00", "end": "2016-01-01T01:00:00+00:00"},
-    )
-    assert resp.status_code == 200, f"Response content: {resp.data}"
-
-
-def test_overlapping_time_buckets(base_route, influxdb, gordo_ml_server_client):
-    """
-    Requests for overlapping time sample buckets should only produce
-    predictions whose bucket falls completely within the requested
-    time rang
-
-    This should give one prediction with start end of
-    2016-01-01 00:10:00+00:00 and 2016-01-01 00:20:00+00:00, respectively.
-    because it will not go over, ie. giving a bucket from 00:20:00 to 00:30:00
-    but can give a bucket which contains data before the requested start date.
-    """
-    resp = gordo_ml_server_client.get(
-        f"{base_route}/anomaly/prediction",
-        json={"start": "2016-01-01T00:11:00+00:00", "end": "2016-01-01T00:21:00+00:00"},
-    )
-    assert resp.status_code == 200
-    data = server_utils.dataframe_from_dict(resp.json["data"])
-
-    assert len(data) == 1, f"Expected one prediction, got: {resp.json}"
-    assert data["start"].iloc[0].tolist() == ["2016-01-01T00:10:00+00:00"]
-    assert data["end"].iloc[0].tolist() == ["2016-01-01T00:20:00+00:00"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -139,14 +139,11 @@ def watchman(
     -------
     None
     """
-    from gordo_components.dataset import datasets
     from gordo_components.server import server as gordo_ml_server
 
     with temp_env_vars(MODEL_COLLECTION_DIR=model_location):
         # Create gordo ml servers
-        gordo_server_app = gordo_ml_server.build_app(
-            data_provider=datasets.RandomDataProvider()
-        )
+        gordo_server_app = gordo_ml_server.build_app()
         gordo_server_app.testing = True
         gordo_server_app = gordo_server_app.test_client()
 


### PR DESCRIPTION
Problem :car: 
---
We have a `GET` endpoint for the ML server which has gone unused for some time and has shown no use for continued support.

Solution :truck: 
---
Remove it. 