### PR TITLE
Change matplotlib log level to info

### DIFF
--- a/gordo_components/__init__.py
+++ b/gordo_components/__init__.py
@@ -63,3 +63,4 @@ logging.basicConfig(
 )
 
 logging.getLogger("azure.datalake").setLevel(azure_log_level)
+logging.getLogger("matplotlib").setLevel(logging.INFO)


### PR DESCRIPTION
I think this is ok for now, unless you think it is better to swap everything to INFO, and specify what should be debug, but it will be either or anyway. Fixes #651 