### PR TITLE
Update gordo server to run with Gunicorn

### DIFF
--- a/Dockerfile-ModelServer
+++ b/Dockerfile-ModelServer
@@ -22,4 +22,4 @@ COPY --from=builder /code/dist/gordo-components-packed.tar.gz .
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 RUN pip install ./gordo-components-packed.tar.gz
 
-CMD ["gordo-components", "run-server", "--host", "0.0.0.0", "--port", "5555"]
+CMD ["gordo-components", "run-server"]

--- a/gordo_components/__init__.py
+++ b/gordo_components/__init__.py
@@ -1,4 +1,8 @@
+import logging
+import os
+import traceback
 from typing import Tuple
+import warnings
 
 try:
     from ._version import version as __version__
@@ -25,3 +29,37 @@ def _parse_version(version: str) -> Tuple[int, ...]:
 
 
 MAJOR_VERSION, MINOR_VERSION = _parse_version(__version__)
+
+try:
+    # FIXME(https://github.com/abseil/abseil-py/issues/99)
+    # FIXME(https://github.com/abseil/abseil-py/issues/102)
+    # Unfortunately, many libraries that include absl (including Tensorflow)
+    # will get bitten by double-logging due to absl's incorrect use of
+    # the python logging library:
+    #   2019-07-19 23:47:38,829 my_logger   779 : test
+    #   I0719 23:47:38.829330 139904865122112 foo.py:63] test
+    #   2019-07-19 23:47:38,829 my_logger   779 : test
+    #   I0719 23:47:38.829469 139904865122112 foo.py:63] test
+    # The code below fixes this double-logging.  FMI see:
+    #   https://github.com/tensorflow/tensorflow/issues/26691#issuecomment-500369493
+
+    import absl.logging
+
+    logging.root.removeHandler(absl.logging._absl_handler)
+    absl.logging._warn_preinit_stderr = False
+
+except Exception:
+    warnings.warn(f"Failed to fix absl logging bug {traceback.format_exc()}")
+    pass
+
+
+# Set log level, defaulting to DEBUG
+log_level = os.getenv("LOG_LEVEL", "DEBUG").upper()
+azure_log_level = os.getenv("AZURE_DATALAKE_LOG_LEVEL", "INFO").upper()
+
+logging.basicConfig(
+    level=getattr(logging, log_level),
+    format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
+)
+
+logging.getLogger("azure.datalake").setLevel(azure_log_level)

--- a/gordo_components/cli/custom_types.py
+++ b/gordo_components/cli/custom_types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import ipaddress
 import os
 import typing
 
@@ -47,6 +48,21 @@ class IsoFormatDateTime(click.ParamType):
             return parser.isoparse(value)
         except ValueError:
             self.fail(f"Failed to parse date '{value}' as ISO formatted date'")
+
+
+class HostIP(click.ParamType):
+    """
+    Validate input is a valid IP address
+    """
+
+    name = "host"
+
+    def convert(self, value, param, ctx):
+        try:
+            ipaddress.ip_address(value)
+            return value
+        except ValueError as e:
+            self.fail(e)
 
 
 def key_value_par(val) -> typing.Tuple[str, str]:

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ apscheduler~=3.6
 Click~=7.0
 cachetools~=3.1
 dictdiffer
+gunicorn~=19.9.0
 h5py~=2.8
 influxdb~=5.2
 jinja2~=2.10
@@ -26,3 +27,4 @@ aiohttp~=3.6
 aiodns~=2.0
 urllib3>=1.24.2,<2.0
 simplejson~=3.16
+gevent~=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,12 @@ dictdiffer==0.8.0
 flask-restplus==0.13.0
 flask==1.1.1
 gast==0.2.2               # via tensorflow
+gevent==1.4.0
 google-auth==1.6.3        # via kubernetes
 google-pasta==0.1.7       # via tensorflow
+greenlet==0.4.15          # via gevent
 grpcio==1.24.1            # via tensorboard, tensorflow
+gunicorn==19.9.0
 h5py==2.10.0
 idna==2.8                 # via requests, yarl
 influxdb==5.2.3

--- a/tests/gordo_components/server/test_gordo_server.py
+++ b/tests/gordo_components/server/test_gordo_server.py
@@ -3,10 +3,10 @@
 import logging
 
 import pytest
-import numpy as np
+import subprocess
 
+from gordo_components.server.server import run_cmd
 from gordo_components import serializer
-from tests import utils as tu
 
 
 logger = logging.getLogger(__name__)
@@ -64,3 +64,19 @@ def test_download_model(base_route, gordo_ml_server_client):
 
     # Models MUST have either predict or transform
     assert hasattr(model, "predict") or hasattr(model, "transform")
+
+
+def test_run_cmd(monkeypatch):
+    """
+    Test that execution error catchings work as expected
+    """
+
+    # Call command that raises FileNotFoundError, a subclass of OSError
+    cmd = ["gumikorn", "gordo_components.server.server:app"]
+    with pytest.raises(OSError):
+        run_cmd(cmd)
+
+    # Call command that raises a CalledProcessError
+    cmd = ["ping", "--bad-option"]
+    with pytest.raises(subprocess.CalledProcessError):
+        run_cmd(cmd)


### PR DESCRIPTION
This PR does the following:
* Updates `server.server::run_server` to run the Flask server app with Gunicorn and subprocess
   - this includes instantiating the app with import, and running the module runs the flask `app.run()` method 
* Update cli `run-server` command a tad
* Update run server cli test to check input validation
* Update Dockerfile to call cli with no args (i.e. defaults). 

This could be done differently by adding some logic in `server.run_server()` and configuring with an env var or something, but I didn't like that approach.