### PR TITLE
Update client metadata fetching

### DIFF
--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -244,15 +244,15 @@ class Client:
         Dict[str, dict]
             Mapping of target names to their metadata
         """
-        if hasattr(self, "_metadata") and not force_refresh:
-            return self._metadata.copy()
+        if hasattr(self, "metadata_") and not force_refresh:
+            return self.metadata_.copy()
 
         if force_refresh:
             self.endpoints = self.get_endpoints()  # Forced refresh if
-        self._metadata: Dict[str, dict] = {
+        self.metadata_: Dict[str, dict] = {
             ep.name: ep.raw_metadata() for ep in self.endpoints
         }
-        return self._metadata.copy()
+        return self.metadata_.copy()
 
     def predict(
         self, start: datetime, end: datetime, refresh_endpoints: bool = False

--- a/gordo_components/client/client.py
+++ b/gordo_components/client/client.py
@@ -246,15 +246,13 @@ class Client:
         """
         if hasattr(self, "_metadata") and not force_refresh:
             return self._metadata.copy()
-        else:
-            self._metadata: Dict[str, dict] = dict()
-            for endpoint in self.endpoints:
-                resp = self.session.get(f"{self.base_url + endpoint.endpoint}/metadata")
-                if resp.ok:
-                    self._metadata[endpoint.name] = resp.json()
-                else:
-                    raise IOError(f"Failed to get metadata: '{repr(resp.content)}'")
-            return self.get_metadata()
+
+        if force_refresh:
+            self.endpoints = self.get_endpoints()  # Forced refresh if
+        self._metadata: Dict[str, dict] = {
+            ep.name: ep.raw_metadata() for ep in self.endpoints
+        }
+        return self._metadata.copy()
 
     def predict(
         self, start: datetime, end: datetime, refresh_endpoints: bool = False

--- a/gordo_components/client/forwarders.py
+++ b/gordo_components/client/forwarders.py
@@ -118,7 +118,7 @@ class ForwardPredictionsIntoInflux:
         None
         """
         # Setup tags; metadata (if any) and other key value pairs.
-        tags = {"machine": f"{endpoint.target_name}"}
+        tags = {"machine": f"{endpoint.endpoint_metadata.metadata.name}"}
         tags.update(metadata)
 
         # The measurements to be posted to Influx
@@ -139,8 +139,13 @@ class ForwardPredictionsIntoInflux:
 
             # Set the sub df's column names equal to the name of the tags if
             # they match the length of the tag list.
-            if len(sub_df.columns) == len(endpoint.tag_list):
-                sub_df.columns = [tag.name for tag in endpoint.tag_list]
+            if len(sub_df.columns) == len(
+                endpoint.endpoint_metadata.metadata.dataset.tag_list
+            ):
+                sub_df.columns = [
+                    tag.name
+                    for tag in endpoint.endpoint_metadata.metadata.dataset.tag_list
+                ]
 
             self._write_to_influx_with_retries(sub_df, tags, top_lvl_name)
 

--- a/gordo_components/client/forwarders.py
+++ b/gordo_components/client/forwarders.py
@@ -118,7 +118,7 @@ class ForwardPredictionsIntoInflux:
         None
         """
         # Setup tags; metadata (if any) and other key value pairs.
-        tags = {"machine": f"{endpoint.endpoint_metadata.metadata.name}"}
+        tags = {"machine": f"{endpoint.name}"}
         tags.update(metadata)
 
         # The measurements to be posted to Influx
@@ -139,13 +139,8 @@ class ForwardPredictionsIntoInflux:
 
             # Set the sub df's column names equal to the name of the tags if
             # they match the length of the tag list.
-            if len(sub_df.columns) == len(
-                endpoint.endpoint_metadata.metadata.dataset.tag_list
-            ):
-                sub_df.columns = [
-                    tag.name
-                    for tag in endpoint.endpoint_metadata.metadata.dataset.tag_list
-                ]
+            if len(sub_df.columns) == len(endpoint.tag_list):
+                sub_df.columns = [tag.name for tag in endpoint.tag_list]
 
             self._write_to_influx_with_retries(sub_df, tags, top_lvl_name)
 

--- a/gordo_components/client/utils.py
+++ b/gordo_components/client/utils.py
@@ -18,6 +18,12 @@ class EndpointMetadata:
         """
         self.__data = data
 
+    def raw_metadata(self):
+        """
+        Access the raw metadata
+        """
+        return self.__data.copy()
+
     @property
     def name(self):
         """Name of this endpoint"""

--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from typing import Tuple, List, Dict, Union, Optional, Iterable, Callable
+from typing import Tuple, List, Dict, Union, Optional, Iterable, Callable, Sequence
 from datetime import datetime
 
 import pandas as pd
@@ -22,8 +22,8 @@ class TimeSeriesDataset(GordoBaseDataset):
         data_provider: GordoBaseDataProvider,
         from_ts: datetime,
         to_ts: datetime,
-        tag_list: List[Union[str, Dict, SensorTag]],
-        target_tag_list: Optional[List[Union[str, Dict, SensorTag]]] = None,
+        tag_list: Sequence[Union[str, Dict, SensorTag]],
+        target_tag_list: Optional[Sequence[Union[str, Dict, SensorTag]]] = None,
         resolution: Optional[str] = "10T",
         row_filter: str = "",
         aggregation_methods: Union[str, List[str], Callable] = "mean",
@@ -44,10 +44,10 @@ class TimeSeriesDataset(GordoBaseDataset):
             Earliest possible point in the dataset (inclusive)
         to_ts: datetime
             Earliest possible point in the dataset (exclusive)
-        tag_list: List[Union[str, Dict, sensor_tag.SensorTag]]
+        tag_list: Sequence[Union[str, Dict, sensor_tag.SensorTag]]
             List of tags to include in the dataset. The elements can be strings,
             dictionaries or SensorTag namedtuples.
-        target_tag_list: Optional[List[Union[str, Dict, sensor_tag.SensorTag]]]
+        target_tag_list: Sequence[List[Union[str, Dict, sensor_tag.SensorTag]]]
             List of tags to set as the dataset y. These will be treated the same as
             tag_list when fetching and pre-processing (resampling) but will be split
             into the y return from ``.get_data()``
@@ -76,9 +76,9 @@ class TimeSeriesDataset(GordoBaseDataset):
         """
         self.from_ts = from_ts
         self.to_ts = to_ts
-        self.tag_list = normalize_sensor_tags(tag_list)
+        self.tag_list = normalize_sensor_tags(list(tag_list))
         self.target_tag_list = (
-            normalize_sensor_tags(target_tag_list) if target_tag_list else []
+            normalize_sensor_tags(list(target_tag_list)) if target_tag_list else []
         )
         self.resolution = resolution
         self.data_provider = data_provider

--- a/tests/gordo_components/client/test_client.py
+++ b/tests/gordo_components/client/test_client.py
@@ -351,9 +351,9 @@ def test_client_cli_predict_non_zero_exit(
         out = runner.invoke(cli.gordo, args=args)
 
     if should_fail:
-        assert out.exit_code != 0, f"{out.output}"
+        assert out.exit_code != 0, f"{out.output or out.exception}"
     else:
-        assert out.exit_code == 0, f"{out.output}"
+        assert out.exit_code == 0, f"{out.output or out.exception}"
 
 
 @pytest.mark.parametrize(
@@ -385,13 +385,11 @@ def _endpoint_metadata(name: str, healthy: bool) -> EndpointMetadata:
     Helper to build a basic EndpointMetadata with only name and healthy fields set
     """
     return EndpointMetadata(
-        target_name=name,
-        healthy=healthy,
-        endpoint=None,
-        tag_list=None,
-        target_tag_list=None,
-        resolution=None,
-        model_offset=None,
+        data={
+            "endpoint-metadata": {"metadata": {"name": name}},
+            "healthy": healthy,
+            "endpoint": "/gordo/v0/test-project",
+        }
     )
 
 

--- a/tests/gordo_components/client/test_forwarders.py
+++ b/tests/gordo_components/client/test_forwarders.py
@@ -16,13 +16,21 @@ def test_influx_forwarder(influxdb):
     multi-indexed series
     """
     endpoint = EndpointMetadata(
-        "some-target-name",
-        healthy=True,
-        endpoint="/some-endpoint",
-        tag_list=tu.SENSORTAG_LIST,
-        target_tag_list=tu.SENSORTAG_LIST,
-        resolution="10T",
-        model_offset=0,
+        data={
+            "endpoint-metadata": {
+                "metadata": {
+                    "name": "some-target-name",
+                    "dataset": {
+                        "tag_list": tu.SENSORTAG_LIST,
+                        "target_tag_list": tu.SENSORTAG_LIST,
+                        "resolution": "10T",
+                    },
+                    "model": {"model-offset": 0},
+                }
+            },
+            "endpoint": "/some-endpoint",
+            "healthy": True,
+        }
     )
 
     # Feature outs which match length of tags

--- a/tests/gordo_components/client/test_utils.py
+++ b/tests/gordo_components/client/test_utils.py
@@ -1,0 +1,28 @@
+import io
+from gordo_components.client.utils import EndpointMetadata
+
+
+def test_endpoint_metadata():
+
+    data = dict(
+        key1="value1",
+        key2=[dict(subkey1="subvalue1")],
+        key3=dict(subkey2="subkey2"),
+        key4=[1, 2],
+        key5={"hyphen-key": 2},
+        key6=dict(underscore_key=1),
+    )
+
+    epm = EndpointMetadata(data)
+    assert epm.key1 == "value1"
+    assert epm.key2[0].subkey1 == "subvalue1"
+    assert epm.key3.subkey2 == "subkey2"
+    assert epm.key4[0] == 1
+    assert len(epm.key4) == 2
+    assert epm.key4[0] == 1
+    assert epm.key4[1] == 2
+    assert epm.key5.hyphen_key == 2
+    assert epm.key6.underscore_key == 1
+
+    # Access item raw by calling it.
+    assert epm.key5() == {"hyphen-key": 2}

--- a/tests/gordo_components/client/test_utils.py
+++ b/tests/gordo_components/client/test_utils.py
@@ -1,28 +1,29 @@
-import io
 from gordo_components.client.utils import EndpointMetadata
+from gordo_components.dataset.sensor_tag import SensorTag
 
 
 def test_endpoint_metadata():
-
-    data = dict(
-        key1="value1",
-        key2=[dict(subkey1="subvalue1")],
-        key3=dict(subkey2="subkey2"),
-        key4=[1, 2],
-        key5={"hyphen-key": 2},
-        key6=dict(underscore_key=1),
-    )
+    data = {
+        "endpoint-metadata": {
+            "metadata": {
+                "name": "test-project-target-a",
+                "dataset": {
+                    "resolution": "10T",
+                    "tag_list": [],
+                    "target_tag_list": [{"asset": "foo", "name": "bar"}],
+                },
+                "model": {"model-offset": 1},
+            }
+        },
+        "healthy": True,
+        "endpoint": "/gordo/v0/test-project/test-project-target-a",
+    }
 
     epm = EndpointMetadata(data)
-    assert epm.key1 == "value1"
-    assert epm.key2[0].subkey1 == "subvalue1"
-    assert epm.key3.subkey2 == "subkey2"
-    assert epm.key4[0] == 1
-    assert len(epm.key4) == 2
-    assert epm.key4[0] == 1
-    assert epm.key4[1] == 2
-    assert epm.key5.hyphen_key == 2
-    assert epm.key6.underscore_key == 1
-
-    # Access item raw by calling it.
-    assert epm.key5() == {"hyphen-key": 2}
+    assert epm.name == "test-project-target-a"
+    assert epm.endpoint == "/gordo/v0/test-project/test-project-target-a"
+    assert epm.tag_list == []
+    assert epm.target_tag_list == [SensorTag(name="bar", asset="foo")]
+    assert epm.resolution == "10T"
+    assert epm.model_offset == 1
+    assert epm.healthy is True

--- a/tests/gordo_components/client/test_utils.py
+++ b/tests/gordo_components/client/test_utils.py
@@ -27,3 +27,4 @@ def test_endpoint_metadata():
     assert epm.resolution == "10T"
     assert epm.model_offset == 1
     assert epm.healthy is True
+    assert epm.raw_metadata() == data


### PR DESCRIPTION
Will close #577 

- [X] get_metadata() should returned pre-fetched metadata
- [X] More direct mapping between `EndpointMetadata` and actual metadata
- [X] `.predict(..., refresh_endpoints=True)` param to optionally update endpoint metadata before making predictions.