### PR TITLE
Fix parallel testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [aliases]
 
 # All tests in parallel, minus any requiring docker
-test             = pytest --addopts "-n auto -m 'not dockertest'"
+test             = pytest --addopts "-n auto -m 'not dockertest' --ignore benchmarks"
 
 # Test _everything_
 testall          = pytest --addopts "--ignore benchmarks"

--- a/tests/gordo_components/workflow/test_workflow_generator/test_workflow_generator.py
+++ b/tests/gordo_components/workflow/test_workflow_generator/test_workflow_generator.py
@@ -111,7 +111,7 @@ def _get_env_for_machine_build_serve_task(machine, expanded_template):
 @pytest.mark.parametrize(
     "fp_config", ("/code/examples/config_legacy.yaml", "/code/examples/config_crd.yaml")
 )
-@pytest.mark.slowtest
+@pytest.mark.dockertest
 def test_argo_lint(argo_docker_image, fp_config, docker_client, repo_dir):
     """
     Test the example config files, assumed to be valid, produces a valid workflow via `argo lint`


### PR DESCRIPTION
Add `--ignore benchmarks` to the `test`, so it will run tests, ignoring benchmarks and docker tests.

Side note: checked to see what would happen in CircleCI if we ran two tests, one with the docker tests and the other without (using parallelism) but that job still took >10mins. 

