### PR TITLE
Take paths to metrics as well as function names

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -592,14 +592,14 @@ def provide_saved_model(
 def metrics_from_list(metric_list: Optional[List[str]] = None) -> List[Callable]:
     """
     Given a list of metric function paths. ie. sklearn.metrics.r2_score or
-    simple function names which are expected to be in the ``sklearn.metrics`` module
-    will also work to return the loaded functions
+    simple function names which are expected to be in the ``sklearn.metrics`` module,
+    this will return a list of those loaded functions.
 
     Parameters
     ----------
     metrics: Optional[List[str]]
         List of function paths to use as metrics for the model
-        Defaults to:
+        Defaults to those specified in :class:`gordo_components.workflow.config_components.NormalizedConfig`
         sklearn.metrics.explained_variance_score,
         sklearn.metrics.r2_score,
         sklearn.metrics.mean_squared_error,

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -591,8 +591,9 @@ def provide_saved_model(
 
 def metrics_from_list(metric_list: Optional[List[str]] = None) -> List[Callable]:
     """
-    Given a list of metric function paths. ie. sklearn.metrics.r2_score
-    return the loaded functions
+    Given a list of metric function paths. ie. sklearn.metrics.r2_score or
+    simple function names which are expected to be in the ``sklearn.metrics`` module
+    will also work to return the loaded functions
 
     Parameters
     ----------
@@ -611,7 +612,7 @@ def metrics_from_list(metric_list: Optional[List[str]] = None) -> List[Callable]
 
     Raises
     ------
-    ValueError
+    AttributeError:
        If the function cannot be loaded.
     """
     defaults = NormalizedConfig.DEFAULT_CONFIG_GLOBALS["evaluation"]["metrics"]
@@ -619,7 +620,8 @@ def metrics_from_list(metric_list: Optional[List[str]] = None) -> List[Callable]
     for func_path in metric_list or defaults:
         func = pydoc.locate(func_path)
         if func is None:
-            raise ValueError(f"Could not locate metric function: {func_path}")
+            # Final attempt, load function from sklearn.metrics module.
+            funcs.append(getattr(metrics, func_path))
         else:
             funcs.append(func)
     return funcs

--- a/gordo_components/workflow/config_elements/normalized_config.py
+++ b/gordo_components/workflow/config_elements/normalized_config.py
@@ -50,10 +50,10 @@ class NormalizedConfig:
             "cv_mode": "full_build",
             "scoring_scaler": "sklearn.preprocessing.RobustScaler",
             "metrics": [
-                "explained_variance_score",
-                "r2_score",
-                "mean_squared_error",
-                "mean_absolute_error",
+                "sklearn.metrics.explained_variance_score",
+                "sklearn.metrics.r2_score",
+                "sklearn.metrics.mean_squared_error",
+                "sklearn.metrics.mean_absolute_error",
             ],
         },
     }

--- a/gordo_components/workflow/config_elements/normalized_config.py
+++ b/gordo_components/workflow/config_elements/normalized_config.py
@@ -50,10 +50,10 @@ class NormalizedConfig:
             "cv_mode": "full_build",
             "scoring_scaler": "sklearn.preprocessing.RobustScaler",
             "metrics": [
-                "sklearn.metrics.explained_variance_score",
-                "sklearn.metrics.r2_score",
-                "sklearn.metrics.mean_squared_error",
-                "sklearn.metrics.mean_absolute_error",
+                "explained_variance_score",
+                "r2_score",
+                "mean_squared_error",
+                "mean_absolute_error",
             ],
         },
     }

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -629,7 +629,12 @@ def test_model_builder_cv_scores_only(should_be_equal: bool, evaluation_config: 
 
 
 @pytest.mark.parametrize(
-    "metrics_", (["r2_score"], None, ["r2_score", "explained_variance_score"])
+    "metrics_",
+    (
+        ["sklearn.metrics.r2_score"],
+        None,
+        ["sklearn.metrics.r2_score", "sklearn.metrics.explained_variance_score"],
+    ),
 )
 def test_model_builder_metrics_list(metrics_: Optional[List[str]]):
     model_config = {
@@ -652,14 +657,15 @@ def test_model_builder_metrics_list(metrics_: Optional[List[str]]):
     )
 
     expected_metrics = metrics_ or [
-        "explained_variance_score",
-        "r2_score",
-        "mean_squared_error",
-        "mean_absolute_error",
+        "sklearn.metrics.explained_variance_score",
+        "sklearn.metrics.r2_score",
+        "sklearn.metrics.mean_squared_error",
+        "sklearn.metrics.mean_absolute_error",
     ]
 
     assert all(
-        metric.replace("_", "-") in metadata["model"]["cross-validation"]["scores"]
+        metric.split(".")[-1].replace("_", "-")
+        in metadata["model"]["cross-validation"]["scores"]
         for metric in expected_metrics
     )
 
@@ -676,7 +682,9 @@ def test_metrics_from_list():
         metrics.mean_absolute_error,
     ]
 
-    specifics = metrics_from_list(["adjusted_mutual_info_score", "r2_score"])
+    specifics = metrics_from_list(
+        ["sklearn.metrics.adjusted_mutual_info_score", "sklearn.metrics.r2_score"]
+    )
     assert specifics == [metrics.adjusted_mutual_info_score, metrics.r2_score]
 
 

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -632,6 +632,7 @@ def test_model_builder_cv_scores_only(should_be_equal: bool, evaluation_config: 
     "metrics_",
     (
         ["sklearn.metrics.r2_score"],
+        ["r2_score"],  # string names for funcs in sklearn.metrics should also work
         None,
         ["sklearn.metrics.r2_score", "sklearn.metrics.explained_variance_score"],
     ),


### PR DESCRIPTION
In relation to: https://github.com/equinor/gordo-components/pull/631#discussion_r344616190

Should take the full paths to the function names, rather than assuming they're in `sklearn.metrics`