### PR TITLE
Piptools chain req and test dev

### DIFF
--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -1,3 +1,4 @@
+-c requirements.txt
 pip>=19.2.3
 pip-tools~=4.2
 sphinx-rtd-theme~=0.4

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -14,14 +14,14 @@ docutils==0.15.2          # via recommonmark, sphinx
 future==0.17.1            # via commonmark
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-jinja2==2.10.1            # via sphinx
+jinja2==2.10.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==19.2           # via sphinx
 pbr==5.4.3                # via sphinx-click
 pip-tools==4.2.0
 pygments==2.4.2           # via sphinx
 pyparsing==2.4.2          # via packaging
-pytz==2019.2              # via babel
+pytz==2019.3              # via babel
 recommonmark==0.6.0
 requests==2.22.0          # via sphinx
 six==1.12.0               # via packaging, pip-tools
@@ -39,5 +39,5 @@ sphinxcontrib-websupport==1.1.2
 urllib3==1.25.6           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.3
-# setuptools==41.4.0        # via sphinx
+# pip==19.3.1
+# setuptools==41.6.0        # via sphinx

--- a/test_requirements.in
+++ b/test_requirements.in
@@ -1,3 +1,4 @@
+-c requirements.txt
 docker~=4.0
 pytest~=5.2
 pytest-xdist~=1.26  # Parallelises the test-runs


### PR DESCRIPTION
This adds requirements.txt as a check in test_requirements.in.
This means that if there are incompatibilities pip-tools will give an error,
instead of allowing us to have different environments in test/prod.