### PR TITLE
Workflow exponential retries

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -80,35 +80,108 @@ spec:
       - name: GORDO_PROJECT_VERSION
         value: "{{project_version}}"
 
+  - name: apply-with-retries
+    retryStrategy:
+      limit: 4
+    inputs:
+      parameters:
+        - name: resource
+    metadata:
+      labels:
+        app: apply-with-retries
+        applications.gordo.equinor.com/project-name: "{{project_name}}"
+        applications.gordo.equinor.com/project-version: "{{project_version}}"
+    script:
+      image: {{ docker_registry }}/{{ docker_repository }}/gordo-deploy:{{gordo_version}}
+      command: [bash]
+      source: |
+        # Retries a command a configurable number of times with backoff.
+        #
+        # The retry count is given by ATTEMPTS (default 6), the initial backoff
+        # timeout is given by TIMEOUT in seconds (default 15.)
+        #
+        # Successive backoffs double the timeout.
+        # Thanks to  `phs` from stackoverflow:
+        # https://stackoverflow.com/questions/8350942/how-to-re-run-the-curl-command-automatically-when-the-error-occurs/8351489#8351489
+        function with_backoff {
+            local max_attempts=${ATTEMPTS-6}
+            local timeout=${TIMEOUT-15}
+            local attempt=0
+            local exitCode=0
+
+            while (( $attempt < $max_attempts ))
+            do
+                if "$@"
+                then
+                    return 0
+                else
+                    exitCode=$?
+                fi
+                echo "Got exitcode $exitCode" 1>&2
+                echo "Failure! Retrying in $timeout.." 1>&2
+                sleep $timeout
+                attempt=$(( attempt + 1 ))
+                timeout=$(( timeout * 2 ))
+            done
+
+            if [[ $exitCode != 0 ]]
+            then
+                echo "Command failed too many times, exiting! ($@)" 1>&2
+            fi
+
+            return $exitCode
+        }
+
+        function apply_once {
+            echo "$K_RESOURCE" | kubectl apply -f -
+        }
+        echo "applying resource:" 1>&2
+        echo "$K_RESOURCE" 1>&2
+        with_backoff apply_once
+
+
+      resources:
+        requests:
+          memory: "150M"
+          cpu: "10m"
+        limits:
+          memory: "200M"
+          cpu: "100m"
+      env:
+      - name: K_RESOURCE
+        value: {{ '"{{inputs.parameters.resource}}" '}}
 
   - name: gordo-influx-service
-    retryStrategy:
-      limit: 5
-    resource:
-      action: apply
-      manifest: |
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: gordo-influx-{{project_name}}
-          labels:
-            app: gordo-influx-{{project_name}}
-            app.kubernetes.io/name: influx
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-         {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-        {% endif %}
-        spec:
-          selector:
-            app: gordo-influx-{{project_name}}
-          ports:
-          - port: 8086
-            name: api
-            targetPort: 8086
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value: |
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: gordo-influx-{{project_name}}
+                    labels:
+                      app: gordo-influx-{{project_name}}
+                      app.kubernetes.io/name: influx
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                   {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                  {% endif %}
+                  spec:
+                    selector:
+                      app: gordo-influx-{{project_name}}
+                    ports:
+                    - port: 8086
+                      name: api
+                      targetPort: 8086
+
   - name: gordo-influx-statefulset
     retryStrategy:
       limit: 5
@@ -223,34 +296,36 @@ spec:
         template: gordo-influx-database-creator
 
   - name: gordo-grafana-service
-    retryStrategy:
-      limit: 5
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: gordo-grafana-{{project_name}}
-          labels:
-            app: gordo-grafana-{{project_name}}
-            app.kubernetes.io/name: grafana
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          selector:
-            app: gordo-grafana-{{project_name}}
-          ports:
-          - port: 3000
-            name: api
-            targetPort: 3000
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: gordo-grafana-{{project_name}}
+                    labels:
+                      app: gordo-grafana-{{project_name}}
+                      app.kubernetes.io/name: grafana
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    selector:
+                      app: gordo-grafana-{{project_name}}
+                    ports:
+                    - port: 3000
+                      name: api
+                      targetPort: 3000
 
   - name: gordo-grafana-statefulset
     retryStrategy:
@@ -354,33 +429,35 @@ spec:
 
 
   - name: gordo-postgres-service
-    retryStrategy:
-      limit: 5
-    resource:
-      action: apply
-      manifest: |
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: gordo-postgres-{{project_name}}
-          labels:
-            app: gordo-postgres-{{project_name}}
-            app.kubernetes.io/name: postgres
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          selector:
-            app: gordo-postgres-{{project_name}}
-          ports:
-          - port: 5432
-            name: api
-            targetPort: 5432
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value: |
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: gordo-postgres-{{project_name}}
+                    labels:
+                      app: gordo-postgres-{{project_name}}
+                      app.kubernetes.io/name: postgres
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    selector:
+                      app: gordo-postgres-{{project_name}}
+                    ports:
+                    - port: 5432
+                      name: api
+                      targetPort: 5432
   - name: gordo-postgres-statefulset
     retryStrategy:
       limit: 5
@@ -581,234 +658,243 @@ spec:
           cpu: "{{ model_builder_resources_limits_cpu }}m"
 
   - name: gordo-server-hpa
-    retryStrategy:
-      limit: 5
     inputs:
       parameters:
       - name: host-name
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: autoscaling/v1
-        kind: HorizontalPodAutoscaler
-        metadata:
-          name: "gordoserver-scaler-{{project_name}}"
-          labels:
-            app: "{{'{{inputs.parameters.host-name}}'}}"
-            app.kubernetes.io/name: model-server
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: "{{'{{inputs.parameters.host-name}}'}}"
-          minReplicas: 1
-          maxReplicas: {{ max_server_replicas }}
-          targetCPUUtilizationPercentage: 25
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: autoscaling/v1
+                  kind: HorizontalPodAutoscaler
+                  metadata:
+                    name: "gordoserver-scaler-{{project_name}}"
+                    labels:
+                      app: "{{'{{inputs.parameters.host-name}}'}}"
+                      app.kubernetes.io/name: model-server
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    scaleTargetRef:
+                      apiVersion: apps/v1
+                      kind: Deployment
+                      name: "{{'{{inputs.parameters.host-name}}'}}"
+                    minReplicas: 1
+                    maxReplicas: {{ max_server_replicas }}
+                    targetCPUUtilizationPercentage: 25
 
 
   - name: gordo-server-svc
-    retryStrategy:
-      limit: 5
     inputs:
       parameters:
       - name: host-name
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: "{{'{{inputs.parameters.host-name}}'}}"
-          annotations:
-            getambassador.io/config: |
-              ---
-              apiVersion: ambassador/v0
-              kind:  Mapping
-              name:  "{{'{{inputs.parameters.host-name}}'}}"
-              prefix: "/gordo/v0/{{project_name}}/.+"
-              prefix_regex: true
-              rewrite: ""
-              service: "{{'{{inputs.parameters.host-name}}'}}.{{namespace}}"
-              timeout_ms: 600000  # 10 mins
-          labels:
-            app: "{{'{{inputs.parameters.host-name}}'}}"
-            app.kubernetes.io/name: model-server
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          selector:
-            app: "{{'{{inputs.parameters.host-name}}'}}"
-          ports:
-          - port: 80
-            name: http-gordo
-            targetPort: http-api
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: "{{'{{inputs.parameters.host-name}}'}}"
+                    annotations:
+                      getambassador.io/config: |
+                        ---
+                        apiVersion: ambassador/v0
+                        kind:  Mapping
+                        name:  "{{'{{inputs.parameters.host-name}}'}}"
+                        prefix: "/gordo/v0/{{project_name}}/.+"
+                        prefix_regex: true
+                        rewrite: ""
+                        service: "{{'{{inputs.parameters.host-name}}'}}.{{namespace}}"
+                        timeout_ms: 600000  # 10 mins
+                    labels:
+                      app: "{{'{{inputs.parameters.host-name}}'}}"
+                      app.kubernetes.io/name: model-server
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    selector:
+                      app: "{{'{{inputs.parameters.host-name}}'}}"
+                    ports:
+                    - port: 80
+                      name: http-gordo
+                      targetPort: http-api
 
   - name: gordo-server-istio
-    retryStrategy:
-      limit: 5
     inputs:
       parameters:
       - name: host-name
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: networking.istio.io/v1alpha3
-        kind: VirtualService
-        metadata:
-          name: "{{'{{inputs.parameters.host-name}}'}}"
-          annotations:
-          labels:
-            app: "{{'{{inputs.parameters.host-name}}'}}"
-            app.kubernetes.io/name: model-server
-            app.kubernetes.io/component: VirtualService
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          hosts:
-          - "*"
-          gateways:
-          - istio-system/istio-gateway
-          http:
-          - match:
-            - uri:
-                regex: "/gordo/v0/{{project_name}}/.+"
-            route:
-            - destination:
-                host: "{{'{{inputs.parameters.host-name}}'}}"
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value: |
+                  ---
+                  apiVersion: networking.istio.io/v1alpha3
+                  kind: VirtualService
+                  metadata:
+                    name: "{{'{{inputs.parameters.host-name}}'}}"
+                    annotations:
+                    labels:
+                      app: "{{'{{inputs.parameters.host-name}}'}}"
+                      app.kubernetes.io/name: model-server
+                      app.kubernetes.io/component: VirtualService
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    hosts:
+                    - "*"
+                    gateways:
+                    - istio-system/istio-gateway
+                    http:
+                    - match:
+                      - uri:
+                          regex: "/gordo/v0/{{project_name}}/.+"
+                      route:
+                      - destination:
+                          host: "{{'{{inputs.parameters.host-name}}'}}"
 
   # SVC to notify watchman that a model has been built and can be served by the ML Server
   # This should only be temporary, as it's not _really_ a service, but used to notify Watchman
   # that the model is built and should be able to be contacted via the main server.
   # Here until we create a 'GordoModel' CRD which can then notify that the model is built.
   - name: gordo-notification-svc
-    retryStrategy:
-      limit: 5
     inputs:
       parameters:
         - name: model-name
         - name: host-name
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: "gordo-ntf-{{project_name}}-{{'{{inputs.parameters.model-name}}'}}"
-          labels:
-            app: "model-stache-{{'{{inputs.parameters.model-name}}'}}"
-            app.kubernetes.io/name: model-server
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-            applications.gordo.equinor.com/model-name: "{{'{{inputs.parameters.model-name}}'}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          clusterIP: None
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value: |
+                  ---
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: "gordo-ntf-{{project_name}}-{{'{{inputs.parameters.model-name}}'}}"
+                    labels:
+                      app: "model-stache-{{'{{inputs.parameters.model-name}}'}}"
+                      app.kubernetes.io/name: model-server
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                      applications.gordo.equinor.com/model-name: "{{'{{inputs.parameters.model-name}}'}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    clusterIP: None
 
 
   - name: gordo-server-deployment
-    retryStrategy:
-      limit: 5
     inputs:
       parameters:
       - name: host-name
-    resource:
-      action: apply
-      successCondition: status.readyReplicas > 0
-      manifest: |
-        ---
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: "{{'{{inputs.parameters.host-name}}'}}"
-          labels:
-            app: "{{'{{inputs.parameters.host-name}}'}}"
-            app.kubernetes.io/name: model-server-deployment
-            app.kubernetes.io/component: server
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app: "{{'{{inputs.parameters.host-name}}'}}"
-          strategy:
-            type: Recreate
-          template:
-            metadata:
-              labels:
-                app: "{{'{{inputs.parameters.host-name}}'}}"
-            spec:
-              containers:
-                 - image: "{{ docker_registry }}/{{ docker_repository }}/gordo-model-server:{{gordo_version}}"
-                   imagePullPolicy: "IfNotPresent"
-                   name: "gordoserver-{{ project_name }}"
-                   volumeMounts:
-                     - mountPath: "/gordo"
-                       name: gstor
-                   ports:
-                     - name: http-api
-                       containerPort: 5555
-                   livenessProbe:
-                     httpGet:
-                       path: /healthcheck
-                       port: http-api
-                     initialDelaySeconds: 600 # We give it a lot of time to load the model and start up
-                     timeoutSeconds: 5
-                   readinessProbe:
-                     httpGet:
-                       path: /healthcheck
-                       port: http-api
-                     initialDelaySeconds: 5
-                     timeoutSeconds: 5
-                   env:
-                     - name: MODEL_COLLECTION_DIR
-                       value: /gordo/models/{{project_name}}/{{project_version}}
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  metadata:
+                    name: "{{'{{inputs.parameters.host-name}}'}}"
+                    labels:
+                      app: "{{'{{inputs.parameters.host-name}}'}}"
+                      app.kubernetes.io/name: model-server-deployment
+                      app.kubernetes.io/component: server
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    replicas: 1
+                    selector:
+                      matchLabels:
+                        app: "{{'{{inputs.parameters.host-name}}'}}"
+                    strategy:
+                      type: Recreate
+                    template:
+                      metadata:
+                        labels:
+                          app: "{{'{{inputs.parameters.host-name}}'}}"
+                      spec:
+                        containers:
+                           - image: "{{ docker_registry }}/{{ docker_repository }}/gordo-model-server:{{gordo_version}}"
+                             imagePullPolicy: "IfNotPresent"
+                             name: "gordoserver-{{ project_name }}"
+                             volumeMounts:
+                               - mountPath: "/gordo"
+                                 name: gstor
+                             ports:
+                               - name: http-api
+                                 containerPort: 5555
+                             livenessProbe:
+                               httpGet:
+                                 path: /healthcheck
+                                 port: http-api
+                               initialDelaySeconds: 600 # We give it a lot of time to load the model and start up
+                               timeoutSeconds: 5
+                             readinessProbe:
+                               httpGet:
+                                 path: /healthcheck
+                                 port: http-api
+                               initialDelaySeconds: 5
+                               timeoutSeconds: 5
+                             env:
+                               - name: MODEL_COLLECTION_DIR
+                                 value: /gordo/models/{{project_name}}/{{project_version}}
 
-                   resources:
-                     requests:
-                       memory: "{{ server_resources['requests']['memory'] }}M"
-                       cpu: "{{ server_resources['requests']['cpu'] }}m"
-                     limits:
-                       memory: "{{ server_resources['limits']['memory'] }}M"
-                       cpu: "{{ server_resources['limits']['cpu'] }}m"
-              terminationGracePeriodSeconds: 1
-              volumes:
-                - name: gstor
-                  persistentVolumeClaim:
-                    claimName: "azurefile"
+                             resources:
+                               requests:
+                                 memory: "{{ server_resources['requests']['memory'] }}M"
+                                 cpu: "{{ server_resources['requests']['cpu'] }}m"
+                               limits:
+                                 memory: "{{ server_resources['limits']['memory'] }}M"
+                                 cpu: "{{ server_resources['limits']['cpu'] }}m"
+                        terminationGracePeriodSeconds: 1
+                        volumes:
+                          - name: gstor
+                            persistentVolumeClaim:
+                              claimName: "azurefile"
 
   - name: gordo-server
     inputs:
@@ -956,152 +1042,157 @@ spec:
             key: tenant_id_secret
 
   - name: gordo-watchman-svc
-    retryStrategy:
-      limit: 5
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: "gordo-watchman-{{project_name}}"
-          annotations:
-            getambassador.io/config: |
-              ---
-              apiVersion: ambassador/v0
-              kind:  Mapping
-              name:  "gordo-watchman-{{project_name}}"
-              prefix: "/gordo/v0/{{project_name}}/$"
-              prefix_regex: true
-              service: "gordo-watchman-{{project_name}}.{{namespace}}"
-              timeout_ms: 600000  # 10 mins
-          labels:
-            app: "gordo-watchman-{{project_name}}"
-            app.kubernetes.io/name: watchman
-            app.kubernetes.io/component: service
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          selector:
-            app: "gordo-watchman-{{project_name}}"
-          ports:
-          - port: 80
-            name: http-gordo
-            targetPort: http-api
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: "gordo-watchman-{{project_name}}"
+                    annotations:
+                      getambassador.io/config: |
+                        ---
+                        apiVersion: ambassador/v0
+                        kind:  Mapping
+                        name:  "gordo-watchman-{{project_name}}"
+                        prefix: "/gordo/v0/{{project_name}}/$"
+                        prefix_regex: true
+                        service: "gordo-watchman-{{project_name}}.{{namespace}}"
+                        timeout_ms: 600000  # 10 mins
+                    labels:
+                      app: "gordo-watchman-{{project_name}}"
+                      app.kubernetes.io/name: watchman
+                      app.kubernetes.io/component: service
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    selector:
+                      app: "gordo-watchman-{{project_name}}"
+                    ports:
+                    - port: 80
+                      name: http-gordo
+                      targetPort: http-api
 
 
 
   - name: gordo-watchman-istio
-    retryStrategy:
-      limit: 5
-    resource:
-      action: apply
-      manifest: |
-        ---
-        apiVersion: networking.istio.io/v1alpha3
-        kind: VirtualService
-        metadata:
-          name: "gordo-watchman-{{project_name}}"
-          annotations:
-          labels:
-            app: "gordo-watchman-{{project_name}}"
-            app.kubernetes.io/name: watchman
-            app.kubernetes.io/component: VirtualService
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          hosts:
-          - "*"
-          gateways:
-          - istio-system/istio-gateway
-          http:
-          - match:
-            - uri:
-                regex: "/gordo/v0/{{project_name}}/$"
-            rewrite:
-              uri: "/"
-            route:
-            - destination:
-                host: "gordo-watchman-{{project_name}}"
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: networking.istio.io/v1alpha3
+                  kind: VirtualService
+                  metadata:
+                    name: "gordo-watchman-{{project_name}}"
+                    annotations:
+                    labels:
+                      app: "gordo-watchman-{{project_name}}"
+                      app.kubernetes.io/name: watchman
+                      app.kubernetes.io/component: VirtualService
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    hosts:
+                    - "*"
+                    gateways:
+                    - istio-system/istio-gateway
+                    http:
+                    - match:
+                      - uri:
+                          regex: "/gordo/v0/{{project_name}}/$"
+                      rewrite:
+                        uri: "/"
+                      route:
+                      - destination:
+                          host: "gordo-watchman-{{project_name}}"
 
 
 
   - name: gordo-watchman-deployment
-    retryStrategy:
-      limit: 5
-    resource:
-      action: apply
-      successCondition: status.readyReplicas > 0
-      manifest: |
-        ---
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: "gordo-watchman-{{project_name}}"
-          labels:
-            app: "gordo-watchman-{{project_name}}"
-            app.kubernetes.io/name: watchman-deployment
-            app.kubernetes.io/component: watchman
-            app.kubernetes.io/part-of: gordo
-            app.kubernetes.io/managed-by: gordo
-            applications.gordo.equinor.com/project-name: "{{project_name}}"
-            applications.gordo.equinor.com/project-version: "{{project_version}}"
-          {% if owner_references is defined %}
-          ownerReferences: {{owner_references}}
-          {% endif %}
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app: "gordo-watchman-{{project_name}}"
-          strategy:
-            type: Recreate
-          template:
-            metadata:
-              labels:
-                app: "gordo-watchman-{{project_name}}"
-            spec:
-              containers:
-                 - image: "{{ docker_registry }}/{{ docker_repository }}/gordo-watchman:{{gordo_version}}"
-                   imagePullPolicy: "IfNotPresent"
-                   name: "gordo-watchman-{{project_name}}"
-                   ports:
-                     - name: http-api
-                       containerPort: 5556
-                   readinessProbe:
-                     httpGet:
-                       path: /healthcheck
-                       port: http-api
-                     initialDelaySeconds: 5
-                     timeoutSeconds: 2
-                   env:
-                     - name: TARGET_NAMES
-                       value: "{{target_names}}"
-                     - name: PROJECT_NAME
-                       value: {{project_name}}
-                     - name: PROJECT_VERSION
-                       value: "{{project_version}}"
-                     - name: AMBASSADOR_NAMESPACE
-                       value: "{{ambassador_namespace}}"
-                   resources:
-                     requests:
-                       memory: 500M
-                       cpu: 10m
-                     limits:
-                       memory: 1G
-                       cpu: 1
-              terminationGracePeriodSeconds: 1
+    steps:
+      - - name: apply-with-retries
+          template: apply-with-retries
+          arguments:
+            parameters:
+              - name: resource
+                value:  |
+                  ---
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  metadata:
+                    name: "gordo-watchman-{{project_name}}"
+                    labels:
+                      app: "gordo-watchman-{{project_name}}"
+                      app.kubernetes.io/name: watchman-deployment
+                      app.kubernetes.io/component: watchman
+                      app.kubernetes.io/part-of: gordo
+                      app.kubernetes.io/managed-by: gordo
+                      applications.gordo.equinor.com/project-name: "{{project_name}}"
+                      applications.gordo.equinor.com/project-version: "{{project_version}}"
+                    {% if owner_references is defined %}
+                    ownerReferences: {{owner_references}}
+                    {% endif %}
+                  spec:
+                    replicas: 1
+                    selector:
+                      matchLabels:
+                        app: "gordo-watchman-{{project_name}}"
+                    strategy:
+                      type: Recreate
+                    template:
+                      metadata:
+                        labels:
+                          app: "gordo-watchman-{{project_name}}"
+                      spec:
+                        containers:
+                           - image: "{{ docker_registry }}/{{ docker_repository }}/gordo-watchman:{{gordo_version}}"
+                             imagePullPolicy: "IfNotPresent"
+                             name: "gordo-watchman-{{project_name}}"
+                             ports:
+                               - name: http-api
+                                 containerPort: 5556
+                             readinessProbe:
+                               httpGet:
+                                 path: /healthcheck
+                                 port: http-api
+                               initialDelaySeconds: 5
+                               timeoutSeconds: 2
+                             env:
+                               - name: TARGET_NAMES
+                                 value: "{{target_names}}"
+                               - name: PROJECT_NAME
+                                 value: {{project_name}}
+                               - name: PROJECT_VERSION
+                                 value: "{{project_version}}"
+                               - name: AMBASSADOR_NAMESPACE
+                                 value: "{{ambassador_namespace}}"
+                             resources:
+                               requests:
+                                 memory: 500M
+                                 cpu: 10m
+                               limits:
+                                 memory: 1G
+                                 cpu: 1
+                        terminationGracePeriodSeconds: 1
 
 
   - name: gordo-watchman


### PR DESCRIPTION
This replaces the argo workflow `resource` template type with a script which does the same, but with possibility for exponential backoff. By default it retries 6 times starting with 15 seconds (15, 30, 60, 120, 240, 480), for a total of 945s (15.75min). This pod is again retried 4 times (because what if it just gets killed at some point, it must be also be retried :-/), for a max wait of ~1 hour. 

Parameters can be changed. And the whole idea can be ditched. Who knows?