### PR TITLE
`gordo-components workflow generate` updates

### DIFF
--- a/gordo_components/cli/workflow_generator.py
+++ b/gordo_components/cli/workflow_generator.py
@@ -83,6 +83,7 @@ def workflow_cli():
     type=str,
     default="ambassador",
     help="Namespace we should expect to find the Ambassador service in.",
+    envvar=f"{PREFIX}_AMBASSADOR_NAMESPACE",
 )
 @click.option(
     "--split-workflows",
@@ -92,24 +93,28 @@ def workflow_cli():
     "workflows, where each workflow contains at most this nr of models. The "
     "workflows are outputted sequentially with '---' in between, which allows "
     "kubectl to apply them all at once.",
+    envvar=f"{PREFIX}_SPLIT_WORKFLOWS",
 )
 @click.option(
     "--n-servers",
     type=int,
     default=None,
     help="Max number of ML Servers to use, defaults to N machines * 10",
+    envvar=f"{PREFIX}_N_SERVERS",
 )
 @click.option(
     "--docker-repository",
     type=str,
     default="gordo-components",
     help="The docker repo to use for pulling component images from",
+    envvar=f"{PREFIX}_DOCKER_REPOSITORY",
 )
 @click.option(
     "--docker-registry",
     type=str,
     default="auroradevacr.azurecr.io",  # TODO: Change to docker.io after migrating
     help="The docker registry to use for pulling component images from",
+    envvar=f"{PREFIX}_DOCKER_REGISTRY",
 )
 def workflow_generator_cli(**kwargs: dict):
     """

--- a/gordo_components/cli/workflow_generator.py
+++ b/gordo_components/cli/workflow_generator.py
@@ -31,6 +31,7 @@ def workflow_cli():
     type=str,
     help="Machine configuration file",
     envvar=f"{PREFIX}_MACHINE_CONFIG",
+    required=True,
 )
 @click.option("--workflow-template", type=str, help="Template to expand")
 @click.option(
@@ -56,6 +57,7 @@ def workflow_cli():
     help="Name of the project which own the workflow.",
     allow_from_autoenv=True,
     envvar=f"{PREFIX}_PROJECT_NAME",
+    required=True,
 )
 @click.option(
     "--project-version",

--- a/gordo_components/cli/workflow_generator.py
+++ b/gordo_components/cli/workflow_generator.py
@@ -44,11 +44,11 @@ def workflow_cli():
     envvar=f"{PREFIX}_OWNER_REFERENCES",
 )
 @click.option(
-    "--cleanup-version",
+    "--version",
     type=str,
     default=wg._docker_friendly_version(__version__),
-    help="Version of cleanup image (gordo-deploy)",
-    envvar=f"{PREFIX}_CLEANUP_VERSION",
+    help="Version of gordo to use, if different than this one",
+    envvar=f"{PREFIX}_VERSION",
 )
 @click.option(
     "--project-name",
@@ -120,8 +120,7 @@ def workflow_generator_cli(**kwargs: dict):
     yaml_content = wg.get_dict_from_yaml(kwargs["machine_config"])
 
     # Context directly from args.
-    context["gordo_version"] = wg._docker_friendly_version(__version__)
-    context["cleanup_version"] = kwargs["cleanup_version"]
+    context["gordo_version"] = kwargs["version"]
     context["project_name"] = kwargs["project_name"]
     context["project_version"] = kwargs["project_version"]
     context["namespace"] = kwargs["namespace"]

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -43,7 +43,7 @@ spec:
         applications.gordo.equinor.com/project-name: "{{project_name}}"
         applications.gordo.equinor.com/project-version: "{{project_version}}"
     script:
-      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Ensuring that no other versions of workflows for this project is running at the same time"
@@ -199,7 +199,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Creating feeder database for influx for project {{project_name}}" \
@@ -322,7 +322,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Creating grafana influxdb and postgres datasources for project {{project_name}}" \
@@ -500,7 +500,7 @@ spec:
     retryStrategy:
       limit: 5
     script:
-      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{cleanup_version}}
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
       command: [bash]
       source: |
         echo "Feeding sql with metadata for project {{project_name}} using source ur http://$AMBASSADOR_HOST/gordo/v0/$PROJECT_NAME/ and postgres url gordo-postgres-$PROJECT_NAME " \

--- a/tests/gordo_components/workflow/test_workflow_generator/test_workflow_generator.py
+++ b/tests/gordo_components/workflow/test_workflow_generator/test_workflow_generator.py
@@ -170,6 +170,40 @@ def test_basic_generation(path_to_config_files):
     assert len(machines) == 2
 
 
+def test_generation_to_file(tmp_dir, path_to_config_files):
+    """
+    Test that the workflow generator can output to a file, and it matches
+    what would have been output to stdout.
+    """
+    project_name = "my-sweet-project"
+    config_filename = "config-test-with-models.yml"
+    expanded_template = _generate_test_workflow_str(
+        path_to_config_files, config_filename, project_name=project_name
+    )
+
+    # Execute CLI by passing a file to write to.
+    config_file = os.path.join(path_to_config_files, config_filename)
+    outfile = os.path.join(tmp_dir.name, "out.yml")
+    args = [
+        "workflow",
+        "generate",
+        "--machine-config",
+        config_file,
+        "--project-name",
+        project_name,
+        "--output-file",
+        outfile,
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli.gordo, args)
+    assert result.exit_code == 0
+
+    # Open the file and ensure they are the same
+    with open(outfile, "r") as f:
+        outfile_contents = f.read()
+    assert outfile_contents.rstrip() == expanded_template.rstrip()
+
+
 def test_overrides_builder_datasource(path_to_config_files):
     expanded_template = _generate_test_workflow_yaml(
         path_to_config_files, "config-test-datasource.yml"


### PR DESCRIPTION
Problems :1234: 
---
- We still had `cleanup_version` which was left over from gordo-infrastructure days
- Not all options were picked up from environment variables, and now that https://github.com/equinor/gordo-controller/pull/27 is in, we can set these param via the Gordo CRD config file in `spec.deploy-environment` mapping.
- The `kwargs` held much of the variables which `context` ends up having, might as well treat them the same. 

Solutions :checkered_flag: 
---
- Remove `cleanup_version` in favor of `gordo_version`
- Add `envvar` params to each option
- Rename `kwargs` to `context` and remove duplicate lines.