### PR TITLE
Update Makefile DOCKER_REPO settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
             make push-client
             make push-builder
             make push-watchman
+            make push-workflow-generator
 
   # Publish to PyPi, only on tagged commits.
   publish-to-pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ jobs:
           command: make images
 
   # Push images, only when on master and/or tagged commits.
-  # TODO: After we switch gordo-deploy to gordo-components, push that as well
   push-images:
     machine:
       docker_layer_caching: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,18 @@ script:
 
 deploy:
   - provider: script
-    script: make images push-prod-images
+    script: |
+      make images push-prod-images
+
+      # TODO: Remove this once we fully move gordo-deploy to gordo-components in controller
+      DOCKER_REPO=gordo-infrastructure GORDO_PROD_MODE=true make push-workflow-generator
     on:
       branch: master
   - provider: script
-    script: make images push-prod-images
+    script: |
+      make images push-prod-images
+
+      # TODO: Remove this once we fully move gordo-deploy to gordo-components in controller
+      DOCKER_REPO=gordo-infrastructure GORDO_PROD_MODE=true make push-workflow-generator
     on:
       tags: true

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,19 @@ push-client: client
 	export DOCKER_IMAGE=$(CLIENT_IMG_NAME);\
 	bash ./docker_push.sh
 
-# Publish images to the currently logged in docker repo
-push-dev-images: export DOCKER_REGISTRY:=auroradevacr.azurecr.io
-push-dev-images: push-builder push-server push-watchman push-client push-workflow-generator
+# Publish development images
+push-dev-images:
+
+	# Push everything to auroradevacr.azurecr.io/gordo-components
+	export DOCKER_REGISTRY=auroradevacr.azurecr.io;\
+	export DOCKER_REPO=gordo-components;\
+	$(MAKE) push-builder push-server push-watchman push-client push-workflow-generator
+
+	# Also push workflow-generator to auroradevacr.azurecr.io/gordo-infrastructure
+	# as gordo-controller still expects it to be located there.
+	export DOCKER_REGISTRY=auroradevacr.azurecr.io;\
+	export DOCKER_REPO=gordo-infrastructure;\
+	$(MAKE) push-workflow-generator
 
 push-prod-images: export GORDO_PROD_MODE:="true"
 push-prod-images: push-builder push-server push-watchman push-client push-workflow-generator

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ workflow-generator:
 
 # Publish image to the currently logged in docker repo
 push-workflow-generator: workflow-generator
-	export DOCKER_REPO="gordo-infrastructure";\
 	export DOCKER_NAME=$(WORKFLOW_GENERATOR_IMG_NAME);\
 	export DOCKER_IMAGE=$(WORKFLOW_GENERATOR_IMG_NAME);\
 	./docker_push.sh
@@ -32,25 +31,21 @@ client:
 	docker build . -f Dockerfile-Client -t $(CLIENT_IMG_NAME)
 
 push-server: model-server
-	export DOCKER_REPO="gordo-components";\
 	export DOCKER_NAME=$(MODEL_SERVER_IMG_NAME);\
 	export DOCKER_IMAGE=$(MODEL_SERVER_IMG_NAME);\
 	bash ./docker_push.sh
 
 push-builder: model-builder
-	export DOCKER_REPO="gordo-components";\
 	export DOCKER_NAME=$(MODEL_BUILDER_IMG_NAME);\
 	export DOCKER_IMAGE=$(MODEL_BUILDER_IMG_NAME);\
 	bash ./docker_push.sh
 
 push-watchman: watchman
-	export DOCKER_REPO="gordo-components";\
 	export DOCKER_NAME=$(WATCHMAN_IMG_NAME);\
 	export DOCKER_IMAGE=$(WATCHMAN_IMG_NAME);\
 	bash ./docker_push.sh
 
 push-client: client
-	export DOCKER_REPO="gordo-components";\
 	export DOCKER_NAME=$(CLIENT_IMG_NAME);\
 	export DOCKER_IMAGE=$(CLIENT_IMG_NAME);\
 	bash ./docker_push.sh


### PR DESCRIPTION
Problem :water_buffalo: 
---
Setting `DOCKER_REPO=gordo-components` in the Makefile caused CircleCI to fail because `gordo-components` is not a repo on Dockerhub, `equinor` is. ie. `equinor/gordo-model-server:latest`.

Solution? :cow2: 
---
Set the `DOCKER_REPO` var in `.travis` and `.circleci/config.yml` separately, and additionally in `.travis.yml` push `gordo-deploy` to both aurora's `gordo-components` and `gordo-infrastructure` repos until we move it in the system to use `gordo-components` repo.