### PR TITLE
Make client have Mutex for setting endpoints

### DIFF
--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -125,13 +125,13 @@ class Client:
 
         # Thread safe single access and updating of endpoints.
         with self._mutex:
-            if len(self.endpoints) == 0:
-                endpoints = self._endpoints_from_watchman(self.watchman_endpoint)
-            self.endpoints = self._filter_endpoints(
-                endpoints=endpoints,
-                target=target,
-                ignore_unhealthy_targets=ignore_unhealthy_targets,
-            )
+            if not self.endpoints:
+                self.endpoints = self._endpoints_from_watchman(self.watchman_endpoint)
+                self.endpoints = self._filter_endpoints(
+                    endpoints=self.endpoints,
+                    target=target,
+                    ignore_unhealthy_targets=ignore_unhealthy_targets,
+                )
 
     @staticmethod
     def _filter_endpoints(

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -7,7 +7,6 @@ import logging
 import typing
 from dateutil.parser import isoparse  # type: ignore
 import asyncio
-import mock
 
 import pytest
 import pandas as pd
@@ -57,36 +56,6 @@ def test_client_download_model(watchman_service):
     with pytest.raises(ValueError):
         client = Client(project=tu.GORDO_PROJECT, target="non-existent-target")
         client.download_model()
-
-
-def test_client_load_metadata_once(watchman_service):
-    """
-    When creating multiple clients, it should only collect the metadata/endpoints
-    one time and share that variable across new instances.
-    """
-
-    # Using Client.call_metadata_once() will create a class attribute `endpoints`
-    # so that all following instantiations of `Client` will not make calls to watchman
-    with mock.patch(
-        "gordo_components.client.client.Client._cache_endpoints",
-        side_effect=Client._cache_endpoints,
-    ) as m:
-        with Client.cached_endpoints_client() as EfficientClient:
-            clients = [
-                EfficientClient(project=tu.GORDO_PROJECT, target=tu.GORDO_SINGLE_TARGET)
-                for i in range(10)
-            ]
-            assert m.call_count == 1
-            assert all(hasattr(client, "endpoints") for client in clients)
-
-        # Now it should not be called, because we will not set `endpoints` as
-        # an attribute of the class but per instance of the class
-        clients = [
-            Client(project=tu.GORDO_PROJECT, target=tu.GORDO_SINGLE_TARGET)
-            for i in range(10)
-        ]
-        assert m.call_count == 1  # Call count to _set_endpoints should remain the same
-        assert all(hasattr(client, "endpoints") for client in clients)
 
 
 @pytest.mark.parametrize("batch_size", (10, 100))


### PR DESCRIPTION
Will close #513 

Problem :lollipop: 
---
If a situation arises which requires a user of the Client to create many clients; each one will fetch all the endpoints for each new instantiation. 

Solution :tea: 
---
Create a context manager which gives a modified version of `Client` which will make a single call, and new instantiations will reuse the first metadata.