### PR TITLE
Add load_test.py as a CLI tool

### DIFF
--- a/benchmarks/load_test/README.md
+++ b/benchmarks/load_test/README.md
@@ -1,0 +1,27 @@
+### Load testing
+
+Create a Locust load testing instance by using the CLI tool `load_test.py`
+
+It *requires* locust to be installed, use `pip install locustio` (if dev-dependencies is not already installed).
+
+#### Usage
+
+- Start port-forwarding with *ambassador* on a cluster (with an existing gordo-project).
+
+    `kubectl port-forward svc/ambassador -n ambassador 8888:80`
+
+- Use the CLI tool `load_test.py`, specify the *project name* (required), *host* (optional) and *port* (optional).
+**Note** the port needs to match the port which is port-forwarded to*. 
+An example is which uses ambassador is: 
+ 
+    `python load_test.py --project-name example-project --ambassador`
+
+
+- Go to the Locust instance at: [http://127.0.0.1:8089](http://127.0.0.1:8089) and specify the number of users to simulate, as well as the the number of users
+to *hatch* per second.
+  
+
+#### Advanced customization
+Additional parameters can be specified in the script, such as *min-wait* and *max-wait*, as well as other Locust
+parameters to prioritize certain tasks over others. Please see: [locust documentation](https://docs.locust.io/en/stable/)
+for more information.

--- a/benchmarks/load_test/load_test.py
+++ b/benchmarks/load_test/load_test.py
@@ -1,0 +1,103 @@
+import os
+import requests
+import subprocess
+import yaml
+from collections import namedtuple
+
+import numpy as np
+import jinja2
+import click
+from locust import HttpLocust
+
+from gordo_components.client.utils import EndpointMetadata
+
+TEMPLATE_FILE = "task_set.py.jinja2"
+Task = namedtuple("Task", "name path json")
+
+
+def fetch_metadata(project_name, host, port, ambassador, watchman_port):
+    if ambassador:
+        data = requests.get(
+            f"{host}:{port}/gordo/v0/{project_name}/", proxies={"http": None}
+        )
+    else:
+        data = requests.get(f"{host}:{watchman_port}", proxies={"http": None})
+
+    json_data = yaml.safe_load(data.content)
+
+    endpoint_metadata = [
+        EndpointMetadata(endpoint) for endpoint in json_data["endpoints"]
+    ]
+    tags = {
+        metadata.name: {
+            "tag_list": len(metadata.tag_list),
+            "target_tag_list": len(metadata.target_tag_list),
+        }
+        for metadata in endpoint_metadata
+    }
+
+    return tags
+
+
+def generate_random_data(len_x, len_y, samples=100):
+    if len_y > 0:
+        return {
+            "X": np.random.random((samples, len_x)).tolist(),
+            "y": np.random.random((samples, len_y)).tolist(),
+        }
+    return {"X": np.random.random((samples, len_x)).tolist()}
+
+
+def make_tasks(tags, endpoint):
+    tasks = list()
+    for name, dict_values in tags.items():
+        data = generate_random_data(
+            dict_values["tag_list"], dict_values["target_tag_list"]
+        )
+        path = f"/gordo/v0/{endpoint}/{name}/prediction"
+        tasks.append(Task(name=f"fn_{name.replace('-', '_')}", path=path, json=data))
+
+    return tasks
+
+
+@click.command()
+@click.option("--project-name", type=str, help="Project name", required=True)
+@click.option(
+    "--host",
+    type=str,
+    default="http://127.0.0.1",
+    help="Host is usually 127.0.0.1 (localhost)",
+)
+@click.option("--port", type=int, default=8888, help="Port which hosts the project")
+@click.option(
+    "--ambassador", is_flag=True, help="Use if routing should go through ambassador"
+)
+@click.option(
+    "--watchman-port",
+    type=int,
+    default=8889,
+    help="Use if you wanna port-forward watchman to a different port",
+)
+def main(project_name, host, port, ambassador, watchman_port):
+    template_loader = jinja2.FileSystemLoader(searchpath=os.path.dirname(__file__))
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template(TEMPLATE_FILE)
+
+    tags = fetch_metadata(project_name, host, port, ambassador, watchman_port)
+    tasks = make_tasks(tags, project_name)
+    path = os.path.join(os.path.dirname(__file__), "task_set.py")
+    template.stream(tasks=tasks).dump(path)
+
+    subprocess.run(["locust", "-f", f"{__file__}", "--host", f"{host}:{port}"])
+
+
+if __name__ == "__main__":
+    main()
+
+
+class MyLocust(HttpLocust):
+    from benchmarks.load_test.task_set import Tasks
+
+    task_set = Tasks
+    min_wait = 1000
+    max_wait = 1000

--- a/benchmarks/load_test/task_set.py.jinja2
+++ b/benchmarks/load_test/task_set.py.jinja2
@@ -1,0 +1,16 @@
+
+# -*- coding: utf-8 -*-
+
+from locust import TaskSet, task
+
+
+class Tasks(TaskSet):
+    """
+    Generated locust TaskSet where methods/tasks are generated for each
+    gordo model listed in the project's config file.
+    """
+{% for task in tasks %}
+    @task
+    def {{ task.name }}(self):
+        self.client.post("{{ task.path }}", json={{ task.json }})
+{% endfor %}

--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -1,4 +1,5 @@
 -c requirements.txt
+locustio>=0.12.2
 pip>=19.2.3
 pip-tools~=4.2
 sphinx-rtd-theme~=0.4

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,25 +6,33 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.7.0              # via sphinx
-certifi==2019.9.11        # via requests
+certifi==2019.9.11        # via geventhttpclient-wheels, requests
 chardet==3.0.4            # via requests
-click==7.0                # via pip-tools
+click==7.0                # via flask, pip-tools
 commonmark==0.9.0         # via recommonmark
 docutils==0.15.2          # via recommonmark, sphinx
+flask==1.1.1              # via locustio
 future==0.17.1            # via commonmark
+gevent==1.4.0             # via geventhttpclient-wheels, locustio
+geventhttpclient-wheels==1.3.1.dev2  # via locustio
+greenlet==0.4.15          # via gevent
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-jinja2==2.10.3            # via sphinx
+itsdangerous==1.1.0       # via flask
+jinja2==2.10.3            # via flask, sphinx
+locustio==0.12.2
 markupsafe==1.1.1         # via jinja2
+msgpack-python==0.5.6     # via locustio
 packaging==19.2           # via sphinx
 pbr==5.4.3                # via sphinx-click
 pip-tools==4.2.0
 pygments==2.4.2           # via sphinx
 pyparsing==2.4.2          # via packaging
 pytz==2019.3              # via babel
+pyzmq==18.1.0             # via locustio
 recommonmark==0.6.0
-requests==2.22.0          # via sphinx
-six==1.12.0               # via packaging, pip-tools
+requests==2.22.0          # via locustio, sphinx
+six==1.12.0               # via geventhttpclient-wheels, locustio, packaging, pip-tools
 snowballstemmer==2.0.0    # via sphinx
 sphinx-click==2.3.0
 sphinx-rtd-theme==0.4.3
@@ -37,6 +45,7 @@ sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 sphinxcontrib-websupport==1.1.2
 urllib3==1.25.7           # via requests
+werkzeug==0.16.0          # via flask
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.3.1


### PR DESCRIPTION
Add a load test CLI tool to use Locust to simulate users and load on the servers. This can be used to test how the servers respond to many requests as well as how the cluster handles autoscaling. Fixes #570 