### PR TITLE
Allow parametrization of image sources in workflow

### DIFF
--- a/gordo_components/cli/workflow_generator.py
+++ b/gordo_components/cli/workflow_generator.py
@@ -99,6 +99,18 @@ def workflow_cli():
     default=None,
     help="Max number of ML Servers to use, defaults to N machines * 10",
 )
+@click.option(
+    "--docker-repository",
+    type=str,
+    default="gordo-components",
+    help="The docker repo to use for pulling component images from",
+)
+@click.option(
+    "--docker-registry",
+    type=str,
+    default="auroradevacr.azurecr.io",  # TODO: Change to docker.io after migrating
+    help="The docker registry to use for pulling component images from",
+)
 def workflow_generator_cli(**kwargs: dict):
     """
     Machine Configuration to Argo Workflow
@@ -114,8 +126,10 @@ def workflow_generator_cli(**kwargs: dict):
     context["project_version"] = kwargs["project_version"]
     context["namespace"] = kwargs["namespace"]
     context["ambassador_namespace"] = kwargs["ambassador_namespace"]
-    # Create normalized config
+    context["docker_repository"] = kwargs["docker_repository"]
+    context["docker_registry"] = kwargs["docker_registry"]
 
+    # Create normalized config
     config = NormalizedConfig(yaml_content, project_name=kwargs["project_name"])
 
     context["machines"] = config.machines

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -43,7 +43,7 @@ spec:
         applications.gordo.equinor.com/project-name: "{{project_name}}"
         applications.gordo.equinor.com/project-version: "{{project_version}}"
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
       command: [bash]
       source: |
         echo "Ensuring that no other versions of workflows for this project is running at the same time"
@@ -199,7 +199,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
       command: [bash]
       source: |
         echo "Creating feeder database for influx for project {{project_name}}" \
@@ -322,7 +322,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
       command: [bash]
       source: |
         echo "Creating grafana influxdb and postgres datasources for project {{project_name}}" \
@@ -500,7 +500,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
       command: [bash]
       source: |
         echo "Feeding sql with metadata for project {{project_name}} using source ur http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/ and postgres url gordo-postgres-$PROJECT_NAME " \
@@ -537,7 +537,7 @@ spec:
       - name: data-provider
       - name: evaluation-config
     container:
-      image: auroradevacr.azurecr.io/gordo-components/gordo-model-builder:{{gordo_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-model-builder:{{gordo_version}}
       env:
       - name: OUTPUT_DIR
         value: "/gordo/models/{{project_name}}/{{project_version}}/{{'{{inputs.parameters.model-name}}'}}"
@@ -728,7 +728,7 @@ spec:
                 app: "{{'{{inputs.parameters.host-name}}'}}"
             spec:
               containers:
-                 - image: "auroradevacr.azurecr.io/gordo-components/gordo-model-server:{{gordo_version}}"
+                 - image: "{{ docker_registry }}/{{ docker_repository }}/gordo-model-server:{{gordo_version}}"
                    imagePullPolicy: "IfNotPresent"
                    name: "gordoserver-{{ project_name }}"
                    volumeMounts:
@@ -866,7 +866,7 @@ spec:
         applications.gordo.equinor.com/project-name: "{{project_name}}"
         applications.gordo.equinor.com/project-version: "{{project_version}}"
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{gordo_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Waiting until there is less than $GORDO_MAX_CLIENTS instances of gordo client for project_name: $GORDO_PROJECT_NAME, project-version=$GORDO_PROJECT_VERSION"
@@ -924,7 +924,7 @@ spec:
         applications.gordo.equinor.com/project-name: "{{project_name}}"
         applications.gordo.equinor.com/project-version: "{{project_version}}"
     script:
-      image: auroradevacr.azurecr.io/gordo-components/gordo-model-builder:{{gordo_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-model-builder:{{gordo_version}}
       command: [bash]
       source: |
         echo "Starting client prediction for machine $GORDO_CLIENT_TARGET" \
@@ -1040,7 +1040,7 @@ spec:
                 app: "gordo-watchman-{{project_name}}"
             spec:
               containers:
-                 - image: "auroradevacr.azurecr.io/gordo-components/gordo-watchman:{{gordo_version}}"
+                 - image: "{{ docker_registry }}/{{ docker_repository }}/gordo-watchman:{{gordo_version}}"
                    imagePullPolicy: "IfNotPresent"
                    name: "gordo-watchman-{{project_name}}"
                    ports:
@@ -1083,7 +1083,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{gordo_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Deleting influx, grafana and PVC for {{project_name}} different than {{project_version}}" \
@@ -1104,7 +1104,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{gordo_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Deleting postgres PVC for {{project_name}} different than {{project_version}}" \
@@ -1122,7 +1122,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy:{{gordo_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Deleting gordo deployments and services for project {{project_name}} different than {{project_version}}" \


### PR DESCRIPTION
Problem :credit_card: 
---
It is currently not possible to parametrize where the images are pulled from. ie. If someone (us) makes images available on, say, Dockerhub, we can't choose to use them if deploying on something like minikube or somewhere which we cannot access our azure images.

Solution :moneybag: 
---
Add ability in workflow generator CLI to specify the image registry and repository to pull from.