### PR TITLE
Workflow: Move model notification up to top-level

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1282,35 +1282,6 @@ spec:
         template: gordo-watchman-to-postgres
         {% endif %}
 
-
-  - name: build-single-machine
-    inputs:
-      parameters:
-        - name: model-name
-        - name: model-config
-        - name: metadata
-        - name: data-config
-        - name: data-provider
-        - name: evaluation-config
-    steps:
-      -  - name: build-model
-           template: model-builder
-           arguments:
-            parameters: [{name: model-name, value: {{ '"{{inputs.parameters.model-name}}"' }}  },
-                         {name: model-config, value: {{ '"{{inputs.parameters.model-config}}"' }} },
-                         {name: metadata, value: {{'"{{inputs.parameters.metadata}}"'}} },
-                         {name: data-config, value: {{ '"{{inputs.parameters.data-config}}"' }}},
-                         {name: data-provider, value: {{ '"{{inputs.parameters.data-provider}}"' }}},
-                         {name: evaluation-config, value: {{ '"{{inputs.parameters.evaluation-config}}"' }}}
-            ]
-      -  - name: model-notification-svc
-           template: gordo-notification-svc
-           arguments:
-             parameters:
-               - name: model-name
-                 value: {{ '"{{inputs.parameters.model-name}}"' }}
-               - name: host-name
-                 value: "ml-server-{{ project_name }}"
   - name: ml-server
     inputs:
       parameters:
@@ -1340,7 +1311,7 @@ spec:
             - ensure-single-workflow
         {% for machine in machines %}
         - name: model-builder-{{ machine.name }}
-          template: build-single-machine
+          template: model-builder
           arguments:
             parameters: [{name: model-name, value: "{{ machine.name }}"},
                          {name: model-config, value: "{{ machine.model }}"},
@@ -1352,6 +1323,14 @@ spec:
           dependencies:
             - watchman
             - ml-server
+        - name: model-notification-{{ machine.name }}
+          template: gordo-notification-svc
+          arguments:
+            parameters: [{name: model-name, value: "{{ machine.name }}"},
+                         {name: host-name, value: "ml-server-{{ project_name }}"}
+            ]
+          dependencies:
+            - model-builder-{{ machine.name }}
         {% endfor %}
         - name: postgres-cleanup
           template: postgres-cleanup


### PR DESCRIPTION
Simplifies the workflow by removing nested templates. I.e. instead of having
a template consisting of building-then-post-service, we add the building
and service-posting as top-level tasks in do-all, and add the builder as a
dependency of the service.

Needed beause of https://github.com/argoproj/argo/issues/1713