### PR TITLE
Workflow server after ensure single wf

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1177,6 +1177,8 @@ spec:
             parameters:
               - name: host-name
                 value: "ml-server-{{ project_name }}"
+          dependencies:
+            - ensure-single-workflow
         {% for machine in machines %}
         {% if machine.runtime["influx"]["enable"] %}
         - name: gordo-client-{{machine.name}}

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1149,6 +1149,7 @@ spec:
 
           dependencies:
             - watchman
+            - ml-server
         {% endfor %}
         - name: postgres-cleanup
           template: postgres-cleanup


### PR DESCRIPTION
This closes #571

It also sets the ml-server as a dependency for the model-building. This ensures that before we start building all the models we have watchman and the server up, which is probably a good idea so we dont risk using all the resources to such a degree that the ml-server dont get to start. 