### PR TITLE
Bump test req tornado>=4,<6 to ~6

### DIFF
--- a/test_requirements.in
+++ b/test_requirements.in
@@ -10,10 +10,9 @@ responses~=0.10
 black==19.3b0
 pytest-flakes~=4.0
 adal~=1.2
-jupyter==1.0.0
+jupyter~=1.0.0
 notebook~=6.0
 nbconvert~=5.4
-tornado>=4, <6  # https://github.com/jupyter/notebook/pull/4310#issuecomment-452368841
 pytest-asyncio~=0.10
 asynctest~=0.12
 urllib3>=1.24.2,<2.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -90,7 +90,7 @@ six==1.12.0               # via bleach, cryptography, docker, jsonschema, mock, 
 terminado==0.8.2          # via notebook
 testpath==0.4.2           # via nbconvert
 toml==0.10.0              # via black
-tornado==5.1.1
+tornado==6.0.3            # via ipykernel, jupyter-client, notebook, terminado
 traitlets==4.3.3          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbconvert, nbformat, notebook, qtconsole
 typed-ast==1.4.0          # via mypy
 typing-extensions==3.7.4  # via mypy


### PR DESCRIPTION
We needed to pin it <6 because of a bug, but it has been fixed, so now we no longer must pin. 