### PR TITLE
Remove custom keras model serializations

### DIFF
--- a/gordo_components/model/base.py
+++ b/gordo_components/model/base.py
@@ -18,16 +18,6 @@ class GordoBase(abc.ABC):
         """Return a dict containing all parameters used to initialized object"""
         ...
 
-    @abc.abstractclassmethod
-    def load_from_dir(cls, directory: str):
-        """Load this model from a directory"""
-        ...
-
-    @abc.abstractmethod
-    def save_to_dir(self, directory: str):
-        """Save this model to a directory"""
-        ...
-
     @abc.abstractmethod
     def score(
         self,

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -107,7 +107,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
             with h5py.File(buf, compression="lzf") as h5:
                 state["model"] = tensorflow.keras.models.load_model(h5, compile=False)
             if "history" in state:
-                state["model"].__dict__["history"] = state["history"]
+                state["model"].__dict__["history"] = state.pop("history")
         self.__dict__ = state
         return self
 

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -86,7 +86,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
 
         if hasattr(self, "model") and self.model is not None:
             buf = io.BytesIO()
-            with h5py.File(buf) as h5:
+            with h5py.File(buf, compression="lzf") as h5:
                 tensorflow.keras.models.save_model(self.model, h5, overwrite=True)
                 context["model"] = buf.getvalue()
             if hasattr(self.model, "history"):
@@ -109,10 +109,11 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
 
         if "model" in state:
             buf = io.BytesIO(state["model"])
-            with h5py.File(buf) as h5:
+            with h5py.File(buf, compression="lzf") as h5:
                 self.model = tensorflow.keras.models.load_model(h5)
             if "history" in state:
                 from tensorflow.python.keras.callbacks import History
+
                 history, params, epoch = pickle.loads(state["history"])
                 self.model.history = History()
                 self.model.history.history = history

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -88,7 +88,8 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
             buf = io.BytesIO()
             with h5py.File(buf, compression="lzf") as h5:
                 tensorflow.keras.models.save_model(self.model, h5, overwrite=True)
-                context["model"] = buf.getvalue()
+                buf.seek(0)
+                context["model"] = buf.read()
             if hasattr(self.model, "history"):
                 context["history"] = pickle.dumps(
                     (

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -9,6 +9,7 @@ from abc import ABCMeta
 
 import h5py
 import tensorflow.keras.models
+from tensorflow.keras.models import load_model, save_model
 from tensorflow.keras.preprocessing.sequence import pad_sequences, TimeseriesGenerator
 from tensorflow.keras.wrappers.scikit_learn import KerasRegressor as BaseWrapper
 import numpy as np
@@ -86,9 +87,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         if hasattr(self, "model") and self.model is not None:
             buf = io.BytesIO()
             with h5py.File(buf, compression="lzf") as h5:
-                tensorflow.keras.models.save_model(
-                    self.model, h5, overwrite=True, save_format="h5"
-                )
+                save_model(self.model, h5, overwrite=True, save_format="h5")
                 buf.seek(0)
                 state["model"] = buf
             if hasattr(self.model, "history"):
@@ -103,9 +102,8 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
 
     def __setstate__(self, state):
         if "model" in state:
-            buf = state["model"]
-            with h5py.File(buf, compression="lzf") as h5:
-                state["model"] = tensorflow.keras.models.load_model(h5, compile=False)
+            with h5py.File(state["model"], compression="lzf") as h5:
+                state["model"] = load_model(h5, compile=False)
             if "history" in state:
                 state["model"].__dict__["history"] = state.pop("history")
         self.__dict__ = state

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -86,7 +86,9 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         if hasattr(self, "model") and self.model is not None:
             buf = io.BytesIO()
             with h5py.File(buf, compression="lzf") as h5:
-                tensorflow.keras.models.save_model(self.model, h5, overwrite=True)
+                tensorflow.keras.models.save_model(
+                    self.model, h5, overwrite=True, save_format="h5"
+                )
                 buf.seek(0)
                 context["model"] = buf
             if hasattr(self.model, "history"):
@@ -103,7 +105,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         if "model" in state:
             buf = state["model"]
             with h5py.File(buf, compression="lzf") as h5:
-                state["model"] = tensorflow.keras.models.load_model(h5)
+                state["model"] = tensorflow.keras.models.load_model(h5, compile=False)
             if "history" in state:
                 state["model"].__dict__["history"] = state["history"]
         self.__dict__ = state

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -81,7 +81,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
 
     def __getstate__(self):
 
-        context = self.__dict__.copy()
+        state = self.__dict__.copy()
 
         if hasattr(self, "model") and self.model is not None:
             buf = io.BytesIO()
@@ -90,7 +90,7 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
                     self.model, h5, overwrite=True, save_format="h5"
                 )
                 buf.seek(0)
-                context["model"] = buf
+                state["model"] = buf
             if hasattr(self.model, "history"):
                 from tensorflow.python.keras.callbacks import History
 
@@ -98,8 +98,8 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
                 history.history = self.model.history.history
                 history.params = self.model.history.params
                 history.epoch = self.model.history.epoch
-                context["history"] = history
-        return context
+                state["history"] = history
+        return state
 
     def __setstate__(self, state):
         if "model" in state:

--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -3,7 +3,6 @@
 import abc
 import logging
 import io
-import pickle
 from pprint import pprint
 from typing import Union, Callable, Dict, Any, Optional
 from abc import ABCMeta

--- a/gordo_components/serializer/serializer.py
+++ b/gordo_components/serializer/serializer.py
@@ -1,21 +1,15 @@
 # -*- coding: utf-8 -*-
 
-import bz2
-import glob
-import io
 import simplejson
 import logging
 import os
-import pydoc
 import re
 import pickle
-import tarfile
-import tempfile
 
 from os import path
-from typing import Tuple, Union, Dict, Any, IO  # pragma: no flakes
+from typing import Union, Any  # pragma: no flakes
 
-from sklearn.pipeline import FeatureUnion, Pipeline
+from sklearn.pipeline import Pipeline
 from sklearn.base import TransformerMixin, BaseEstimator  # noqa
 
 from gordo_components.model.base import GordoBase
@@ -53,13 +47,7 @@ def dumps(model: Union[Pipeline, GordoBase]) -> bytes:
     >>> model_clone = serializer.loads(serialized)
     >>> assert isinstance(model_clone, KerasAutoEncoder)
     """
-    with tempfile.TemporaryDirectory() as tmp:
-        dump(model, tmp)
-        tarbuff = io.BytesIO()
-        with tarfile.open(fileobj=tarbuff, mode="w:gz") as archive:
-            archive.add(tmp, recursive=True, arcname="serialized_gordo_model")
-        tarbuff.seek(0)
-        return tarbuff.read()
+    return pickle.dumps(model)
 
 
 def loads(bytes_object: bytes) -> GordoBase:
@@ -76,14 +64,7 @@ def loads(bytes_object: bytes) -> GordoBase:
     Union[GordoBase, Pipeline, BaseEstimator]
         Custom gordo model, scikit learn pipeline or other scikit learn like object.
     """
-    with tempfile.TemporaryDirectory() as tmp:
-
-        tarbuff = io.BytesIO(bytes_object)
-        tarbuff.seek(0)
-
-        with tarfile.open(fileobj=tarbuff, mode="r:gz") as archive:
-            archive.extractall(tmp)
-        return load(os.path.join(tmp, "serialized_gordo_model"))
+    return pickle.loads(bytes_object)
 
 
 def load_metadata(source_dir: str) -> dict:
@@ -139,127 +120,8 @@ def load(source_dir: str) -> Any:
     """
     # This source dir should have a single pipeline entry directory.
     # may have been passed a top level dir, containing such an entry:
-    if not source_dir.startswith("n_step"):
-        dirs = [d for d in os.listdir(source_dir) if "n_step=" in d]
-        if len(dirs) != 1:
-            raise ValueError(
-                f"Found multiple object entries to load from, "
-                f"should pass a directory to pipeline directly or "
-                f"a directory containing a single object entry."
-                f"Possible objects found: {dirs}"
-            )
-        else:
-            source_dir = path.join(source_dir, dirs[0])
-
-    # Load step always returns a tuple of (str, object), index to object
-    return _load_step(source_dir)[1]
-
-
-def _parse_dir_name(source_dir: str) -> Tuple[int, str]:
-    """
-    Parses the required params from a directory name for loading
-    Expected name format ``n_step=<int>-class=<path.to.class.Model>``
-    """
-    match = N_STEP_REGEX.search(source_dir)
-    if match is None:
-        raise ValueError(
-            f'Source dir not valid, expected "n_step=" in '
-            f"directory but instead got: {source_dir}"
-        )
-    else:
-        n_step = int(match.groups()[0])  # type: int
-
-    match = CLASS_REGEX.search(source_dir)
-    if match is None:
-        raise ValueError(
-            f'Source dir not valid, expected "class=" in directory '
-            f"but instead got: {source_dir}"
-        )
-    else:
-        class_path = match.groups()[0]  # type: str
-    return n_step, class_path
-
-
-def _load_step(source_dir: str) -> Tuple[str, object]:
-    """
-    Load a single step from a source directory
-
-    Parameters
-    ----------
-        source_dir: str - directory in format "n_step=<int>-class=<path.to.class.Model>"
-
-    Returns
-    -------
-        Tuple[str, object]
-    """
-    n_step, class_path = _parse_dir_name(source_dir)
-    StepClass = pydoc.locate(
-        class_path
-    )  # type: Union[FeatureUnion, Pipeline, BaseEstimator]
-    if StepClass is None:
-        logger.warning(
-            f'Specified a class path of "{class_path}" but it does '
-            f"not exist. Will attempt to unpickle it from file in "
-            f"source directory: {source_dir}."
-        )
-    step_name = f"step={str(n_step).zfill(3)}"
-    params = dict()  # type: Dict[str, Any]
-
-    # If this is a FeatureUnion, we also have a `params.json` for it
-    if StepClass == FeatureUnion:
-        with open(os.path.join(source_dir, "params.json"), "r") as p:
-            params = simplejson.load(p)
-
-    # Pipelines and FeatureUnions have sub steps which need to be loaded
-    if any(StepClass == Obj for Obj in (Pipeline, FeatureUnion)):
-
-        # Load the sub_dirs to load into the Pipeline/FeatureUnion in order
-        sub_dirs_to_load = sorted(
-            [
-                sub_dir
-                for sub_dir in os.listdir(source_dir)
-                if path.isdir(path.join(source_dir, sub_dir))
-            ],
-            key=lambda d: _parse_dir_name(d)[0],
-        )
-        steps = [
-            _load_step(path.join(source_dir, sub_dir)) for sub_dir in sub_dirs_to_load
-        ]
-        return step_name, StepClass(steps, **params)
-
-    # May model implementing load_from_dir method, from GordoBase
-    elif hasattr(StepClass, "load_from_dir"):
-        return step_name, StepClass.load_from_dir(source_dir)
-
-    # Otherwise we have a normal Scikit-Learn transformer
-    else:
-        # Find the name of this file in the directory, should only be one
-        file = glob.glob(path.join(source_dir, "*.pkl.gz"))
-        if len(file) != 1:
-            raise ValueError(
-                f"Expected a single file in what is expected to be "
-                f"a single object directory, found {len(file)} "
-                f"in directory: {source_dir}"
-            )
-        with bz2.open(path.join(source_dir, file[0]), "rb") as f:  # type: IO[bytes]
-            model = pickle.load(f)
-
-        # This model may have been an estimator which took a GordoBase as a parameter
-        # and would have had that parameter/model dumped to a seperate directory and
-        # replaced the attribute with the location of that model.
-        for attr_name, attr_value in model.__dict__.items():
-            if isinstance(attr_value, dict) and all(
-                k in attr_value for k in ("class_path", "load_dir")
-            ):
-                class_path, load_dir = attr_value["class_path"], attr_value["load_dir"]
-                if class_path is not None:
-                    GordoModel: GordoBase = pydoc.locate(class_path)  # type: ignore
-                    attr_model = GordoModel.load_from_dir(load_dir)
-                else:
-                    # Otherwise it was another attr which required dumping
-                    attr_model = load(load_dir)
-                setattr(model, attr_name, attr_model)
-        return step_name, model
+    with open(os.path.join(source_dir, "model.pkl"), "rb") as f:
+        return pickle.load(f)
 
 
 def dump(obj: object, dest_dir: Union[os.PathLike, str], metadata: dict = None):
@@ -304,102 +166,8 @@ def dump(obj: object, dest_dir: Union[os.PathLike, str], metadata: dict = None):
     ...     serializer.dump(obj=pipe, dest_dir=tmp)
     ...     pipe_clone = serializer.load(source_dir=tmp)
     """
-    _dump_step(step=("obj", obj), n_step=0, dest_dir=dest_dir)
+    with open(os.path.join(dest_dir, "model.pkl"), "wb") as m:
+        pickle.dump(obj, m)
     if metadata is not None:
         with open(os.path.join(dest_dir, "metadata.json"), "w") as f:
             simplejson.dump(metadata, f, default=str)
-
-
-def _dump_step(
-    step: Tuple[str, Union[GordoBase, TransformerMixin]],
-    dest_dir: Union[os.PathLike, str],
-    n_step: int = 0,
-):
-    """
-    Accepts any Scikit-Learn transformer and dumps it into a directory
-    recoverable by gordo_components.serializer.pipeline_serializer.load
-
-    Parameters
-    ----------
-    step
-        The step to dump
-    dest_dir
-        The path to the top level directory to start the potentially recursive saving of steps.
-    n_step
-        The order of this step in the pipeline, default to 0
-
-    Returns
-    -------
-    None
-        Creates a new directory at the `dest_dir` in the format:
-        `n_step=000-class=<full.path.to.Object` with any required files for recovery stored there.
-    """
-    step_name, step_transformer = step
-    step_import_str = (
-        f"{step_transformer.__module__}.{step_transformer.__class__.__name__}"
-    )
-    sub_dir = os.path.join(
-        dest_dir, f"n_step={str(n_step).zfill(3)}-class={step_import_str}"
-    )
-
-    os.makedirs(sub_dir, exist_ok=True)
-
-    if any(isinstance(step_transformer, Obj) for Obj in [FeatureUnion, Pipeline]):
-        steps_attr = (
-            "transformer_list"
-            if isinstance(step_transformer, FeatureUnion)
-            else "steps"
-        )
-        for i, step in enumerate(getattr(step_transformer, steps_attr)):
-            _dump_step(step=step, n_step=i, dest_dir=sub_dir)
-
-        # If this is a feature Union, we want to save `n_jobs` & `transformer_weights`
-        if isinstance(step_transformer, FeatureUnion):
-            params = {
-                "n_jobs": getattr(step_transformer, "n_jobs"),
-                "transformer_weights": getattr(step_transformer, "transformer_weights"),
-            }
-            with open(os.path.join(sub_dir, "params.json"), "w") as f:
-                simplejson.dump(params, f)
-    else:
-
-        if isinstance(step_transformer, GordoBase):
-            if not hasattr(step_transformer, "load_from_dir"):
-                raise AttributeError(
-                    f'The object in this step implements a "save_to_dir" but '
-                    f'not "load_from_dir" it will be un-recoverable!'
-                )
-            logger.info(f"Saving model to sub_dir: {sub_dir}")
-            step_transformer.save_to_dir(os.path.join(sub_dir))
-
-        # This may be a transformer which has a GordoBase as a parameter
-        else:
-
-            # We have to ensure this is a pickle-able transformer, in that it doesn't
-            # have any GordoBase models hiding as a parameter to it.
-            attrs_dir = os.path.join(sub_dir, "_gordo_base_attributes")
-            for attr_name, attr_value in step_transformer.__dict__.items():
-                if isinstance(attr_value, Pipeline):
-                    attr_serialization_dir = os.path.join(attrs_dir, attr_name)
-                    new_attr_val = {
-                        "class_path": None,
-                        "load_dir": attr_serialization_dir,
-                    }
-                    dump(attr_value, attr_serialization_dir)
-                    setattr(step_transformer, attr_name, new_attr_val)
-
-                elif isinstance(attr_value, GordoBase):
-                    attr_serialization_dir = os.path.join(attrs_dir, attr_name)
-                    os.makedirs(attr_serialization_dir, exist_ok=True)
-
-                    attr_value.save_to_dir(attr_serialization_dir)
-                    new_attr_val = {
-                        "class_path": f"{attr_value.__module__}.{attr_value.__class__.__name__}",
-                        "load_dir": attr_serialization_dir,
-                    }
-                    setattr(step_transformer, attr_name, new_attr_val)
-
-            with bz2.open(
-                os.path.join(sub_dir, f"{step_name}.pkl.gz"), "wb"
-            ) as s:  # type: IO[bytes]
-                pickle.dump(step_transformer, s)

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -114,12 +114,8 @@ def test_output_dir(tmp_dir):
     _save_model_for_workflow(model=model, metadata=metadata, output_dir=output_dir)
 
     # Assert the model was saved at the location
-    # using gordo_components.serializer should create some subdir(s)
-    # which start with 'n_step'
-    dirs = [d for d in os.listdir(output_dir) if d.startswith("n_step")]
-    assert (
-        len(dirs) >= 1
-    ), "Expected saving of model to create at least one subdir, but got {len(dirs)}"
+    # Should be model file, and the metadata
+    assert len(os.listdir(output_dir)) == 2
 
 
 @pytest.mark.parametrize(
@@ -413,12 +409,8 @@ def test_provide_saved_model_simple_happy_path(tmp_dir):
     )
 
     # Assert the model was saved at the location
-    # using gordo_components.serializer should create some subdir(s)
-    # which start with 'n_step'
-    dirs = [d for d in os.listdir(model_location) if d.startswith("n_step")]
-    assert (
-        len(dirs) >= 1
-    ), "Expected saving of model to create at least one subdir, but got {len(dirs)}"
+    # Should be model file, and the metadata
+    assert len(os.listdir(output_dir)) == 2
 
 
 def test_provide_saved_model_caching_handle_existing_same_dir(tmp_dir):

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -400,7 +400,7 @@ def test_provide_saved_model_simple_happy_path(tmp_dir):
     data_config = get_random_data()
     output_dir = os.path.join(tmp_dir.name, "model")
 
-    model_location = provide_saved_model(
+    provide_saved_model(
         name="model-name",
         model_config=model_config,
         data_config=data_config,

--- a/tests/gordo_components/model/test_model.py
+++ b/tests/gordo_components/model/test_model.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import unittest
-import tempfile
+import pickle
 import logging
 import pydoc
 
@@ -128,36 +127,32 @@ def test_save_load(model, kind):
     xTest = np.random.random(size=6).reshape(3, 2)
     xHat = model_out.predict(xTest)
 
-    with tempfile.TemporaryDirectory() as tmp:
-        model_out.save_to_dir(tmp)
-        model_out_clone = pydoc.locate(
-            f"gordo_components.model.models.{model}"
-        ).load_from_dir(tmp)
+    model_out_clone = pickle.loads(pickle.dumps(model_out))
 
-        # Assert parameters are the same.
-        assert model_out_clone.get_params() == model_out_clone.get_params()
+    # Assert parameters are the same.
+    assert model_out_clone.get_params() == model_out_clone.get_params()
 
-        # Assert it maintained the state by ensuring predictions are the same
-        assert np.allclose(xHat.flatten(), model_out_clone.predict(xTest).flatten())
+    # Assert it maintained the state by ensuring predictions are the same
+    assert np.allclose(xHat.flatten(), model_out_clone.predict(xTest).flatten())
 
-        assert "history" in model_out.get_metadata()
-        assert (
-            model_out.get_metadata() == model_out_clone.get_metadata()
-        ), "Metadata from model is not same after saving and loading"
+    assert "history" in model_out.get_metadata()
+    assert (
+        model_out.get_metadata() == model_out_clone.get_metadata()
+    ), "Metadata from model is not same after saving and loading"
 
-        # Assert that epochs list, history dict and params dict in
-        # the History object are the same
-        assert (
-            model_out.model.history.epoch == model_out_clone.model.history.epoch
-        ), "Epoch lists differ between original and loaded model history"
+    # Assert that epochs list, history dict and params dict in
+    # the History object are the same
+    assert (
+        model_out.model.history.epoch == model_out_clone.model.history.epoch
+    ), "Epoch lists differ between original and loaded model history"
 
-        assert (
-            model_out.model.history.history == model_out_clone.model.history.history
-        ), "History dictionary with losses and accuracies differ between original and loaded model history"
+    assert (
+        model_out.model.history.history == model_out_clone.model.history.history
+    ), "History dictionary with losses and accuracies differ between original and loaded model history"
 
-        assert (
-            model_out.model.history.params == model_out_clone.model.history.params
-        ), "Params dictionaries differ between original and loaded model history"
+    assert (
+        model_out.model.history.params == model_out_clone.model.history.params
+    ), "Params dictionaries differ between original and loaded model history"
 
 
 def test_lookback_window_ae_valueerror_during_fit():

--- a/tests/gordo_components/serializer/test_serializer_load_dump.py
+++ b/tests/gordo_components/serializer/test_serializer_load_dump.py
@@ -3,8 +3,6 @@
 import unittest
 import logging
 
-from collections import OrderedDict
-from os import path, listdir
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -23,32 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 class PipelineSerializationTestCase(unittest.TestCase):
-    def _structure_verifier(self, prefix_dir, structure):
-        """
-        Recursively check directory / file structure as represented in an
-        OrderedDict
-        """
-        for directory, file_or_dict in structure.items():
-
-            # Join the prefix_dir to the relative directory for this key/value
-            directory = path.join(prefix_dir, directory)
-
-            logger.debug(f"Prefix dir listing: {listdir(prefix_dir)}")
-            logger.debug(f"Dir: {directory}")
-            logger.debug(f"File or dict: {file_or_dict}")
-            logger.debug(f"Files in dir: {listdir(directory)}")
-            logger.debug("-" * 30)
-
-            self.assertTrue(path.isdir(directory))
-
-            # If this is an OrderedDict, then it's another subdirectory struct
-            if isinstance(file_or_dict, OrderedDict):
-                self._structure_verifier(directory, file_or_dict)
-            else:
-
-                # Otherwise we just need to verify that this is indeed a file
-                self.assertTrue(path.isfile(path.join(directory, file_or_dict)))
-
     def test_pipeline_serialization(self):
 
         pipe = Pipeline(
@@ -83,64 +55,6 @@ class PipelineSerializationTestCase(unittest.TestCase):
             # Test dump
             metadata = {"key": "value"}
             serializer.dump(pipe, tmp, metadata=metadata)
-
-            # Assert that a dirs are created for each step in Pipeline
-            expected_structure = OrderedDict(
-                [
-                    ("n_step=000-class=sklearn.pipeline.Pipeline", "metadata.json"),
-                    (
-                        "n_step=000-class=sklearn.pipeline.Pipeline",
-                        OrderedDict(
-                            [
-                                (
-                                    "n_step=000-class=sklearn.decomposition.pca.PCA",
-                                    "pca1.pkl.gz",
-                                ),
-                                (
-                                    "n_step=001-class=sklearn.pipeline.FeatureUnion",
-                                    "params.json",
-                                ),
-                                (
-                                    "n_step=001-class=sklearn.pipeline.FeatureUnion",
-                                    OrderedDict(
-                                        [
-                                            (
-                                                "n_step=000-class=sklearn.decomposition.pca.PCA",
-                                                "pca2.pkl.gz",
-                                            ),
-                                            (
-                                                "n_step=001-class=sklearn.pipeline.Pipeline",
-                                                OrderedDict(
-                                                    [
-                                                        (
-                                                            "n_step=000-class=sklearn.preprocessing.data.MinMaxScaler",
-                                                            "minmax.pkl.gz",
-                                                        ),
-                                                        (
-                                                            "n_step=001-class=sklearn.decomposition.truncated_svd.TruncatedSVD",
-                                                            "truncsvd.pkl.gz",
-                                                        ),
-                                                    ]
-                                                ),
-                                            ),
-                                        ]
-                                    ),
-                                ),
-                                (
-                                    "n_step=002-class=gordo_components.model.models.KerasAutoEncoder",
-                                    "model.h5",
-                                ),
-                                (
-                                    "n_step=002-class=gordo_components.model.models.KerasAutoEncoder",
-                                    "params.json",
-                                ),
-                            ]
-                        ),
-                    ),
-                ]
-            )
-
-            self._structure_verifier(prefix_dir=tmp, structure=expected_structure)
 
             # Test load from the serialized pipeline above
             pipe_clone = serializer.load(tmp)


### PR DESCRIPTION
Problem-ish :spaghetti: 
---
Previously (our) Keras models couldn't be pickled. We worked around this by creating a directory tree of individually pickled steps in the model/pipeline, and any keras model's encountred would be saved and loaded using `.save_to_dir()`/`load_from_dir()` methods. 

This introduced quite complex saving logic and thus code and tests

Solution? :hamburger: 
---
Implement custom `__getstate__` and `__setstate__` methods for our models, so we can "just" pickle the entire pipeline/model directly.