### PR TITLE
Add --ignore benchmarks & refactor pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,9 +10,9 @@ addopts =
     --flakes
     --doctest-glob='*.md'
     --doctest-glob='*.rst'
+    --junitxml=junit/junit.xml
     --cov-report=xml
     --cov=gordo_components
-    --junitxml=junit/junit.xml
 flakes-ignore =
     __init__.py UnusedImport
     test_*.py UnusedImport

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,18 @@
 [pytest]
-addopts = --ignore=docs --benchmark-skip --durations=50 --log-cli-level=ERROR --doctest-modules --mypy -p gordo_components --flakes --doctest-glob='*.md' --doctest-glob='*.rst' --cov-report=xml --cov=gordo_components --junitxml=junit/junit.xml
+addopts =
+    --ignore=docs
+    --ignore benchmarks
+    --benchmark-skip
+    --durations=50
+    --log-cli-level=ERROR
+    --doctest-modules
+    --mypy -p gordo_components
+    --flakes
+    --doctest-glob='*.md'
+    --doctest-glob='*.rst'
+    --cov-report=xml
+    --cov=gordo_components
+    --junitxml=junit/junit.xml
 flakes-ignore =
     __init__.py UnusedImport
     test_*.py UnusedImport


### PR DESCRIPTION
Running `python -m pytest` will try loading benchmark tests. 
This adds the `--ignore benchmarks` flag and refactors the long line as well. 