### PR TITLE
Workflow: Clean up quoting data to builder

### DIFF
--- a/examples/config_crd.yaml
+++ b/examples/config_crd.yaml
@@ -26,6 +26,8 @@ spec:
               limits: # The resources we are limited to using.
                 memory: 2000 #Kill the server if it uses more than 2GB
                 cpu: 2000 #Throttle the server to never using more than 2 cores
+        metadata:
+            model-hierarchy: "1218 -\u003e -\u003e g's"
         name: ct-23-0001 #1st machine
 
       - dataset:

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1301,13 +1301,24 @@ spec:
         - name: model-builder-{{ machine.name }}
           template: model-builder
           arguments:
-            parameters: [{name: model-name, value: "{{ machine.name }}"},
-                         {name: model-config, value: "{{ machine.model }}"},
-                         {name: metadata, value: "{{ machine.metadata }}"},
-                         {name: data-config, value: "{{ machine.dataset.to_dict() }}"},
-                         {name: data-provider, value: "{{ machine.data_provider.to_dict() }}"},
-                         {name: evaluation-config, value: "{{ machine.evaluation}}"},
-            ]
+            parameters:
+              - name: model-name
+                value: "{{ machine.name }}"
+              - name: model-config
+                value: |
+                  {{ machine.model  | tojson }}
+              - name: metadata
+                value: |
+                  {{ machine.metadata | tojson }}
+              - name: data-config
+                value: |
+                  {{ machine.dataset.to_dict() | tojson }}
+              - name: data-provider
+                value: |
+                  {{ machine.data_provider.to_dict() | tojson }}
+              - name: evaluation-config
+                value: |
+                  {{ machine.evaluation | tojson}}
           dependencies:
             - watchman
             - gordo-server

--- a/tests/gordo_components/workflow/test_workflow_generator/data/config-test-quotes.yml
+++ b/tests/gordo_components/workflow/test_workflow_generator/data/config-test-quotes.yml
@@ -1,0 +1,28 @@
+machines:
+  - name: machine-1
+    dataset:
+      tags:  # Quotes in the tag-names, because why not
+        - CT/1
+        - CT"2
+        - CT'3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+    metadata:
+      withSingle: "a string with ' in it"
+      withDouble: 'a string with " in it'
+      "single'in'key": "why not"
+
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - sklearn.compose.ColumnTransformer:
+            transformers:
+              - - dropper
+                - drop
+                - CT'3 # Legal with weird quotes inside the model as well
+            remainder: passthrough
+        - gordo_components.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass


### PR DESCRIPTION
This standardizes on using the jinja2 json filter and yaml literal
quote to send data to the model-builder for all data. Earlier we relied
on python string-formatting the values in a sane way, which did not work
if the strings contained a single quote, since then python would switch to
using double quotes where it usually uses single quotes.

This closes #682