### PR TITLE
Fix CLI connection to watchman-to-sql command

### DIFF
--- a/gordo_components/cli/workflow_generator.py
+++ b/gordo_components/cli/workflow_generator.py
@@ -2,12 +2,14 @@ import logging
 import time
 import pkg_resources
 import json
+import sys
 
 from typing import Dict, Any
 
 import click
 
 from gordo_components import __version__
+from gordo_components.workflow.watchman_to_sql.watchman_to_sql import watchman_to_sql
 from gordo_components.workflow.config_elements.normalized_config import NormalizedConfig
 from gordo_components.workflow.workflow_generator import workflow_generator as wg
 
@@ -227,8 +229,51 @@ def unique_tag_list_cli(machine_config: str, output_file_tag_list: str):
             print(tag)
 
 
+@click.command("watchman-to-sql")
+@click.option("--watchman-address", help="Address of watchman", required=True, type=str)
+@click.option("--sql-host", help="Host of the sql server", required=True, type=str)
+@click.option(
+    "--sql-port", help="Port of the sql server", required=False, type=int, default=5432
+)
+@click.option(
+    "--sql-database",
+    help="Username of the sql server",
+    required=False,
+    type=str,
+    default="postgres",
+)
+@click.option(
+    "--sql-username",
+    help="Username of the sql server",
+    required=False,
+    type=str,
+    default="postgres",
+)
+@click.option(
+    "--sql-password",
+    help="Port of the sql server",
+    required=False,
+    type=str,
+    default=None,
+)
+def watchman_to_sql_cli(
+    watchman_address, sql_host, sql_port, sql_database, sql_username, sql_password
+):
+    """
+    Program to fetch metadata from watchman and push the metadata to a postgres sql
+    database. Pushes to the table `machine`.
+    """
+    if watchman_to_sql(
+        watchman_address, sql_host, sql_port, sql_database, sql_username, sql_password
+    ):
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
 workflow_cli.add_command(workflow_generator_cli)
 workflow_cli.add_command(unique_tag_list_cli)
+workflow_cli.add_command(watchman_to_sql_cli)
 
 if __name__ == "__main__":
     workflow_cli()

--- a/gordo_components/workflow/watchman_to_sql/watchman_to_sql.py
+++ b/gordo_components/workflow/watchman_to_sql/watchman_to_sql.py
@@ -1,9 +1,8 @@
 from typing import List, Dict, Optional
 
-import click
 import requests
 import logging
-import sys
+
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -199,50 +198,3 @@ def _extract_machines_from_watchman_response(
                 logger.info(f"Found non-healthy endpoint {ep}, ignoring")
                 machines.append(None)
     return machines
-
-
-@click.command()
-@click.option("--watchman-address", help="Address of watchman", required=True, type=str)
-@click.option("--sql-host", help="Host of the sql server", required=True, type=str)
-@click.option(
-    "--sql-port", help="Port of the sql server", required=False, type=int, default=5432
-)
-@click.option(
-    "--sql-database",
-    help="Username of the sql server",
-    required=False,
-    type=str,
-    default="postgres",
-)
-@click.option(
-    "--sql-username",
-    help="Username of the sql server",
-    required=False,
-    type=str,
-    default="postgres",
-)
-@click.option(
-    "--sql-password",
-    help="Port of the sql server",
-    required=False,
-    type=str,
-    default=None,
-)
-def watchman_to_sql_cli(
-    watchman_address, sql_host, sql_port, sql_database, sql_username, sql_password
-):
-    """
-    Program to fetch metadata from watchman and push the metadata to a postgres sql
-    database. Pushes to the table `machine`.
-
-    """
-    if watchman_to_sql(
-        watchman_address, sql_host, sql_port, sql_database, sql_username, sql_password
-    ):
-        sys.exit(0)
-    else:
-        sys.exit(1)
-
-
-if __name__ == "__main__":
-    watchman_to_sql_cli()

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -504,7 +504,7 @@ spec:
       command: [bash]
       source: |
         echo "Feeding sql with metadata for project {{project_name}} using source ur http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/ and postgres url gordo-postgres-$PROJECT_NAME " \
-        && watchman-to-sql --watchman-address "http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/" --sql-host "gordo-postgres-$PROJECT_NAME"
+        && gordo-components workflow watchman-to-sql --watchman-address "http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/" --sql-host "gordo-postgres-$PROJECT_NAME"
       env:
         - name: PROJECT_NAME
           value: "{{project_name}}"

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -351,3 +351,10 @@ def test_start_server_cli(host, port):
 
         assert result.exit_code == 0
         m.assert_called_once_with(host, port)
+
+
+def test_watchman_to_sql_cli():
+    runner = CliRunner()
+    args = ["workflow", "watchman-to-sql", "--help"]
+    result = runner.invoke(cli.gordo, args)
+    assert result.exit_code == 0


### PR DESCRIPTION
Problem :moon: 
---
During the initial move of workflow generator into components #534 , the `watchman-to-sql` CLI command wasn't not hooked up to the `gordo-components` CLI entry point and not updated in the workflow template.

Solution :sun_behind_large_cloud: 
---
Hook it up under `gordo-components workflow watchman-to-sql` and update the workflow template to reflect this.