### PR TITLE
Add catboost to requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,3 +26,4 @@ cchardet~=2.1
 urllib3>=1.24.2,<2.0
 simplejson~=3.16
 gevent~=1.4.0
+catboost~=0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,12 +13,14 @@ astor==0.8.0              # via tensorflow
 attrs==19.2.0             # via jsonschema
 azure-datalake-store==0.0.48
 cachetools==3.1.1
+catboost==0.18
 cchardet==2.1.4
 certifi==2019.9.11        # via kubernetes, requests
 cffi==1.12.3              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
 click==7.0
 cryptography==2.7         # via adal
+cycler==0.10.0            # via matplotlib
 dictdiffer==0.8.0
 flask-restplus==0.13.0
 flask==1.1.1
@@ -26,6 +28,7 @@ gast==0.2.2               # via tensorflow
 gevent==1.4.0
 google-auth==1.6.3        # via kubernetes
 google-pasta==0.1.7       # via tensorflow
+graphviz==0.13            # via catboost
 greenlet==0.4.15          # via gevent
 grpcio==1.24.1            # via tensorboard, tensorflow
 gunicorn==19.9.0
@@ -38,15 +41,18 @@ joblib==0.14.0            # via scikit-learn
 jsonschema==3.0.2         # via flask-restplus
 keras-applications==1.0.8  # via tensorflow
 keras-preprocessing==1.1.0  # via tensorflow
+kiwisolver==1.1.0         # via matplotlib
 kubernetes==9.0.1
 markdown==3.1.1           # via tensorboard
 markupsafe==1.1.1         # via jinja2
+matplotlib==3.1.1         # via catboost
 numexpr==2.7.0
 numpy==1.17.3
 oauthlib==3.1.0           # via requests-oauthlib
 opt-einsum==3.1.0         # via tensorflow
 pandas==0.25.1
 peewee==3.11.2
+plotly==4.2.1             # via catboost
 protobuf==3.10.0          # via tensorboard, tensorflow
 psycopg2-binary==2.8.4
 pyarrow==0.15.0
@@ -54,17 +60,19 @@ pyasn1-modules==0.2.6     # via google-auth
 pyasn1==0.4.7             # via pyasn1-modules, rsa
 pycparser==2.19           # via cffi
 pyjwt==1.7.1              # via adal
+pyparsing==2.4.2          # via matplotlib
 pyrsistent==0.15.4        # via jsonschema
 python-dateutil==2.8.0
 pytz==2019.3              # via apscheduler, flask-restplus, influxdb, pandas, tzlocal
 pyyaml==5.1.2
 requests-oauthlib==1.2.0  # via kubernetes
 requests==2.22.0
+retrying==1.3.3           # via plotly
 rsa==4.0                  # via google-auth
 scikit-learn==0.21.3
-scipy==1.3.1              # via scikit-learn
+scipy==1.3.1              # via catboost, scikit-learn
 simplejson==3.16.0
-six==1.12.0               # via absl-py, apscheduler, cryptography, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras-preprocessing, kubernetes, protobuf, pyarrow, pyrsistent, python-dateutil, tensorboard, tensorflow, websocket-client
+six==1.12.0               # via absl-py, apscheduler, catboost, cryptography, cycler, flask-restplus, google-auth, grpcio, h5py, influxdb, jsonschema, keras-preprocessing, kubernetes, plotly, protobuf, pyarrow, pyrsistent, python-dateutil, retrying, tensorboard, tensorflow, websocket-client
 tensorboard==2.0.0        # via tensorflow
 tensorflow-estimator==2.0.0  # via tensorflow
 tensorflow==2.0.0
@@ -78,4 +86,4 @@ wheel==0.33.6             # via tensorboard, tensorflow
 wrapt==1.11.2             # via tensorflow
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via apscheduler, jsonschema, kubernetes, markdown, protobuf, tensorboard
+# setuptools==41.5.0        # via apscheduler, jsonschema, kiwisolver, kubernetes, markdown, protobuf, tensorboard


### PR DESCRIPTION
This PR closes #580, Here I've added `catboost` to the pip requirements, along with an example using the `CatBoostRegressor` in [gordo-test-project #33](https://github.com/equinor/gordo-test-project/pull/33). 