### PR TITLE
Remove unused explicit dependency joblib

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,6 @@ cachetools~=3.1
 h5py~=2.8
 influxdb~=5.2
 jinja2~=2.10
-joblib~=0.13
 Keras~=2.2,<2.3
 pyarrow~=0.14
 numpy~=1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ idna==2.8                 # via idna-ssl, requests, yarl
 influxdb==5.2.3
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1
-joblib==0.14.0
+joblib==0.14.0            # via scikit-learn
 jsonschema==3.0.2         # via flask-restplus
 keras-applications==1.0.8  # via keras, tensorflow
 keras-preprocessing==1.1.0  # via keras, tensorflow


### PR DESCRIPTION
It is a dependency of scikit-learn, and is in requirements.txt, but should not
be in requirements.in