### PR TITLE
Workflow manuall pod gc

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1260,7 +1260,10 @@ spec:
         echo "Deleting gordo deployments and services for project {{project_name}} different than {{project_version}}" \
          && kubectl delete deployments -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}} \
          && kubectl delete svc -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}} \
-         && kubectl delete hpa -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}}
+         && kubectl delete hpa -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version!={{project_version}} \
+         && echo "Deleting Succeeded gordo pods for project={{project_name}} version={{project_version}}" \
+         && kubectl delete pods --field-selector=status.phase==Succeeded -l applications.gordo.equinor.com/project-name={{project_name}},applications.gordo.equinor.com/project-version={{project_version}}
+
       resources:
         requests:
           memory: 50M

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -23,13 +23,6 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 115200 # 32 hours
   entrypoint: do-all
-  podGC:
-    # pod gc strategy must be one of the following
-    # * OnPodCompletion - delete pods immediately when pod is completed (including errors/failures)
-    # * OnPodSuccess - delete pods immediately when pod is successful
-    # * OnWorkflowCompletion - delete pods when workflow is completed
-    # * OnWorkflowSuccess - delete pods when workflow is successful
-    strategy: OnWorkflowSuccess
   onExit: sql-and-cleanup
   volumes:
   - name: azurefile


### PR DESCRIPTION
Deletes `Succeeded` pods for the project on workflow exit. Can and should
be replaced with podGC when we move to argo 2.4.
