### PR TITLE
Add junit report generation to pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,10 @@ commands:
           command: |
             mkdir -p /tmp/coverage-reports
             mv ./coverage.xml /tmp/coverage-reports/<< parameters.for >>-coverage.xml
+      - run:
+          name: Rename junit report to << parameters.for >>-junit.xml
+          command: |
+            mv ./junit/junit.xml ./junit/<< parameters.for >>-junit.xml
 
   # Run a collection of 'test' commands
   test-batch:
@@ -75,6 +79,8 @@ commands:
           root: /tmp/coverage-reports
           paths:
             - ./*-coverage.xml
+      - store_test_results:
+          path: ./junit/
       - save-eggs-cache
   upload-coverage-reports:
     description: "Upload the coverage reports"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ignore=docs --benchmark-skip --durations=50 --log-cli-level=ERROR --doctest-modules --mypy -p gordo_components --flakes --doctest-glob='*.md' --doctest-glob='*.rst' --cov-report=xml --cov=gordo_components
+addopts = --ignore=docs --benchmark-skip --durations=50 --log-cli-level=ERROR --doctest-modules --mypy -p gordo_components --flakes --doctest-glob='*.md' --doctest-glob='*.rst' --cov-report=xml --cov=gordo_components --junitxml=junit/junit.xml
 flakes-ignore =
     __init__.py UnusedImport
     test_*.py UnusedImport
@@ -8,3 +8,5 @@ filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
 timeout = 300
+junit_duration_report = call
+junit_suite_name = gordo-components


### PR DESCRIPTION
This saves test-output in junitxml format in the folder ./junit. This
is then read by circleci to give nice graphs.