### PR TITLE
Accept metrics list in evaluation config key

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -25,6 +25,7 @@ from gordo_components.dataset.dataset import _get_dataset
 from gordo_components.dataset.base import GordoBaseDataset
 from gordo_components.model.base import GordoBase
 from gordo_components.model.utils import metric_wrapper
+from gordo_components.workflow.config_elements.normalized_config import NormalizedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -609,10 +610,7 @@ def metrics_from_list(metric_list: Optional[List[str]] = None) -> List[Callable]
     AttributeError
         If the metric name is not found in `sklearn.metrics`
     """
-    metric_list = metric_list or [
-        "explained_variance_score",
-        "r2_score",
-        "mean_squared_error",
-        "mean_absolute_error",
-    ]
+    metric_list = (
+        metric_list or NormalizedConfig.DEFAULT_CONFIG_GLOBALS["evaluation"]["metrics"]
+    )
     return [getattr(metrics, metric) for metric in metric_list]

--- a/gordo_components/workflow/config_elements/normalized_config.py
+++ b/gordo_components/workflow/config_elements/normalized_config.py
@@ -23,7 +23,7 @@ def _calculate_influx_resources(nr_of_machines):
 
 class NormalizedConfig:
 
-    DEFAULT_RUNTIME_GLOBALS = {
+    DEFAULT_CONFIG_GLOBALS = {
         "runtime": {
             "server": {
                 "resources": {
@@ -49,6 +49,12 @@ class NormalizedConfig:
         "evaluation": {
             "cv_mode": "full_build",
             "scoring_scaler": "sklearn.preprocessing.RobustScaler",
+            "metrics": [
+                "explained_variance_score",
+                "r2_score",
+                "mean_squared_error",
+                "mean_absolute_error",
+            ],
         },
     }
 
@@ -60,7 +66,7 @@ class NormalizedConfig:
     globals: dict
 
     def __init__(self, config: dict, project_name: str):
-        default_globals = self.DEFAULT_RUNTIME_GLOBALS
+        default_globals = self.DEFAULT_CONFIG_GLOBALS
         default_globals["runtime"]["influx"][  # type: ignore
             "resources"
         ] = _calculate_influx_resources(  # type: ignore

--- a/tests/gordo_components/workflow/test_config_elements.py
+++ b/tests/gordo_components/workflow/test_config_elements.py
@@ -74,7 +74,7 @@ class DatasetConfigElementTestCase(unittest.TestCase):
 
 
 class MachineConfigElementTestCase(unittest.TestCase):
-    default_globals = dict(NormalizedConfig.DEFAULT_RUNTIME_GLOBALS)
+    default_globals = dict(NormalizedConfig.DEFAULT_CONFIG_GLOBALS)
     # set something different here so we dont have to change the test every time we
     # change the default runtime parameters
     default_globals["runtime"] = {
@@ -155,7 +155,16 @@ class MachineConfigElementTestCase(unittest.TestCase):
                         2018, 1, 2, 9, 0, 30, tzinfo=timezone.utc
                     ).isoformat(),
                 },
-                "evaluation": {"cv_mode": "full_build", "scoring_scaler": None,},
+                "evaluation": {
+                    "cv_mode": "full_build",
+                    "scoring_scaler": None,
+                    "metrics": [
+                        "explained_variance_score",
+                        "r2_score",
+                        "mean_squared_error",
+                        "mean_absolute_error",
+                    ],
+                },
                 "metadata": {
                     "global-metadata": {},
                     "machine-metadata": {"id": "special-id"},


### PR DESCRIPTION
Problem :worried: 
---
We've added the ability to score the model on multiple scoring functions, but those are fixed to 
- r2_score
- explained_variance_score
- mean_squared_error
- mean_absolute_error

Solution :clown_face: 
---
Evaluation config can now take any scorer name in [sklearn.metrics](https://scikit-learn.org/stable/modules/classes.html#sklearn-metrics-metrics)

```yaml
evaluation:
   metrics:
      - r2_score
      - max_error
```

Will close #242 