### PR TITLE
Support setting random seed in evaluation key

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -6,11 +6,13 @@ import json
 import logging
 import os
 import time
+import random
 from pathlib import Path
 from typing import Union, Optional, Dict, Any, Tuple
 
 import pandas as pd
 import numpy as np
+import tensorflow as tf
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.metrics import (
@@ -88,6 +90,13 @@ def build_model(
     -------
         Tuple[Optional[sklearn.base.BaseEstimator], dict]
     """
+    if evaluation_config.get("seed"):
+        seed = evaluation_config["seed"]
+        logger.info(f"Setting random seed: '{seed}'")
+        tf.random.set_seed(seed)
+        np.random.seed(seed)
+        random.seed(seed)
+
     # Get the dataset from config
     logger.debug(f"Initializing Dataset with config {data_config}")
 

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -627,17 +627,26 @@ def test_model_builder_cv_scores_only(should_be_equal: bool, evaluation_config: 
 
 
 @pytest.mark.parametrize("seed", (None, 1234))
-def test_setting_seed(seed):
+@pytest.mark.parametrize(
+    "model_config",
+    (
+        {
+            "sklearn.multioutput.MultiOutputRegressor": {
+                "estimator": "sklearn.ensemble.forest.RandomForestRegressor"
+            }
+        },
+        {
+            "gordo_components.model.models.KerasAutoEncoder": {
+                "kind": "feedforward_hourglass"
+            }
+        },
+    ),
+)
+def test_setting_seed(seed, model_config):
     """
     Test that we can set the seed and get same results.
     """
 
-    # Choosing a random type model to add to the randomness of a trained model
-    model_config = {
-        "sklearn.multioutput.MultiOutputRegressor": {
-            "estimator": "sklearn.ensemble.forest.RandomForestRegressor"
-        }
-    }
     data_config = get_random_data()
     evaluation_config = {"cv_mode": "full_build", "seed": seed}
 
@@ -664,5 +673,6 @@ def test_setting_seed(seed):
     # Equality depends on the seed being set.
     if seed:
         assert df1.equals(df2)
+        assert np.random.seed
     else:
         assert not df1.equals(df2)

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -673,6 +673,5 @@ def test_setting_seed(seed, model_config):
     # Equality depends on the seed being set.
     if seed:
         assert df1.equals(df2)
-        assert np.random.seed
     else:
         assert not df1.equals(df2)

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -624,3 +624,45 @@ def test_model_builder_cv_scores_only(should_be_equal: bool, evaluation_config: 
         assert model is not None
     else:
         assert model is None
+
+
+@pytest.mark.parametrize("seed", (None, 1234))
+def test_setting_seed(seed):
+    """
+    Test that we can set the seed and get same results.
+    """
+
+    # Choosing a random type model to add to the randomness of a trained model
+    model_config = {
+        "sklearn.multioutput.MultiOutputRegressor": {
+            "estimator": "sklearn.ensemble.forest.RandomForestRegressor"
+        }
+    }
+    data_config = get_random_data()
+    evaluation_config = {"cv_mode": "full_build", "seed": seed}
+
+    # Training two instances, without a seed should result in different scores,
+    # while doing it with a seed should result in the same scores.
+    _model, metadata1 = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+        evaluation_config=evaluation_config,
+    )
+    _model, metadata2 = build_model(
+        name="model-name",
+        model_config=model_config,
+        data_config=data_config,
+        metadata={},
+        evaluation_config=evaluation_config,
+    )
+
+    df1 = pd.DataFrame.from_dict(metadata1["model"]["cross-validation"]["scores"])
+    df2 = pd.DataFrame.from_dict(metadata2["model"]["cross-validation"]["scores"])
+
+    # Equality depends on the seed being set.
+    if seed:
+        assert df1.equals(df2)
+    else:
+        assert not df1.equals(df2)


### PR DESCRIPTION
Problem :thinking: 
---
_Sometimes_ it is appropriate to set the seed when training/evaluating models.

Solution :open_hands: 
---
Add ability to do the following in a config in the `evaluation` key:
```yaml
evalutation:
  seed: 1234
```

Will close #452 