### PR TITLE
Add MLflow logging to model builder

### DIFF
--- a/gordo_components/builder/local_build.py
+++ b/gordo_components/builder/local_build.py
@@ -10,10 +10,11 @@ from gordo_components.workflow.workflow_generator.workflow_generator import (
     get_dict_from_yaml,
 )
 from gordo_components.builder import ModelBuilder
+from gordo_components.builder.mlflow_utils import mlflow_context, log_metadata
 
 
 def local_build(
-    config_str: str, enable_remote_logging: bool = True, workspace_kwargs: dict = {}
+    config_str: str, enable_mlflow: bool = True, workspace_kwargs: dict = {}
 ) -> Iterable[Tuple[Union[BaseEstimator, None], dict]]:
     """
     Build model(s) from a bare Gordo config file locally.
@@ -77,10 +78,20 @@ def local_build(
     config = get_dict_from_yaml(io.StringIO(config_str))
     normed = NormalizedConfig(config, project_name="local-build")
     for machine in normed.machines:
-        yield ModelBuilder(
+        model, metadata = ModelBuilder(
             name=machine.name,
             model_config=machine.model,
             data_config=machine.dataset.to_dict(),
             metadata=machine.metadata,
             evaluation_config=machine.evaluation,
-        )._build()
+        ).build()
+
+        if enable_mlflow:
+            # This will enforce a single interactive login and automatically
+            # generate a new key for each model built
+            with mlflow_context(
+                name=machine.name, workspace_kwargs=workspace_kwargs
+            ) as (mlflow_client, run_id):
+                log_metadata(mlflow_client, run_id, metadata)
+
+        yield model, metadata

--- a/gordo_components/builder/local_build.py
+++ b/gordo_components/builder/local_build.py
@@ -12,7 +12,9 @@ from gordo_components.workflow.workflow_generator.workflow_generator import (
 from gordo_components.builder import ModelBuilder
 
 
-def local_build(config_str: str) -> Iterable[Tuple[Union[BaseEstimator, None], dict]]:
+def local_build(
+    config_str: str, enable_remote_logging: bool = True, workspace_kwargs: dict = {}
+) -> Iterable[Tuple[Union[BaseEstimator, None], dict]]:
     """
     Build model(s) from a bare Gordo config file locally.
 
@@ -25,6 +27,15 @@ def local_build(config_str: str) -> Iterable[Tuple[Union[BaseEstimator, None], d
     ----------
     config_str: str
         The raw yaml config file in string format.
+    enable_mlflow: bool
+        Flag to enable Mlflow logging of model building results. With `enable_mlflow`
+        set to `True`, passing `workspace_kwargs` an empty dict (default) will result in
+        local MLflow logging, while passing a dict of keyword arguments as defined in
+        :func:`~gordo_components.builder.mlflow_utils.get_mlflow_client` will result in
+        remote logging.
+    workspace_kwargs: dict
+        AzureML Workspace configuration to use for remote MLFlow tracking. See
+        :func:`gordo_components.builder.azure_utils.get_mlflow_client`.
 
     Examples
     --------
@@ -55,7 +66,7 @@ def local_build(config_str: str) -> Iterable[Tuple[Union[BaseEstimator, None], d
     ...                     estimator: sklearn.linear_model.base.LinearRegression
     ...         name: crazy-sweet-name
     ... '''
-    >>> models_n_metadata = local_build(config)
+    >>> models_n_metadata = local_build(config, enable_mlflow=False)
     >>> assert len(list(models_n_metadata)) == 1
 
     Returns

--- a/gordo_components/builder/mlflow_utils.py
+++ b/gordo_components/builder/mlflow_utils.py
@@ -1,0 +1,490 @@
+from contextlib import contextmanager
+from datetime import datetime
+import json
+import logging
+import os
+import tempfile
+from typing import List
+from uuid import uuid4
+
+from azureml.core import Workspace
+from azureml.core.authentication import (
+    InteractiveLoginAuthentication,
+    ServicePrincipalAuthentication,
+)
+from mlflow.entities import Metric, Param
+from mlflow.tracking import MlflowClient
+from pytz import UTC
+
+from gordo_components.dataset.sensor_tag import normalize_sensor_tags
+
+logger = logging.getLogger(__name__)
+
+
+class MlflowLoggingError(ValueError):
+    pass
+
+
+def _validate_dict(d: dict, required_keys: List[str]):
+    """
+    Validate the required keys are contained in provided dictionary
+
+    Parameters
+    ----------
+    d: dict
+        Dictionary to validate.
+    required_keys: List[str]
+        Keys that must be present in provided dictionary.
+    """
+    if any([key not in d for key in required_keys]):
+        raise MlflowLoggingError(
+            f"Required keys for this dictionary include {', '.join(required_keys)}."
+        )
+
+
+def get_mlflow_client(
+    workspace_kwargs: dict = {}, service_principal_kwargs: dict = {}
+) -> MlflowClient:
+    """
+    Set remote tracking URI for mlflow to AzureML workspace
+
+    Parameters
+    ----------
+    workspace_kwargs: dict
+        AzureML Workspace configuration to use for remote MLFlow tracking. An
+        empty dict will result in local logging by the MlflowClient.
+        Example::
+
+            `{
+                 "subscription_id":<value>,
+                 "resource_group":<value>,
+                 "workspace_name":<value>
+             }`
+    service_principal_kwargs: dict
+        AzureML ServicePrincipalAuthentication keyword arguments. An empty dict
+        will result in interactive authentication.
+        Example::
+
+            `{
+                 "tenant_id":<value>,
+                 "service_principal_id":<value>,
+                 "service_principal_password":<value>
+             }`
+
+    Returns
+    -------
+    client: mlflow.tracking.MlflowClient
+        Client with tracking uri set to AzureML if configured.
+    """
+    logger.info("Creating MLflow tracking client.")
+
+    tracking_uri = None
+
+    # Get AzureML tracking_uri if using Azure as backend
+    if workspace_kwargs:
+        required_keys = ["subscription_id", "resource_group", "workspace_name"]
+        _validate_dict(workspace_kwargs, required_keys)
+
+        msg = "Configuring AzureML backend with {auth_type} authentication."
+        if service_principal_kwargs:
+            required_keys = [
+                "tenant_id",
+                "service_principal_id",
+                "service_principal_password",
+            ]
+            _validate_dict(service_principal_kwargs, required_keys)
+
+            logger.info(msg.format(auth_type="ServicePrincipalAuthentication"))
+            workspace_kwargs["auth"] = ServicePrincipalAuthentication(
+                **service_principal_kwargs
+            )
+        else:
+            logger.info(msg.format(auth_type="interactive"))
+            workspace_kwargs["auth"] = InteractiveLoginAuthentication(force=True)
+
+        tracking_uri = Workspace(**workspace_kwargs).get_mlflow_tracking_uri()
+
+    return MlflowClient(tracking_uri)
+
+
+def get_run_id(client: MlflowClient, experiment_name: str, model_key: str) -> str:
+    """
+    Get an existing or create a new run for the given model_key and experiment_name.
+
+    The model key corresponds to a unique configuration of the model. The corresponding
+    run must be manually stopped using the `mlflow.tracking.MlflowClient.set_terminated`
+    method.
+
+    Parameters
+    ----------
+    client: mlflow.tracking.MlflowClient
+        Client with tracking uri set to AzureML if configured.
+    experiment_name: str
+        Name of experiment to log to.
+    model_key: str
+        Unique ID of model configuration.
+
+    Returns
+    -------
+    run_id: str
+        Unique ID of MLflow run to log to.
+    """
+    experiment = client.get_experiment_by_name(experiment_name)
+
+    experiment_id = (
+        getattr(experiment, "experiment_id")
+        if experiment
+        else client.create_experiment(experiment_name)
+    )
+
+    return client.create_run(experiment_id, tags={"model_key": model_key}).info.run_id
+
+
+def _datetime_to_ms_since_epoch(dt: datetime) -> int:
+    """
+    Convert datetime to milliseconds since Unix epoch (UTC)
+
+    Parameters
+    ----------
+    dt: datetime.datetime
+        Timestamp to convert (can be timezone aware or naive).
+
+    Returns
+    -------
+    dt: int
+        Timestamp as milliseconds since Unix epoch
+
+    Example
+    -------
+    >>> dt = datetime(1970, 1, 1, 0, 0)
+    >>> _datetime_to_ms_since_epoch(dt)
+    0
+    """
+    epoch = datetime.utcfromtimestamp(0).replace(tzinfo=dt.tzinfo)
+    dt = dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=dt.tzinfo)
+    return round((dt - epoch).total_seconds() * 1000.0)
+
+
+def epoch_now() -> int:
+    """
+    Get current timestamp in UTC as milliseconds since Unix epoch.
+
+    Returns
+    -------
+    now: int
+        Milliseconds since Unix epoch.
+    """
+    return _datetime_to_ms_since_epoch(datetime.now(tz=UTC))
+
+
+def get_params(d: dict, keys: List[str]) -> List[Param]:
+    """
+    Extract list of keys and their values from a dictionary as MLflow Params
+
+    Parameters
+    ----------
+    d: dict
+        Dictionary to extract key, value pairs from.
+    keys: List[str]
+        List of keys to extract.
+
+    Returns
+    -------
+    param_list: List[Param]
+        List of extracted key, value pairs stored as `mlflow.entities.Param`s.
+    """
+    param_list: List[Param] = list()
+    for k in keys:
+        if k in d:
+            param_list.append(
+                Param(k, d[k].isoformat() if type(d[k]) is datetime else str(d[k]))
+            )
+    return param_list
+
+
+def get_metrics(d: dict, keys: List[str]) -> List[Metric]:
+    """
+    Extract list of keys and their values from a dictionary as MLflow Metrics
+
+    Parameters
+    ----------
+    d: dict
+        Dictionary to extract key, value pairs from.
+    keys: List[str]
+        List of keys to extract.
+
+    Returns
+    -------
+    param_list: List[Metric]
+        List of extracted key, value pairs stored as `mlflow.entities.Metric`s.
+    """
+    return [Metric(k, float(d[k]), epoch_now(), 0) for k in keys if k in d]
+
+
+def get_batch_kwargs(metadata: dict) -> dict:
+    """
+    Create flat lists of MLflow logging entities from multilevel dictionary
+
+    For more information, see the mlflow docs:
+    https://www.mlflow.org/docs/latest/python_api/mlflow.tracking.html#mlflow.tracking.MlflowClient.log_batch
+
+    Parameters
+    ----------
+    metadata: dict
+        Multi-level dictionary with (key, value) loggables to parse.
+
+    Returns
+    -------
+    batch_kwargs: dict
+        Dict with `metrics` and `param_list` lists for passing to
+        `mlflow.tracking.MlflowClient.log_batch`. The metrics key contains a list of
+        Mlflow `Metric` instances, and the param_list key contains a list of `Param`
+        instances.
+    """
+
+    param_list = get_params(metadata, ["project-name", "name"])
+
+    dataset_keys = [
+        "train_start_date",
+        "train_end_date",
+        "resolution",
+        "filter",
+        "row_filter_buffer_size",
+    ]
+    model_keys = ["model-creation-date", "model-builder-version", "model-offset"]
+    for section, keys in zip(["dataset", "model"], [dataset_keys, model_keys]):
+        param_list += get_params(metadata[section], keys)
+
+    metric_list: List[Metric] = list()
+
+    # Parse cross-validation metrics
+    if metadata["model"].get("cross-validation", {}).get("scores", None):
+        scores = metadata["model"]["cross-validation"]["scores"]
+        keys = sorted(list(scores.keys()))
+        subkeys = ["mean", "max", "min", "std"]
+
+        n_folds = len(scores[keys[0]]) - len(subkeys)
+        tag_list = normalize_sensor_tags(metadata["dataset"]["tag_list"])
+        for k in keys:
+            # Skip per tag data, produces too many params for MLflow
+            if any([t.name in k for t in tag_list]):
+                continue
+
+            # Summary stats per metric
+            for sk in subkeys:
+                metric_list.append(
+                    Metric(f"{k}_{sk}", scores[k][f"fold-{sk}"], epoch_now(), 0)
+                )
+            # Append value for each fold with increasing steps
+            metric_list += [
+                Metric(k, scores[k][f"fold-{i+1}"], epoch_now(), i)
+                for i in range(n_folds)
+            ]
+
+    # Parse fit metrics
+    if metadata["model"].get("history", None):
+        meta_params = metadata["model"]["history"]["params"]
+
+        metric_list += get_metrics(
+            metadata["model"],
+            ["data-query-duration-sec", "model-training-duration-sec"],
+        )
+        param_list += get_params(
+            meta_params, [p for p in meta_params if p != "metrics"]
+        )
+        for m in meta_params["metrics"]:
+            data = metadata["model"]["history"][m]
+            metric_list += [
+                Metric(m, float(x), timestamp=epoch_now(), step=i)
+                for i, x in enumerate(data)
+            ]
+
+    return {"metrics": metric_list, "params": param_list}
+
+
+def get_kwargs_from_secret(name: str, keys: List[str]) -> dict:
+    """
+    Get keyword arguments dictionary from secrets environment variable
+
+    Parameters
+    ----------
+    name: str
+        Name of the environment variable whose content is a colon separated
+        list of secrets.
+
+    Returns
+    -------
+    kwargs: dict
+        Dictionary of keyword arguments parsed from environment variable.
+    """
+    secret_str = os.getenv(name)
+
+    if secret_str is None:
+        raise MlflowLoggingError(f"The value for env var '{name}' must not be `None`.")
+
+    if secret_str:
+        elements = secret_str.split(":")
+        if len(elements) != len(keys):
+            raise MlflowLoggingError(
+                "`keys` len {len(keys)} must be of equal length with env var {name} elements {len(elements)}."
+            )
+        kwargs = {key: elements[i] for i, key in enumerate(keys)}
+    else:
+        kwargs = {}
+
+    return kwargs
+
+
+def get_workspace_kwargs() -> dict:
+    """Get AzureML keyword arguments from environment
+
+    The name of this environment variable is set in the Argo workflow template,
+    and its value should be in the format:
+    `<subscription_id>:<resource_group>:<workspace_name>`.
+
+    Returns
+    -------
+    workspace_kwargs: dict
+        AzureML Workspace configuration to use for remote MLFlow tracking. See
+        :func:`gordo_components.builder.mlflow_utils.get_mlflow_client`.
+    """
+    return get_kwargs_from_secret(
+        "AZUREML_WORKSPACE_STR", ["subscription_id", "resource_group", "workspace_name"]
+    )
+
+
+def get_spauth_kwargs() -> dict:
+    """Get AzureML keyword arguments from environment
+
+    The name of this environment variable is set in the Argo workflow template,
+    and its value should be in the format:
+    `<tenant_id>:<service_principal_id>:<service_principal_password>`
+
+    Returns
+    -------
+    service_principal_kwargs: dict
+        AzureML ServicePrincipalAuthentication keyword arguments. See
+        :func:`gordo_components.builder.mlflow_utils.get_mlflow_client`
+    """
+    return get_kwargs_from_secret(
+        "DL_SERVICE_AUTH_STR",
+        ["tenant_id", "service_principal_id", "service_principal_password"],
+    )
+
+
+class DatetimeEncoder(json.JSONEncoder):
+    """
+    Encode datetime.datetime objects as strings
+
+    Example
+    -------
+    >>> s = json.dumps({"now":datetime.now(tz=UTC)}, cls=DatetimeEncoder, indent=4)
+    >>> s = '{"now": "2019-11-22 08:34:41.636356+"}'
+    """
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.strftime("%Y-%m-%d %H:%M:%S.%f+%z")
+        else:
+            return json.JSONEncoder.default(self, obj)
+
+
+def send_artifacts(client: MlflowClient, run_id: str, metadata: dict):
+    """
+    Send artifacts
+
+    Parameters
+    ----------
+    client: MlflowClient
+        MLflow tracking client.
+    run_id: str
+        MLflow Run ID.
+    metadata: dict
+        Metadata produced by :func:`~gordo_components.builder.build_model.build_model`
+        to extract configs from.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for name, obj in [
+            ("model-config", metadata["model"]["model-config"]),
+            ("dataset-config", metadata["dataset"]),
+            ("user-config", metadata["user-defined"]),
+        ]:
+            fp = os.path.join(tmp_dir, f"{name}.json")
+            json.dump(obj, open(fp, "w"), cls=DatetimeEncoder)
+        client.log_artifacts(run_id, local_dir=tmp_dir)
+
+
+@contextmanager
+def mlflow_context(
+    name: str,
+    model_key: str = uuid4().hex,
+    workspace_kwargs: dict = {},
+    service_principal_kwargs: dict = {},
+):
+    """
+    Generate MLflow logger function with either a local or AzureML backend
+
+    Parameters
+    ----------
+    name: str
+        The name of the log group to log to (e.g. a model name).
+    model_key: str
+        Unique ID of logging run.
+    workspace_kwargs: dict
+        AzureML Workspace configuration to use for remote MLFlow tracking. See
+        :func:`gordo_components.builder.mlflow_utils.get_mlflow_client`.
+    service_principal_kwargs: dict
+        AzureML ServicePrincipalAuthentication keyword arguments. See
+        :func:`gordo_components.builder.mlflow_utils.get_mlflow_client`
+
+    Example
+    -------
+    >>> with tempfile.TemporaryDirectory as tmp_dir:
+    ...     mlflow.set_tracking_uri(f"file:{tmp_dir}")
+    ...     with mlflow_context("log_group", "unique_key", {}, {}) as (mlflow_client, run_id):
+    ...         log_metadata(metadata) # doctest: +SKIP
+    """
+    mlflow_client = get_mlflow_client(workspace_kwargs, service_principal_kwargs)
+    run_id = get_run_id(mlflow_client, experiment_name=name, model_key=model_key)
+
+    logger.info(
+        f"MLflow client configured to use {'AzureML' if workspace_kwargs else 'local backend'}"
+    )
+
+    yield mlflow_client, run_id
+
+    mlflow_client.set_terminated(run_id)
+
+
+def log_metadata(mlflow_client, run_id, metadata: dict):
+    """
+    Send logs to configured MLflow backend
+
+    Parameters
+    ----------
+    mlflow_client: MlflowClient
+        Client instance to call logging methods from.
+    run_id: str
+        Unique ID off MLflow Run to log to.
+    metadata: dict
+        Dictionary to log with MlflowClient.
+    """
+    # Log params and metrics
+    mlflow_client.log_batch(run_id, **get_batch_kwargs(metadata))
+
+    # Send configs as JSON artifacts
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for name, obj in [
+                ("model-config", metadata["model"]["model-config"]),
+                ("dataset-config", metadata["dataset"]),
+                ("user-config", metadata["user-defined"]),
+            ]:
+                fp = os.path.join(tmp_dir, f"{name}.json")
+                json.dump(obj, open(fp, "w"), cls=DatetimeEncoder)
+            mlflow_client.log_artifacts(run_id, local_dir=tmp_dir)
+    # Log error without exiting the build
+    # FIX: when a solution is found when logging artifacts wit azureml lib,
+    # this can raise an error
+    except Exception as e:
+        logger.error(e)

--- a/gordo_components/workflow/config_elements/normalized_config.py
+++ b/gordo_components/workflow/config_elements/normalized_config.py
@@ -35,7 +35,8 @@ class NormalizedConfig:
                 "resources": {
                     "requests": {"memory": 3900, "cpu": 1001},
                     "limits": {"memory": 3900, "cpu": 1001},
-                }
+                },
+                "remote_logging": {"enable": False},
             },
             "client": {
                 "resources": {

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1357,8 +1357,7 @@ spec:
                 value: |
                   {{ machine.evaluation | tojson}}
               - name: enable-remote-logging
-                value: |
-                  {{ machine.runtime.builder.remote_logging.enable }}
+                value: {{ machine.runtime.builder.remote_logging.enable }}
           dependencies:
             - watchman
             - gordo-server

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -631,12 +631,14 @@ spec:
         applications.gordo.equinor.com/project-version: "{{project_version}}"
     inputs:
       parameters:
+      - name: project-name
       - name: model-name
       - name: metadata
       - name: model-config
       - name: data-config
       - name: data-provider
       - name: evaluation-config
+      - name: enable-remote-logging
     container:
       image: {{ docker_registry }}/{{ docker_repository }}/gordo-model-builder:{{gordo_version}}
       env:
@@ -644,6 +646,8 @@ spec:
         value: "/gordo/models/{{project_name}}/{{project_version}}/{{'{{inputs.parameters.model-name}}'}}"
       - name: MODEL_REGISTER_DIR
         value: "/gordo/models/{{project_name}}/model_register"
+      - name: PROJECT_NAME
+        value: "{{ project_name }}"
       - name: MODEL_NAME
         value: {{ '"{{inputs.parameters.model-name}}" '}}
       - name: METADATA
@@ -661,6 +665,13 @@ spec:
         value: {{ '"{{inputs.parameters.data-provider}}"' }}
       - name: EVALUATION_CONFIG
         value: {{ '"{{inputs.parameters.evaluation-config}}"' }}
+      - name: ENABLE_REMOTE_LOGGING
+        value: {{ '"{{inputs.parameters.enable-remote-logging}}"' | capitalize }}
+      - name: AZUREML_WORKSPACE_STR
+        valueFrom:
+          configMapKeyRef:
+            name: gordo-components-config-map
+            key: azureml_workspace_str
       volumeMounts:
       - name: azurefile
         mountPath: /gordo
@@ -1326,6 +1337,8 @@ spec:
           template: model-builder
           arguments:
             parameters:
+              - name: project-name
+                value: "{{ project_name }}"
               - name: model-name
                 value: "{{ machine.name }}"
               - name: model-config
@@ -1343,6 +1356,9 @@ spec:
               - name: evaluation-config
                 value: |
                   {{ machine.evaluation | tojson}}
+              - name: enable-remote-logging
+                value: |
+                  {{ machine.runtime.builder.remote_logging.enable }}
           dependencies:
             - watchman
             - gordo-server

--- a/requirements.in
+++ b/requirements.in
@@ -27,3 +27,5 @@ simplejson~=3.17
 gevent~=1.4
 catboost~=0.20
 typing_extensions~=3.7
+mlflow~=1.4.0
+azureml-contrib-run~=1.0.69

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,84 +4,130 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-absl-py==0.8.1            # via tensorflow
-adal==1.2.2               # via azure-datalake-store
+absl-py==0.8.1            # via tensorboard, tensorflow
+adal==1.2.2               # via azure-datalake-store, azureml-core, msrestazure
+alembic==1.3.1            # via mlflow
 aniso8601==8.0.0          # via flask-restplus
 apscheduler==3.6.3
 astor==0.8.0              # via tensorflow
 attrs==19.3.0             # via jsonschema
+azure-common==1.1.23      # via azure-graphrbac, azure-mgmt-authorization, azure-mgmt-containerregistry, azure-mgmt-keyvault, azure-mgmt-resource, azure-mgmt-storage, azureml-core
 azure-datalake-store==0.0.48
+azure-graphrbac==0.61.1   # via azureml-core
+azure-mgmt-authorization==0.60.0  # via azureml-core
+azure-mgmt-containerregistry==2.8.0  # via azureml-core
+azure-mgmt-keyvault==2.0.0  # via azureml-core
+azure-mgmt-resource==6.0.0  # via azureml-core
+azure-mgmt-storage==6.0.0  # via azureml-core
+azureml-contrib-run==1.0.76
+azureml-core==1.0.76      # via azureml-mlflow
+azureml-mlflow==1.0.76    # via azureml-contrib-run
+backports.tempfile==1.0   # via azureml-core
+backports.weakref==1.0.post1  # via backports.tempfile
 cachetools==3.1.1
 catboost==0.20
 cchardet==2.1.5
-certifi==2019.9.11        # via kubernetes, requests
-cffi==1.13.2              # via azure-datalake-store
+certifi==2019.11.28       # via kubernetes, msrest, requests
+cffi==1.13.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
 click==7.0
-cryptography==2.8         # via adal
+cloudpickle==1.2.2        # via mlflow
+configparser==4.0.2       # via databricks-cli
+contextlib2==0.6.0.post1  # via azureml-core
+cryptography==2.8         # via adal, azureml-core, pyopenssl, secretstorage
 cycler==0.10.0            # via matplotlib
+databricks-cli==0.9.1     # via mlflow
 dictdiffer==0.8.0
+docker==4.1.0             # via azureml-core, mlflow
+entrypoints==0.3          # via mlflow
 flask-restplus==0.13.0
 flask==1.1.1
 gast==0.2.2               # via tensorflow
 gevent==1.4.0
-google-auth==1.7.1        # via kubernetes
+gitdb2==2.0.6             # via gitpython
+gitpython==3.0.5          # via mlflow
+google-auth-oauthlib==0.4.1  # via tensorboard
+google-auth==1.7.1        # via google-auth-oauthlib, kubernetes, tensorboard
 google-pasta==0.1.8       # via tensorflow
+gorilla==0.3.0            # via mlflow
 graphviz==0.13.2          # via catboost
 greenlet==0.4.15          # via gevent
-grpcio==1.25.0            # via tensorflow
+grpcio==1.25.0            # via tensorboard, tensorflow
 gunicorn==20.0.4
 h5py==2.10.0
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via jsonschema
+importlib-metadata==1.1.0  # via jsonschema
 influxdb==5.2.3
+isodate==0.6.0            # via msrest
 itsdangerous==1.1.0       # via flask
+jeepney==0.4.1            # via secretstorage
 jinja2==2.10.3
+jmespath==0.9.4           # via azureml-core
 joblib==0.14.0            # via scikit-learn
+jsonpickle==1.2           # via azureml-core, azureml-mlflow
 jsonschema==3.2.0         # via flask-restplus
 keras-applications==1.0.8  # via tensorflow
 keras-preprocessing==1.1.0  # via tensorflow
 kiwisolver==1.1.0         # via matplotlib
 kubernetes==10.0.1
-markupsafe==1.1.1         # via jinja2
+mako==1.1.0               # via alembic
+markdown==3.1.1           # via tensorboard
+markupsafe==1.1.1         # via jinja2, mako
 matplotlib==3.1.2         # via catboost
+mlflow==1.4.0
+more-itertools==8.0.0     # via zipp
+msrest==0.6.10            # via azure-graphrbac, azure-mgmt-authorization, azure-mgmt-containerregistry, azure-mgmt-keyvault, azure-mgmt-resource, azure-mgmt-storage, azureml-core, msrestazure
+msrestazure==0.6.2        # via azure-graphrbac, azure-mgmt-authorization, azure-mgmt-containerregistry, azure-mgmt-keyvault, azure-mgmt-resource, azure-mgmt-storage, azureml-core
+ndg-httpsclient==0.5.1    # via azureml-core
 numexpr==2.7.0
 numpy==1.17.4
 oauthlib==3.1.0           # via requests-oauthlib
 opt-einsum==3.1.0         # via tensorflow
 pandas==0.25.3
+pathspec==0.6.0           # via azureml-core
 peewee==3.12.0
 plotly==4.3.0             # via catboost
-protobuf==3.10.0          # via tensorflow
+protobuf==3.11.1          # via mlflow, tensorboard, tensorflow
 psycopg2-binary==2.8.4
 pyarrow==0.15.1
 pyasn1-modules==0.2.7     # via google-auth
-pyasn1==0.4.8             # via rsa
+pyasn1==0.4.8             # via ndg-httpsclient, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pyjwt==1.7.1              # via adal
+pyjwt==1.7.1              # via adal, azureml-core
+pyopenssl==19.1.0         # via azureml-core, ndg-httpsclient
 pyparsing==2.4.5          # via matplotlib
 pyrsistent==0.15.6        # via jsonschema
 python-dateutil==2.8.1
-pytz==2019.3              # via flask-restplus, influxdb
-pyyaml==5.1.2
-requests-oauthlib==1.3.0  # via kubernetes
+python-editor==1.0.4      # via alembic
+pytz==2019.3              # via apscheduler, azureml-core, flask-restplus, influxdb, pandas, tzlocal
+pyyaml==5.2
+querystring-parser==1.2.4  # via mlflow
+requests-oauthlib==1.3.0  # via google-auth-oauthlib, kubernetes, msrest
 requests==2.22.0
 retrying==1.3.3           # via plotly
 rsa==4.0                  # via google-auth
-scikit-learn==0.21.3
+ruamel.yaml==0.15.89      # via azureml-core
+scikit-learn==0.22
 scipy==1.3.3              # via catboost, scikit-learn
+secretstorage==3.1.1      # via azureml-core
 simplejson==3.17.0
-six==1.13.0               # via catboost, flask-restplus, google-auth, google-pasta, grpcio, h5py, influxdb, jsonschema, keras-preprocessing, kubernetes, plotly, protobuf, pyrsistent, tensorflow, websocket-client
-tensorboard==2.0.1        # via tensorflow
+six==1.13.0               # via absl-py, apscheduler, azureml-core, catboost, cryptography, cycler, databricks-cli, docker, flask-restplus, google-auth, google-pasta, grpcio, h5py, influxdb, isodate, jsonschema, keras-preprocessing, kubernetes, mlflow, plotly, protobuf, pyarrow, pyopenssl, pyrsistent, python-dateutil, querystring-parser, retrying, tensorboard, tensorflow, websocket-client
+smmap2==2.0.5             # via gitdb2
+sqlalchemy==1.3.11        # via alembic, mlflow
+sqlparse==0.3.0           # via mlflow
+tabulate==0.8.6           # via databricks-cli
+tensorboard==2.0.2        # via tensorflow
 tensorflow-estimator==2.0.1  # via tensorflow
 tensorflow==2.0.0
 termcolor==1.1.0          # via tensorflow
 typing-extensions==3.7.4.1
+tzlocal==2.0.0            # via apscheduler
 urllib3==1.25.7
-websocket-client==0.56.0  # via kubernetes
-werkzeug==0.16.0          # via flask
-wheel==0.33.6             # via tensorflow
+websocket-client==0.56.0  # via docker, kubernetes
+werkzeug==0.16.0          # via flask, tensorboard
+wheel==0.33.6             # via tensorboard, tensorflow
 wrapt==1.11.2             # via tensorflow
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via google-auth, gunicorn, jsonschema, kubernetes, protobuf
+# setuptools==42.0.2        # via apscheduler, google-auth, gunicorn, jsonschema, kiwisolver, kubernetes, markdown, protobuf, tensorboard

--- a/tests/gordo_components/builder/test_local_build.py
+++ b/tests/gordo_components/builder/test_local_build.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+import mock
 
 from gordo_components.builder import local_build
 
@@ -59,7 +60,7 @@ from gordo_components.builder import local_build
     ),
 )
 def test_local_builder_valid_configs(config):
-    models_n_metadata = list(local_build(config))
+    models_n_metadata = list(local_build(config, enable_remote_logging=False))
     assert len(models_n_metadata) == 1
 
     model_n_metadata = models_n_metadata.pop()
@@ -117,4 +118,49 @@ def test_local_builder_valid_configs(config):
 )
 def test_local_builder_invalid_configs(config):
     with pytest.raises(Exception):
-        list(local_build(config))
+        list(local_build(config, enable_remote_logging=False))
+
+
+@mock.patch("gordo_components.builder.azure_utils.MlflowClient", autospec=True)
+@pytest.mark.parametrize("enable_remote_logging", [True, False])
+def test_local_builder_mlflow(MockClient, enable_remote_logging):
+    """
+    Test that logging is called when mlflow flag is enabled
+    """
+
+    config = """
+    machines:
+      - dataset:
+          tags:
+            - SOME-TAG1
+            - SOME-TAG2
+          train_end_date: '2019-03-01T00:00:00+00:00'
+          train_start_date: '2019-01-01T00:00:00+00:00'
+          asset: asgb
+          data_provider:
+            type: RandomDataProvider
+        name: crazy-sweet-name1
+      - dataset:
+          tags:
+            - SOME-TAG1
+            - SOME-TAG2
+          train_end_date: '2019-03-01T00:00:00+00:00'
+          train_start_date: '2019-01-01T00:00:00+00:00'
+          asset: asgb
+          data_provider:
+            type: RandomDataProvider
+        name: crazy-sweet-name2
+    globals:
+        model:
+          gordo_components.model.anomaly.diff.DiffBasedAnomalyDetector:
+            base_estimator:
+              sklearn.pipeline.Pipeline:
+                steps:
+                - sklearn.decomposition.pca.PCA
+                - sklearn.multioutput.MultiOutputRegressor:
+                    estimator: sklearn.linear_model.base.LinearRegression
+    """
+    n_builds = len(
+        list(local_build(config, enable_remote_logging=enable_remote_logging))
+    )
+    assert MockClient.call_count == (n_builds if enable_remote_logging else 0)

--- a/tests/gordo_components/builder/test_local_build.py
+++ b/tests/gordo_components/builder/test_local_build.py
@@ -60,7 +60,7 @@ from gordo_components.builder import local_build
     ),
 )
 def test_local_builder_valid_configs(config):
-    models_n_metadata = list(local_build(config, enable_remote_logging=False))
+    models_n_metadata = list(local_build(config, enable_mlflow=False))
     assert len(models_n_metadata) == 1
 
     model_n_metadata = models_n_metadata.pop()
@@ -118,12 +118,12 @@ def test_local_builder_valid_configs(config):
 )
 def test_local_builder_invalid_configs(config):
     with pytest.raises(Exception):
-        list(local_build(config, enable_remote_logging=False))
+        list(local_build(config, enable_mlflow=False))
 
 
-@mock.patch("gordo_components.builder.azure_utils.MlflowClient", autospec=True)
-@pytest.mark.parametrize("enable_remote_logging", [True, False])
-def test_local_builder_mlflow(MockClient, enable_remote_logging):
+@mock.patch("gordo_components.builder.mlflow_utils.MlflowClient", autospec=True)
+@pytest.mark.parametrize("enable_mlflow", [True, False])
+def test_local_builder_mlflow(MockClient, enable_mlflow):
     """
     Test that logging is called when mlflow flag is enabled
     """
@@ -160,7 +160,5 @@ def test_local_builder_mlflow(MockClient, enable_remote_logging):
                 - sklearn.multioutput.MultiOutputRegressor:
                     estimator: sklearn.linear_model.base.LinearRegression
     """
-    n_builds = len(
-        list(local_build(config, enable_remote_logging=enable_remote_logging))
-    )
-    assert MockClient.call_count == (n_builds if enable_remote_logging else 0)
+    n_builds = len(list(local_build(config, enable_mlflow=enable_mlflow)))
+    assert MockClient.call_count == (n_builds if enable_mlflow else 0)

--- a/tests/gordo_components/builder/test_mlflow_utils.py
+++ b/tests/gordo_components/builder/test_mlflow_utils.py
@@ -1,0 +1,406 @@
+from datetime import datetime
+
+import mlflow
+from mlflow.entities import Metric, Param
+import mock
+import pytest
+from pytz import UTC
+
+import gordo_components.builder.mlflow_utils as mlu
+from gordo_components.dataset.sensor_tag import SensorTag
+
+
+@pytest.fixture
+def metadata():
+    """Example metadata for testing"""
+    return {
+        "user-defined": {},
+        "name": "model-name",
+        "dataset": {
+            "tag_list": [
+                SensorTag(name="Tag 1", asset=None),
+                SensorTag(name="Tag 2", asset=None),
+            ],
+            "target_tag_list": [
+                SensorTag(name="Tag 1", asset=None),
+                SensorTag(name="Tag 2", asset=None),
+            ],
+            "train_start_date": datetime(2017, 12, 25, 6, 0, tzinfo=UTC),
+            "train_end_date": datetime(2017, 12, 30, 6, 0, tzinfo=UTC),
+            "resolution": "10T",
+            "filter": "",
+            "row_filter_buffer_size": 0,
+            "data_provider": {"type": "RandomDataProvider"},
+            "asset": None,
+        },
+        "model": {
+            "model-offset": 0,
+            "model-creation-date": "2019-11-19 10:55:19.327827+01:00",
+            "model-builder-version": "0.39.1.dev39+gee79144.d20191118",
+            "model-config": {
+                "sklearn.compose.TransformedTargetRegressor": {
+                    "regressor": {
+                        "sklearn.pipeline.Pipeline": {
+                            "steps": [
+                                "sklearn.preprocessing.data.MinMaxScaler",
+                                {
+                                    "gordo_components.model.models.KerasAutoEncoder": {
+                                        "kind": "feedforward_hourglass",
+                                        "compression_factor": 0.5,
+                                        "encoding_layers": 2,
+                                        "func": "tanh",
+                                        "out_func": "linear",
+                                        "epochs": 3,
+                                    }
+                                },
+                            ]
+                        }
+                    },
+                    "transformer": "sklearn.preprocessing.data.MinMaxScaler",
+                }
+            },
+            "data-query-duration-sec": 0.02436208724975586,
+            "model-training-duration-sec": 0.8394930362701416,
+            "cross-validation": {
+                "cv-duration-sec": 3.47721529006958,
+                "scores": {
+                    "explained-variance-score-Tag-1": {
+                        "fold-mean": 0.051862609201927645,
+                        "fold-std": 0.228637331704387,
+                        "fold-max": 0.29798892173189884,
+                        "fold-min": -0.2528015461893074,
+                        "fold-1": -0.2528015461893074,
+                        "fold-2": 0.11040045206319149,
+                        "fold-3": 0.29798892173189884,
+                    },
+                    "explained-variance-score": {
+                        "fold-mean": 0.0478112662857908,
+                        "fold-std": 0.1421360442077271,
+                        "fold-max": 0.22234102900316643,
+                        "fold-min": -0.12581624610561765,
+                        "fold-1": -0.12581624610561765,
+                        "fold-2": 0.04690901595982361,
+                        "fold-3": 0.22234102900316643,
+                    },
+                    "r2-score-Tag-1": {
+                        "fold-mean": -2.6371828429430884,
+                        "fold-std": 2.6597484998295946,
+                        "fold-max": -0.5211094268414729,
+                        "fold-min": -6.388371625565568,
+                        "fold-1": -6.388371625565568,
+                        "fold-2": -0.5211094268414729,
+                        "fold-3": -1.0020674764222246,
+                    },
+                    "r2-score": {
+                        "fold-mean": -2.666124085334415,
+                        "fold-std": 1.2640159158021866,
+                        "fold-max": -1.5855654684086353,
+                        "fold-min": -4.4396507978661095,
+                        "fold-1": -4.4396507978661095,
+                        "fold-2": -1.9731559897285007,
+                        "fold-3": -1.5855654684086353,
+                    },
+                    "mean-squared-error-Tag-1": {
+                        "fold-mean": 1.112789357356103,
+                        "fold-std": 0.7905379023062951,
+                        "fold-max": 2.209464994153014,
+                        "fold-min": 0.3762968865667915,
+                        "fold-1": 2.209464994153014,
+                        "fold-2": 0.3762968865667915,
+                        "fold-3": 0.7526061913485038,
+                    },
+                    "mean-squared-error": {
+                        "fold-mean": 1.0602699916789435,
+                        "fold-std": 0.34699786692441703,
+                        "fold-max": 1.5184574251830893,
+                        "fold-min": 0.6789938636261353,
+                        "fold-1": 1.5184574251830893,
+                        "fold-2": 0.6789938636261353,
+                        "fold-3": 0.9833586862276062,
+                    },
+                    "mean-absolute-error-Tag-1": {
+                        "fold-mean": 0.838600049984478,
+                        "fold-std": 0.37949884754447927,
+                        "fold-max": 1.3563660334402199,
+                        "fold-min": 0.45737388225784836,
+                        "fold-1": 1.3563660334402199,
+                        "fold-2": 0.45737388225784836,
+                        "fold-3": 0.702060234255366,
+                    },
+                    "mean-absolute-error": {
+                        "fold-mean": 0.8507839848911773,
+                        "fold-std": 0.16306138711492707,
+                        "fold-max": 1.0627475252183525,
+                        "fold-min": 0.6661439848292272,
+                        "fold-1": 1.0627475252183525,
+                        "fold-2": 0.6661439848292272,
+                        "fold-3": 0.8234604446259526,
+                    },
+                },
+            },
+            "history": {
+                "loss": [0.2504836615532805, 0.195994034409523, 0.16305454268967365],
+                "accuracy": [0.56497175, 0.53107345, 0.53107345],
+                "params": {
+                    "batch_size": 32,
+                    "epochs": 3,
+                    "steps": 23,
+                    "samples": 708,
+                    "verbose": 0,
+                    "do_validation": False,
+                    "metrics": ["loss", "accuracy"],
+                },
+            },
+        },
+    }
+
+
+def test_validate_dict():
+    """
+    Test that error is raised when a key is missing from the passed dictionary
+    """
+    required_keys = ["a", "b", "c"]
+    # All keys present passes
+    assert mlu._validate_dict({"a": 1, "b": 2, "c": 3}, required_keys) is None
+    # Key missing fails
+    with pytest.raises(ValueError):
+        mlu._validate_dict({"a": 1, "b": 2}, required_keys)
+
+
+@pytest.mark.parametrize(
+    "workspace_kwargs,service_principal_kwargs,n_interactive,n_spauth,n_get_uri",
+    [
+        # Empty config, local MLflow
+        ({}, {}, 0, 0, 0),
+        # Config with no auth, Azure Interactive Login
+        (
+            {
+                "subscription_id": "dummy",
+                "resource_group": "dummy",
+                "workspace_name": "dummy",
+            },
+            {},
+            1,
+            0,
+            1,
+        ),
+        # Config with auth, Azure ServicePrincipal Auth
+        (
+            {
+                "subscription_id": "dummy",
+                "resource_group": "dummy",
+                "workspace_name": "dummy",
+            },
+            {
+                "tenant_id": "dummy",
+                "service_principal_id": "dummy",
+                "service_principal_password": "dummy",
+            },
+            0,
+            1,
+            1,
+        ),
+    ],
+)
+def test_get_mlflow_client(
+    workspace_kwargs, service_principal_kwargs, n_interactive, n_spauth, n_get_uri
+):
+    """
+    Test that external methods are called correctly given different configurations
+    """
+
+    with mock.patch(
+        "gordo_components.builder.mlflow_utils.Workspace"
+    ) as MockWorkspace, mock.patch(
+        "gordo_components.builder.mlflow_utils.InteractiveLoginAuthentication"
+    ) as MockInteractiveAuth, mock.patch(
+        "gordo_components.builder.mlflow_utils.ServicePrincipalAuthentication"
+    ) as MockSPAuth, mock.patch(
+        "gordo_components.builder.mlflow_utils.MlflowClient"
+    ) as MockClient:
+        MockInteractiveAuth.return_value = True
+        MockWorkspace.return_value.get_mlflow_tracking_uri.return_value = "test_uri"
+        mlu.get_mlflow_client(workspace_kwargs, service_principal_kwargs)
+        assert MockInteractiveAuth.call_count == n_interactive
+        assert MockSPAuth.call_count == n_spauth
+        assert MockWorkspace.call_count == n_get_uri
+        assert MockClient.called_once()
+
+
+@mock.patch("gordo_components.builder.mlflow_utils.InteractiveLoginAuthentication")
+@mock.patch("gordo_components.builder.mlflow_utils.Workspace")
+@mock.patch("gordo_components.builder.mlflow_utils.MlflowClient")
+def test_get_mlflow_client_config(MockClient, MockWorkspace, MockInteractiveLogin):
+    """
+    Test that error is raised with incomplete kwargs
+    """
+    # Incomplete workspace kwargs
+    with pytest.raises(ValueError):
+        mlu.get_mlflow_client(
+            {"subscription_id": "dummy", "workspace_name": "dummy"}, {}
+        )
+
+    # Incomplete service principal kwargs
+    with pytest.raises(ValueError):
+        mlu.get_mlflow_client(
+            {
+                "subscription_id": "dummy",
+                "resource_group": "dummy",
+                "workspace_name": "dummy",
+            },
+            {"tenant_id": "dummy", "service_principal_password": "dummy"},
+        )
+
+
+@mock.patch("gordo_components.builder.mlflow_utils.MlflowClient.get_experiment_by_name")
+@mock.patch("gordo_components.builder.mlflow_utils.MlflowClient.create_experiment")
+@mock.patch("gordo_components.builder.mlflow_utils.MlflowClient.create_run")
+def test_get_run_id_external_calls(
+    mock_create_run, mock_create_experiment, mock_get_experiment, tmp_dir
+):
+    """
+    Test logic for creating an experiment if it does not exist to create new runs
+    """
+
+    class MockRunInfo:
+        def __init__(self, run_id):
+            self.run_id = run_id
+
+    class MockRun:
+        def __init__(self, run_id):
+            self.info = MockRunInfo(run_id)
+
+    class MockExperiment:
+        def __init__(self, experiment_id):
+            self.experiment_id = experiment_id
+
+    def _test_calls(test_run_id, n_create_exp, n_create_run):
+        """Test that number of calls match those specified"""
+        run_id = mlu.get_run_id(client, experiment_name, model_key)
+        assert mock_get_experiment.call_count == 1
+        assert mock_create_experiment.call_count == n_create_exp
+        assert mock_create_run.call_count == n_create_run
+        assert run_id == test_run_id
+
+    # Dummy test name/IDs
+    experiment_name = "test_experiment"
+    test_experiment_id = "dummy_exp_id"
+    test_run_id = "dummy_run_id"
+    model_key = "dummy_model_key"
+
+    mlflow.set_tracking_uri(f"file:{tmp_dir}")
+    client = mlu.MlflowClient()
+
+    # Experiment exists
+    # Create a run with existing experiment_id
+    mock_get_experiment.return_value = MockExperiment(test_experiment_id)
+    mock_create_experiment.return_value = MockExperiment(test_experiment_id)
+    mock_create_run.return_value = MockRun(test_run_id)
+    _test_calls(test_run_id, n_create_exp=0, n_create_run=1)
+
+    # Reset call counts
+    for m in [mock_get_experiment, mock_create_experiment, mock_create_run]:
+        m.call_count = 0
+
+    # Experiment doesn't exist
+    # Create an experiment and use its ID to create a run
+    mock_get_experiment.return_value = None
+    mock_create_experiment.return_value = MockExperiment(test_experiment_id)
+    mock_create_run.return_value = MockRun(test_run_id)
+    _test_calls(test_run_id, n_create_exp=1, n_create_run=1)
+
+
+@pytest.mark.parametrize(
+    "x,expected",
+    [
+        (datetime(1970, 1, 1), 0),
+        (datetime(1970, 1, 1, 0, 0, 1), 1000),
+        (datetime(1970, 1, 1, 0, 0, 0, 1000), 1),
+    ],
+)
+def test_datetime_to_ms_since_epoch(x, expected):
+    """
+    Test that datetime is correctly converted to ms since Unix epoch
+    """
+    assert mlu._datetime_to_ms_since_epoch(x) == expected
+
+
+def test_get_batch_kwargs(metadata):
+    """
+    Test that dicts are correctly converted to MLflow types or errors raised
+    """
+
+    def _test_convert_metadata(metadata):
+        batch_kwargs = mlu.get_batch_kwargs(metadata)
+
+        assert all(type(m) == Metric for m in batch_kwargs["metrics"])
+        assert all(type(p) == Param for p in batch_kwargs["params"])
+
+    # With cross validation and metric scores
+    _test_convert_metadata(metadata)
+
+    # With cross validation, no scores
+    metadata["model"]["cross-validation"].pop("scores")
+    _test_convert_metadata(metadata)
+
+    # no cross validation or scores
+    metadata["model"].pop("cross-validation")
+    _test_convert_metadata(metadata)
+
+
+@pytest.mark.parametrize(
+    "secret_str,keys,keys_valid",
+    [
+        ("dummy1:dummy2:dummy3", ["key1", "key2", "key3"], True),
+        ("dummy1:dummy2:dummy3", ["key1", "key2"], False),
+    ],
+)
+def test_get_kwargs_from_secret(monkeypatch, secret_str, keys, keys_valid):
+    """
+    Test that service principal kwargs are generated correctly if env var present
+    """
+    env_var_name = "TEST_SECRET"
+
+    # TEST_SECRET doesn't exist as env var
+    with pytest.raises(ValueError):
+        mlu.get_kwargs_from_secret(env_var_name, keys)
+
+    # TEST_SECRET exists as env var
+    monkeypatch.setenv(name=env_var_name, value=secret_str)
+    if keys_valid:
+        kwargs = mlu.get_kwargs_from_secret(env_var_name, keys)
+        for key, value in zip(keys, secret_str.split(":")):
+            assert kwargs[key] == value
+    else:
+        with pytest.raises(ValueError):
+            mlu.get_kwargs_from_secret(env_var_name, keys)
+
+
+def test_workspace_spauth_kwargs():
+    """Make sure an error is thrown when env vars not set"""
+    with pytest.raises(ValueError):
+        mlu.get_workspace_kwargs()
+
+    with pytest.raises(ValueError):
+        mlu.get_spauth_kwargs()
+
+
+@mock.patch("gordo_components.builder.mlflow_utils.MlflowClient", autospec=True)
+def test_mlflow_context_log_metadata(MockClient, tmp_dir, recwarn, metadata):
+    """
+    Test that call to wrapped function initiates MLflow logging or throws warning
+    """
+
+    mlflow.set_tracking_uri(f"file:{tmp_dir}")
+
+    mock_client = MockClient()
+    mock_client.log_batch.return_value = "test"
+
+    # Function with a metadata dict returned
+    with mlu.mlflow_context("returns metadata", "unique_key", {}, {}) as (
+        mlflow_client,
+        run_id,
+    ):
+        mlu.log_metadata(mlflow_client, run_id, metadata)
+
+    assert mock_client.log_batch.called

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -1,21 +1,14 @@
-# -*- coding: utf-8 -*-
-
 import os
-import unittest
 import pytest
 import logging
-import tempfile
 
 from click.testing import CliRunner
 from unittest import mock
+import mlflow
 
 
 from gordo_components import cli
-from gordo_components.cli.cli import (
-    expand_model,
-    DEFAULT_MODEL_CONFIG,
-    EXCEPTION_TO_EXITCODE,
-)
+from gordo_components.cli.cli import expand_model, DEFAULT_MODEL_CONFIG
 from gordo_components.serializer import serializer
 from tests.utils import temp_env_vars
 
@@ -39,193 +32,193 @@ MODEL_CONFIG_WITH_PREDICT = {
 logger = logging.getLogger(__name__)
 
 
-class CliTestCase(unittest.TestCase):
+@pytest.fixture
+def runner(tmp_dir):
+    mlflow.set_tracking_uri(f"file:{tmp_dir}")
+    yield CliRunner()
+
+
+def test_build_env_args(runner, tmp_dir):
     """
-    Test the expected usability of the CLI interface
+    Instead of passing OUTPUT_DIR directly to CLI, should be able to
+    read environment variables
     """
 
-    def setUp(self):
-        self.runner = CliRunner()
+    logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG)}")
 
-    def test_build_env_args(self):
-        """
-        Instead of passing OUTPUT_DIR directly to CLI, should be able to
-        read environment variables
-        """
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=tmp_dir,
+        DATA_CONFIG=DATA_CONFIG,
+        MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+    ):
+        result = runner.invoke(cli.gordo, ["build"])
 
-        logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG)}")
+    assert result.exit_code == 0, f"Command failed: {result}, {result.exception}"
+    assert (
+        len(os.listdir(tmp_dir)) > 1
+    ), "Building was supposed to create at least two files (model and metadata) in OUTPUT_DIR, but it did not!"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with temp_env_vars(
-                MODEL_NAME="model-name",
-                OUTPUT_DIR=tmpdir,
-                DATA_CONFIG=DATA_CONFIG,
-                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
-            ):
-                result = self.runner.invoke(cli.gordo, ["build"])
 
-            self.assertEqual(result.exit_code, 0, msg=f"Command failed: {result}")
-            self.assertGreater(
-                len(os.listdir(tmpdir)),
-                1,
-                msg="Building was supposed to create at least two files (model and "
-                "metadata) in OUTPUT_DIR, but it did not!",
-            )
+def test_build_use_registry(runner, tmp_dir):
+    """
+    Using a registry causes the second build of a model to copy the first to the
+    new location.
+    """
 
-    def test_build_use_registry(self):
-        """
-        Using a registry causes the second build of a model to copy the first to the
-        new location.
-        """
+    output_dir_1 = os.path.join(tmp_dir, "dir1")
+    output_dir_2 = os.path.join(tmp_dir, "dir2")
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir_1 = os.path.join(tmpdir, "dir1")
-            output_dir_2 = os.path.join(tmpdir, "dir2")
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=output_dir_1,
+        DATA_CONFIG=DATA_CONFIG,
+        MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+        MODEL_REGISTER_DIR=tmp_dir + "/reg",
+    ):
+        result1 = runner.invoke(cli.gordo, ["build"])
 
-            with temp_env_vars(
-                MODEL_NAME="model-name",
-                OUTPUT_DIR=output_dir_1,
-                DATA_CONFIG=DATA_CONFIG,
-                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
-                MODEL_REGISTER_DIR=tmpdir + "/reg",
-            ):
-                result1 = self.runner.invoke(cli.gordo, ["build"])
+    assert result1.exit_code == 0, f"Command failed: {result1}"
+    # OUTPUT_DIR is the only difference
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=output_dir_2,
+        DATA_CONFIG=DATA_CONFIG,
+        MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+        MODEL_REGISTER_DIR=tmp_dir + "/reg",
+    ):
+        result2 = runner.invoke(cli.gordo, ["build"])
+    assert result2.exit_code == 0, f"Command failed: {result2}"
 
-            self.assertEqual(result1.exit_code, 0, msg=f"Command failed: {result1}")
-            # OUTPUT_DIR is the only difference
-            with temp_env_vars(
-                MODEL_NAME="model-name",
-                OUTPUT_DIR=output_dir_2,
-                DATA_CONFIG=DATA_CONFIG,
-                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
-                MODEL_REGISTER_DIR=tmpdir + "/reg",
-            ):
-                result2 = self.runner.invoke(cli.gordo, ["build"])
-            self.assertEqual(result2.exit_code, 0, msg=f"Command failed: {result2}")
+    first_metadata = serializer.load_metadata(output_dir_1)
+    second_metadata = serializer.load_metadata(output_dir_2)
 
-            first_metadata = serializer.load_metadata(output_dir_1)
-            second_metadata = serializer.load_metadata(output_dir_2)
+    # The metadata contains the model build date, so if it got rebuilt these two
+    # would be different
+    assert (
+        first_metadata["model"]["model-creation-date"]
+        == second_metadata["model"]["model-creation-date"]
+    )
 
-            # The metadata contains the model build date, so if it got rebuilt these two
-            # would be different
+
+def test_build_use_registry_bust_cache(runner, tmp_dir):
+    """
+    Even using a registry we get separate model-paths when we ask for models for
+    different configurations.
+    """
+
+    output_dir_1 = os.path.join(tmp_dir, "dir1")
+    output_dir_2 = os.path.join(tmp_dir, "dir2")
+
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=output_dir_1,
+        DATA_CONFIG=DATA_CONFIG,
+        MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+        MODEL_REGISTER_DIR=tmp_dir + "/reg",
+    ):
+        result1 = runner.invoke(cli.gordo, ["build"])
+
+    assert result1.exit_code == 0, f"Command failed: {result1}"
+
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=output_dir_2,
+        # NOTE: Different train dates!
+        DATA_CONFIG=(
+            "{"
+            ' "type": "RandomDataset",'
+            ' "train_start_date": "2019-01-01T00:00:00+00:00", '
+            ' "train_end_date": "2019-06-01T00:00:00+00:00",'
+            ' "tags": ["TRC1", "TRC2"],'
+            "}"
+        ),
+        MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+        MODEL_REGISTER_DIR=tmp_dir + "/reg",
+    ):
+        result2 = runner.invoke(cli.gordo, ["build"])
+    assert result2.exit_code == 0, f"Command failed: {result2}"
+
+    first_metadata = serializer.load_metadata(output_dir_1)
+    second_metadata = serializer.load_metadata(output_dir_2)
+    # The metadata contains the model build date, so if it got rebuilt these two
+    # would be different
+    assert (
+        first_metadata["model"]["model-creation-date"]
+        != second_metadata["model"]["model-creation-date"]
+    )
+
+
+def test_build_model_with_parameters(runner, tmp_dir):
+    """
+    It works to build a simple model with parameters set
+    """
+
+    model = """
+    {
+     "sklearn.decomposition.pca.PCA":
+      {
+        "svd_solver": "{{svd_solver}}",
+        "n_components": {{n_components}}
+      }
+    }
+    """
+
+    svd_solver = "auto"
+    n_components = 0.5
+
+    logger.info(f"MODEL_CONFIG={json.dumps(model)}")
+
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=tmp_dir,
+        DATA_CONFIG=DATA_CONFIG,
+        MODEL_CONFIG=model,
+    ):
+        args = [
+            "build",
+            "--model-parameter",
+            f"svd_solver,{svd_solver}",
+            "--model-parameter",
+            f"n_components,{n_components}",
+        ]
+
+        # Run it twice to ensure the model location in the location file
+        # is only written once and not appended.
+        for _ in range(2):
+
+            result = runner.invoke(cli.gordo, args=args)
+
             assert (
-                first_metadata["model"]["model-creation-date"]
-                == second_metadata["model"]["model-creation-date"]
-            )
-
-    def test_build_use_registry_bust_cache(self):
-        """
-        Even using a registry we get separate model-paths when we ask for models for
-        different configurations.
-        """
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir_1 = os.path.join(tmpdir, "dir1")
-            output_dir_2 = os.path.join(tmpdir, "dir2")
-
-            with temp_env_vars(
-                MODEL_NAME="model-name",
-                OUTPUT_DIR=output_dir_1,
-                DATA_CONFIG=DATA_CONFIG,
-                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
-                MODEL_REGISTER_DIR=tmpdir + "/reg",
-            ):
-                result1 = self.runner.invoke(cli.gordo, ["build"])
-
-            self.assertEqual(result1.exit_code, 0, msg=f"Command failed: {result1}")
-
-            with temp_env_vars(
-                MODEL_NAME="model-name",
-                OUTPUT_DIR=output_dir_2,
-                # NOTE: Different train dates!
-                DATA_CONFIG=(
-                    "{"
-                    ' "type": "RandomDataset",'
-                    ' "train_start_date": "2019-01-01T00:00:00+00:00", '
-                    ' "train_end_date": "2019-06-01T00:00:00+00:00",'
-                    ' "tags": ["TRC1", "TRC2"],'
-                    "}"
-                ),
-                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
-                MODEL_REGISTER_DIR=tmpdir + "/reg",
-            ):
-                result2 = self.runner.invoke(cli.gordo, ["build"])
-            self.assertEqual(result2.exit_code, 0, msg=f"Command failed: {result2}")
-
-            first_metadata = serializer.load_metadata(output_dir_1)
-            second_metadata = serializer.load_metadata(output_dir_2)
-            # The metadata contains the model build date, so if it got rebuilt these two
-            # would be different
+                result.exit_code == 0
+            ), f"Command failed: {result}, {result.exception}"
             assert (
-                first_metadata["model"]["model-creation-date"]
-                != second_metadata["model"]["model-creation-date"]
-            )
+                len(os.listdir(tmp_dir)) > 1
+            ), "Building was supposed to create at least two files (model and metadata) in OUTPUT_DIR, but it did not!"
 
-    def test_build_model_with_parameters(self):
-        """
-        It works to build a simple model with parameters set
-        """
 
-        model = """
-        {
-         "sklearn.decomposition.pca.PCA":
-          {
-            "svd_solver": "{{svd_solver}}",
-            "n_components": {{n_components}}
-          }
-        }
-        """
+def test_expand_model_default_works():
+    assert expand_model(DEFAULT_MODEL_CONFIG, {}) == DEFAULT_MODEL_CONFIG
 
-        svd_solver = "auto"
-        n_components = 0.5
 
-        logger.info(f"MODEL_CONFIG={json.dumps(model)}")
+def test_expand_model_expand_works():
+    model_params = {"kind": "hourglass", "num": 5}
+    model_template = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': '{{kind}}', 'num': {{num}}}} "
+    expected_model = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': 'hourglass', 'num': 5}} "
+    assert expand_model(model_template, model_params) == expected_model
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with temp_env_vars(
-                MODEL_NAME="model-name",
-                OUTPUT_DIR=tmpdir,
-                DATA_CONFIG=DATA_CONFIG,
-                MODEL_CONFIG=model,
-            ):
-                args = [
-                    "build",
-                    "--model-parameter",
-                    f"svd_solver,{svd_solver}",
-                    "--model-parameter",
-                    f"n_components,{n_components}",
-                ]
 
-                # Run it twice to ensure the model location in the location file
-                # is only written once and not appended.
-                for _ in range(2):
-
-                    result = self.runner.invoke(cli.gordo, args=args)
-
-                    self.assertEqual(
-                        result.exit_code, 0, msg=f"Command failed: {result}"
-                    )
-                    self.assertGreater(
-                        len(os.listdir(tmpdir)),
-                        1,
-                        msg="Building was supposed to create at least two files ("
-                        "model and metadata) in OUTPUT_DIR, but it did not!",
-                    )
-
-    def test_expand_model_default_works(self):
-        self.assertEquals(expand_model(DEFAULT_MODEL_CONFIG, {}), DEFAULT_MODEL_CONFIG)
-
-    def test_expand_model_expand_works(self):
-        model_params = {"kind": "hourglass", "num": 5}
-        model_template = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': '{{kind}}', 'num': {{num}}}} "
-        expected_model = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': 'hourglass', 'num': 5}} "
-        self.assertEquals(expand_model(model_template, model_params), expected_model)
-
-    def test_expand_model_complains_on_missing_vars(self):
-        model_params = {"kind": "hourglass"}
-        model_template = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': '{{kind}}', 'num': {{num}}}} "
-        with self.assertRaises(ValueError):
-            expand_model(model_template, model_params)
+def test_expand_model_complains_on_missing_vars():
+    model_params = {"kind": "hourglass"}
+    model_template = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': '{{kind}}', 'num': {{num}}}} "
+    with pytest.raises(ValueError):
+        expand_model(model_template, model_params)
 
 
 @pytest.mark.parametrize(
@@ -233,12 +226,10 @@ class CliTestCase(unittest.TestCase):
     # exit codes, so it should default to 1
     [(FileNotFoundError, 30), (Exception, 1), (ArithmeticError, 1)],
 )
-def test_build_exit_code(exception, exit_code, tmp_dir: str):
+def test_build_exit_code(exception, exit_code, runner, tmp_dir):
     """
     Test that cli build exists with different exit codes for different errors.
     """
-
-    runner = CliRunner()
 
     logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG_WITH_PREDICT)}")
     with mock.patch(
@@ -246,6 +237,7 @@ def test_build_exit_code(exception, exit_code, tmp_dir: str):
         mock.MagicMock(side_effect=exception, autospec=True, return_value=None),
     ):
         with temp_env_vars(
+            PROJECT_NAME="project-name",
             MODEL_NAME="model-name",
             OUTPUT_DIR=tmp_dir,
             DATA_CONFIG=DATA_CONFIG,
@@ -262,19 +254,22 @@ def test_build_exit_code(exception, exit_code, tmp_dir: str):
     "should_save_model, cv_mode",
     [(True, {"cv_mode": "full_build"}), (False, {"cv_mode": "cross_val_only"})],
 )
-def test_build_cv_mode(should_save_model: bool, cv_mode: str, tmp_dir: str):
+def test_build_cv_mode(
+    runner: CliRunner, should_save_model: bool, cv_mode: str, tmp_dir: str
+):
     """
     Testing build with cv_mode set to full and cross_val_only. Checks that cv_scores are
     printed and model are only saved when using the default (full) value.
     """
-
-    runner = CliRunner()
-
     logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG_WITH_PREDICT)}")
 
+    tmp_model_dir = os.path.join(tmp_dir, "tmp")
+    os.makedirs(tmp_model_dir, exist_ok=True)
+
     with temp_env_vars(
+        PROJECT_NAME="project-name",
         MODEL_NAME="model-name",
-        OUTPUT_DIR=tmp_dir,
+        OUTPUT_DIR=tmp_model_dir,
         DATA_CONFIG=DATA_CONFIG,
         MODEL_CONFIG=json.dumps(MODEL_CONFIG_WITH_PREDICT),
     ):
@@ -283,9 +278,9 @@ def test_build_cv_mode(should_save_model: bool, cv_mode: str, tmp_dir: str):
         )
         # Checks that the file is empty or not depending on the mode.
         if should_save_model:
-            assert len(os.listdir(tmp_dir)) != 0
+            assert len(os.listdir(tmp_model_dir)) != 0
         else:
-            assert len(os.listdir(tmp_dir)) == 0
+            assert len(os.listdir(tmp_model_dir)) == 0
 
         # Checks the output contains 'explained-variance_raw-scores'
         assert "r2-score" in result.output
@@ -302,18 +297,20 @@ def test_build_cv_mode(should_save_model: bool, cv_mode: str, tmp_dir: str):
     ],
 )
 def test_build_cv_mode_cross_val_cache(
-    should_save_model: bool, cv_mode_1: str, cv_mode_2: str, tmp_dir: str
+    should_save_model: bool,
+    cv_mode_1: str,
+    cv_mode_2: str,
+    runner: CliRunner,
+    tmp_dir: str,
 ):
     """
     Checks that cv_scores uses cache if ran after a full build. Loads the same model, and can
     print the cv_scores from them.
     """
-
-    runner = CliRunner()
-
     logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG)}")
 
     with temp_env_vars(
+        PROJECT_NAME="project-name",
         MODEL_NAME="model-name",
         OUTPUT_DIR=tmp_dir,
         DATA_CONFIG=DATA_CONFIG,
@@ -329,18 +326,17 @@ def test_build_cv_mode_cross_val_cache(
             assert len(os.listdir(tmp_dir)) == 0
 
 
-def test_build_cv_mode_build_only(tmp_dir: str):
+def test_build_cv_mode_build_only(runner: CliRunner, tmp_dir: str):
     """
     Testing build with cv_mode set to build_only. Checks that OUTPUT_DIR gets a model
     saved to it. It also checks that the metadata contains cv-duration-sec=None and
     cv-scores={}
     """
 
-    runner = CliRunner()
-
     logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG)}")
 
     with temp_env_vars(
+        PROJECT_NAME="project-name",
         MODEL_NAME="model-name",
         OUTPUT_DIR=tmp_dir,
         DATA_CONFIG=DATA_CONFIG,
@@ -358,6 +354,59 @@ def test_build_cv_mode_build_only(tmp_dir: str):
             metadata_json = json.loads(f.read())
             assert metadata_json["model"]["cross-validation"]["cv-duration-sec"] is None
             assert metadata_json["model"]["cross-validation"]["scores"] == {}
+
+
+@mock.patch("gordo_components.builder.mlflow_utils.get_spauth_kwargs")
+@mock.patch("gordo_components.builder.mlflow_utils.get_workspace_kwargs")
+@mock.patch("gordo_components.builder.mlflow_utils.get_mlflow_client")
+def test_enable_remote_logging(
+    MockClient,
+    mock_get_workspace_kwargs,
+    mock_get_spauth_kwargs,
+    monkeypatch,
+    runner,
+    tmp_dir,
+):
+    """
+    Tests disabling MlFlow logging in cli, and missing env var when enabled
+    """
+
+    mlflow.set_tracking_uri(f"file:{tmp_dir}")
+    with temp_env_vars(
+        PROJECT_NAME="project-name",
+        MODEL_NAME="model-name",
+        OUTPUT_DIR=tmp_dir,
+        DATA_CONFIG=DATA_CONFIG,
+        MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+    ):
+        # Logging enabled, without env vars set:
+        # Raise error
+        result = runner.invoke(cli.gordo, ["build", "--enable-remote-logging=True"])
+        result.exit_code != 0
+
+        # Logging enabled, with env vars set:
+        # Build success, remote logging executed
+        with monkeypatch.context() as m:
+            m.setenv("DL_SERVICE_AUTH_STR", "test:test:test")
+            m.setenv("AZUREML_WORKSPACE_STR", "test:test:test")
+
+            result = runner.invoke(cli.gordo, ["build", "--enable-remote-logging=True"])
+            result.exit_code == 1
+            assert MockClient.called
+            assert mock_get_workspace_kwargs.called
+            assert mock_get_spauth_kwargs.called
+
+        # Reset call counts
+        for m in [MockClient, mock_get_workspace_kwargs, mock_get_spauth_kwargs]:
+            m.reset_mock()
+
+        # Logging not enabled:
+        # Build success, remote logging not executed
+        result = runner.invoke(cli.gordo, ["build", "--enable-remote-logging=False"])
+        result.exit_code == 0
+        assert not MockClient.called
+        assert not mock_get_workspace_kwargs.called
+        assert not mock_get_spauth_kwargs.called
 
 
 @pytest.mark.parametrize(
@@ -378,12 +427,11 @@ def test_build_cv_mode_build_only(tmp_dir: str):
         ("--log-level", "badlevel", True),
     ],
 )
-def test_gunicorn_execution_hosts(monkeypatch, arg, value, exception_expected):
+def test_gunicorn_execution_hosts(runner, arg, value, exception_expected):
     """
     Test the validation of input parameters to the `run_server` function via the gordo cli
     """
 
-    runner = CliRunner()
     with mock.patch(
         "gordo_components.server.server.run_server",
         mock.MagicMock(return_value=None, autospec=True),


### PR DESCRIPTION
Will close #441 

# Problem :airplane: 
The DS team would like to have additional logging of metrics for various configuration of deployed models for post-analysis.

# Solution :rocket: 
Add MLFlow logging to the the CLI `build` command and `gordo_components.builder.build_model::build_model`.

This includes:
- [x] Add a method that authenticates to AzureML and sets MLFlow logging to a wokspace. The configuration is passed to the CLI `build` as a dict, via the env var `MLFLOW_CONFIG`. Default behavior is to require interactive authentication and log MLFlow locally. 
- [x]  Set the workspace (with auth) at the CLI level. 
- [x] Log the `model_id` (changed from `cache_id`) at CLI level.
- [x] Log metadata at `build_model` level
- [x] Add test for `set_mlflow_tracking`
- [x] Add test for `build_model`