### PR TITLE
Add pip requirement for dev_requirements

### DIFF
--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -1,3 +1,4 @@
+pip>=19.2.3
 pip-tools~=4.0
 sphinx-rtd-theme~=0.4
 sphinxcontrib-websupport~=1.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -39,4 +39,5 @@ sphinxcontrib-websupport==1.1.2
 urllib3==1.25.6           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip==19.2.3
 # setuptools==41.4.0        # via sphinx


### PR DESCRIPTION
Problem :ice_cream: 
---
readthedocs doesn't have update pip, so it can't find Tensorflow 2.0

Solution :sun_with_face: 
---
Add it to the `dev_requirements`