### PR TITLE
Support row filter buffering

### DIFF
--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -27,6 +27,7 @@ class TimeSeriesDataset(GordoBaseDataset):
         resolution: str = "10T",
         row_filter: str = "",
         aggregation_methods: Union[str, List[str], Callable] = "mean",
+        row_filter_buffer_size: int = 0,
         **_kwargs,
     ):
         """
@@ -78,6 +79,7 @@ class TimeSeriesDataset(GordoBaseDataset):
         self.data_provider = data_provider
         self.row_filter = row_filter
         self.aggregation_methods = aggregation_methods
+        self.row_filter_buffer_size = row_filter_buffer_size
 
         if not self.from_ts.tzinfo or not self.to_ts.tzinfo:
             raise ValueError(
@@ -100,7 +102,9 @@ class TimeSeriesDataset(GordoBaseDataset):
             aggregation_methods=self.aggregation_methods,
         )
         if self.row_filter:
-            data = pandas_filter_rows(data, self.row_filter)
+            data = pandas_filter_rows(
+                data, self.row_filter, buffer_size=self.row_filter_buffer_size
+            )
 
         x_tag_names = [tag.name for tag in self.tag_list]
         y_tag_names = [tag.name for tag in self.target_tag_list]
@@ -118,6 +122,7 @@ class TimeSeriesDataset(GordoBaseDataset):
             "train_end_date": self.to_ts,
             "resolution": self.resolution,
             "filter": self.row_filter,
+            "row_filter_buffer_size": self.row_filter_buffer_size,
         }
         return metadata
 

--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -67,6 +67,10 @@ class TimeSeriesDataset(GordoBaseDataset):
             and the aggregation method as the second level.
             See :py:func::`pandas.core.resample.Resampler#aggregate` for more
             information on possible aggregation methods.
+        row_filter_buffer_size: int
+            Whatever elements are selected for removal based on the ``row_filter``, will also
+            have this amount of elements removed fore and aft.
+            Default is zero 0
         _kwargs
         """
         self.from_ts = from_ts

--- a/gordo_components/dataset/filter_rows.py
+++ b/gordo_components/dataset/filter_rows.py
@@ -1,5 +1,7 @@
 import ast
 import logging
+import pandas as pd
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +43,44 @@ class _DfNameInserter(ast.NodeTransformer):
         )
 
 
-def pandas_filter_rows(df, filter_str: str):
+def apply_buffer(mask: pd.Series, buffer_size: int = 0):
+    """
+    Take a mask (boolean series) where True indicates keeping a value, and False
+    represents removing the value. This will 'expand' those indexes marked as `False`
+    to the symmetrical bounds of ``buffer_size``
+
+    Parameters
+    ----------
+    mask: pandas.core.Series
+        Boolean pandas series
+    buffer_size: int
+        Size to buffer around ``False`` values
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> series = pd.Series([True, True, False, True, True])
+    >>> apply_buffer(series, buffer_size=1)
+    >>> series
+    0     True
+    1    False
+    2    False
+    3    False
+    4     True
+    dtype: bool
+
+    Returns
+    -------
+    None
+    """
+    idxs, *_rows = np.where(mask == False)
+    for idx in idxs:
+        mask.values[
+            range(max((0, idx - buffer_size)), min((len(mask), idx + buffer_size + 1)))
+        ] = False
+
+
+def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     """
 
     Parameters
@@ -106,6 +145,7 @@ def pandas_filter_rows(df, filter_str: str):
     parsed_filter = _DfNameInserter(df_name="df").visit(parsed_filter)
     # The eval requires the dataframe to be called 'df'
     pandas_filter = eval(compile(parsed_filter, filename=__name__, mode="eval"))
+    apply_buffer(pandas_filter, buffer_size=buffer_size)
     return df[pandas_filter]
 
 

--- a/gordo_components/dataset/filter_rows.py
+++ b/gordo_components/dataset/filter_rows.py
@@ -94,7 +94,8 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
       Column names can be quoted in single/double quotations or back ticks.
       Example of legal filters are " `Tag A` > 5 " , " ('Tag B' > 1) | ('Tag C' > 4)"
       '("Tag D" < 5) '
-
+    buffer_size: int
+      Area fore and aft of the application of ``fitler_str`` to also mark for removal.
 
     Returns
     -------

--- a/tests/gordo_components/dataset/test_filter_rows.py
+++ b/tests/gordo_components/dataset/test_filter_rows.py
@@ -1,35 +1,28 @@
-import unittest
+import pytest
 import numpy as np
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
 from gordo_components.dataset.filter_rows import pandas_filter_rows
 
 
-class TestFilterRows(unittest.TestCase):
-    @classmethod
-    def setUp(self):
-        self.df = pd.DataFrame(list(np.ndindex((10, 2))), columns=["Tag  1", "Tag 2"])
+def test_filter_rows_basic():
+    df = pd.DataFrame(list(np.ndindex((10, 2))), columns=["Tag  1", "Tag 2"])
+    assert len(pandas_filter_rows(df, "`Tag  1` <= `Tag 2`")) == 3
+    assert len(pandas_filter_rows(df, "`Tag  1` == `Tag 2`")) == 2
+    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 2")) == 20
+    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 0.9")) == 9
 
-    def test_filter_rows_basic(self):
-        df = self.df
-        self.assertEqual(len(pandas_filter_rows(df, "`Tag  1` <= `Tag 2`")), 3)
-        self.assertEqual(len(pandas_filter_rows(df, "`Tag  1` == `Tag 2`")), 2)
-        self.assertEqual(
-            len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 2")), 20
-        )
-        self.assertEqual(
-            len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 0.9")), 9
-        )
+    assert_frame_equal(
+        pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`)"),
+        pandas_filter_rows(df, "~(`Tag  1` > `Tag 2`)"),
+    )
 
-        assert_frame_equal(
-            pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`)"),
-            pandas_filter_rows(df, "~(`Tag  1` > `Tag 2`)"),
-        )
 
-    def test_filter_rows_catches_illegal(self):
-        with self.assertRaises(ValueError):
-            pandas_filter_rows(self.df, "sys.exit(0)")
-        with self.assertRaises(ValueError):
-            pandas_filter_rows(self.df, "lambda x:x")
-        with self.assertRaises(ValueError):
-            pandas_filter_rows(self.df, "__import__('os').system('clear')"), ValueError
+def test_filter_rows_catches_illegal():
+    df = pd.DataFrame(list(np.ndindex((10, 2))), columns=["Tag  1", "Tag 2"])
+    with pytest.raises(ValueError):
+        pandas_filter_rows(df, "sys.exit(0)")
+    with pytest.raises(ValueError):
+        pandas_filter_rows(df, "lambda x:x")
+    with pytest.raises(ValueError):
+        pandas_filter_rows(df, "__import__('os').system('clear')"), ValueError


### PR DESCRIPTION
Will close #270 

Problem :chart_with_downwards_trend: 
---
We support a superb `row_filter` param to our `TimeSeriesDataset`, however, there is an additional request that areas fore and aft of such filtering is also filtered out to account for "ramp up" and "ramp down" trends in the time series.

Solution :chart_with_upwards_trend:  
---
Add another parameter to `TimeSeriesDataset` which is passed down into `pandas_filter_rows` which the resulting mask is 'expanded' to include filtering out indexes within the buffer zone.