### PR TITLE
Add missing limits to postgres, grafana and misc workers

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -311,6 +311,9 @@ spec:
                   requests:
                     memory: 1G
                     cpu: 500m
+                  limits:
+                    memory: 2G
+                    cpu: 1000m
                 readinessProbe:
                   httpGet:
                     path: /login
@@ -448,6 +451,9 @@ spec:
                   requests:
                     memory: 256Mi
                     cpu: 50m
+                  limits:
+                    memory: 500Mi
+                    cpu: 500m
                 env:
                   - name: POSTGRES_USER
                     value: postgres

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -210,6 +210,7 @@ spec:
           cpu: 10m
         limits:
           memory: 1G
+          cpu: 200m
 
 
   - name: gordo-influx
@@ -339,6 +340,7 @@ spec:
           cpu: 10m
         limits:
           memory: 1G
+          cpu: 200m
 
 
   - name: gordo-grafana
@@ -453,7 +455,7 @@ spec:
                     cpu: 50m
                   limits:
                     memory: 500Mi
-                    cpu: 500m
+                    cpu: 200m
                 env:
                   - name: POSTGRES_USER
                     value: postgres
@@ -522,6 +524,7 @@ spec:
           cpu: 10m
         limits:
           memory: 1G
+          cpu: 200m
 
 
 
@@ -1130,6 +1133,7 @@ spec:
           cpu: 10m
         limits:
           memory: 1G
+          cpu: 200m
 
   - name: postgres-cleanup
     activeDeadlineSeconds: 300
@@ -1149,6 +1153,7 @@ spec:
           cpu: 10m
         limits:
           memory: 1G
+          cpu: 200m
 
   - name: cleanup
     retryStrategy:
@@ -1167,6 +1172,7 @@ spec:
           cpu: 10m
         limits:
           memory: 1G
+          cpu: 200m
 
 
   - name: sql-and-cleanup


### PR DESCRIPTION
There were a few things we deploy which did not contain resource limits, and its quite possible that in the future there will be default limits imposed, so we should set them ourself instead so we are in control. 

Tested and it works