### PR TITLE
Dockerfiles: Improve caching of large packages

### DIFF
--- a/Dockerfile-Client
+++ b/Dockerfile-Client
@@ -10,11 +10,21 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
+# Extract a few big dependencies which docker will cache even when other dependencies change
+RUN cat /code/requirements.txt | grep tensorflow== > /code/prereq.txt \
+    && cat /code/requirements.txt | grep pyarrow== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep scipy== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep catboost== >> /code/prereq.txt
+
 FROM python:3.6.9-slim-stretch
 
 # Install requirements separately for improved docker caching
+COPY --from=builder /code/prereq.txt .
+RUN pip install --no-deps -r prereq.txt --no-cache-dir
+
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements.txt --no-cache-dir
+
 
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 COPY --from=builder /code/dist/gordo-components-packed.tar.gz .

--- a/Dockerfile-GordoDeploy
+++ b/Dockerfile-GordoDeploy
@@ -26,11 +26,20 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-infrastructure-packed.tar.gz
 
+# Extract a few big dependencies which docker will cache even when other dependencies change
+RUN cat /code/requirements.txt | grep tensorflow== > /code/prereq.txt \
+    && cat /code/requirements.txt | grep pyarrow== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep scipy== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep catboost== >> /code/prereq.txt
+
 FROM python:3.6.9-slim-stretch
 
 # Install requirements separately for improved docker caching
+COPY --from=builder /code/prereq.txt .
+RUN pip install --no-deps -r prereq.txt --no-cache-dir
+
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements.txt --no-cache-dir
 
 COPY ./run_workflow_and_argo.sh /code/run_workflow_and_argo.sh
 

--- a/Dockerfile-ModelBuilder
+++ b/Dockerfile-ModelBuilder
@@ -10,11 +10,21 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
+# Extract a few big dependencies which docker will cache even when other dependencies change
+RUN cat /code/requirements.txt | grep tensorflow== > /code/prereq.txt \
+    && cat /code/requirements.txt | grep pyarrow== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep scipy== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep catboost== >> /code/prereq.txt
+
 FROM python:3.6.9-slim-stretch
 
 # Install requirements separately for improved docker caching
+COPY --from=builder /code/prereq.txt .
+RUN pip install --no-deps -r prereq.txt --no-cache-dir
+
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements.txt --no-cache-dir
+
 
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 COPY --from=builder /code/dist/gordo-components-packed.tar.gz .

--- a/Dockerfile-ModelServer
+++ b/Dockerfile-ModelServer
@@ -10,11 +10,22 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
+# Extract a few big dependencies which docker will cache even when other dependencies change
+RUN cat /code/requirements.txt | grep tensorflow== > /code/prereq.txt \
+    && cat /code/requirements.txt | grep pyarrow== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep scipy== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep catboost== >> /code/prereq.txt
+
 FROM python:3.6.9-slim-stretch
 
 # Install requirements separately for improved docker caching
+COPY --from=builder /code/prereq.txt .
+RUN pip install --no-deps -r prereq.txt --no-cache-dir
+
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements.txt --no-cache-dir
+
+
 
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 COPY --from=builder /code/dist/gordo-components-packed.tar.gz .

--- a/Dockerfile-Watchman
+++ b/Dockerfile-Watchman
@@ -10,11 +10,21 @@ RUN rm -rf /code/dist \
     && python setup.py sdist \
     && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
+# Extract a few big dependencies which docker will cache even when other dependencies change
+RUN cat /code/requirements.txt | grep tensorflow== > /code/prereq.txt \
+    && cat /code/requirements.txt | grep pyarrow== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep scipy== >> /code/prereq.txt \
+    && cat /code/requirements.txt | grep catboost== >> /code/prereq.txt
+
 FROM python:3.6.9-slim-stretch
 
 # Install requirements separately for improved docker caching
+COPY --from=builder /code/prereq.txt .
+RUN pip install --no-deps -r prereq.txt --no-cache-dir
+
 COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements.txt --no-cache-dir
+
 
 # Install gordo-components, packaged from earlier 'python setup.py sdist'
 COPY --from=builder /code/dist/gordo-components-packed.tar.gz .


### PR DESCRIPTION
This patch adds a step in the dockerfile which installs a few big
packages (tensorflow, pyarrow, scipy, and catboost) before the
requirements file is copied over. This allows docker to cache the layer
with those packages even if other requirements change.

Now with dependabot our requirements-file change all the time! And a few of our dependencies sum up to almost 700Mb extracted, so I moved them into a seperate step.