### PR TITLE
Add default_asset to sensortag and dataset

### DIFF
--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -60,6 +60,7 @@ class TimeSeriesDataset(GordoBaseDataset):
         aggregation_methods: Union[str, List[str], Callable] = "mean",
         row_filter_buffer_size: int = 0,
         asset: Optional[str] = None,
+        default_asset: Optional[str] = None,
         **_kwargs,
     ):
         """
@@ -107,13 +108,16 @@ class TimeSeriesDataset(GordoBaseDataset):
             Default is zero 0
         asset: Optional[str]
             Asset for which the tags are associated with.
+        default_asset: Optional[str]
+            Asset which will be used if `asset` is not provided and the tag is not
+            resolvable to a specific asset.
         _kwargs
         """
         self.from_ts = self._validate_dt(from_ts)
         self.to_ts = self._validate_dt(to_ts)
-        self.tag_list = normalize_sensor_tags(list(tag_list), asset)
+        self.tag_list = normalize_sensor_tags(list(tag_list), asset, default_asset)
         self.target_tag_list = (
-            normalize_sensor_tags(list(target_tag_list), asset)
+            normalize_sensor_tags(list(target_tag_list), asset, default_asset)
             if target_tag_list
             else []
         )

--- a/tests/gordo_components/dataset/test_sensor_tag.py
+++ b/tests/gordo_components/dataset/test_sensor_tag.py
@@ -7,28 +7,30 @@ from gordo_components.dataset.sensor_tag import (
 from gordo_components.dataset.sensor_tag import SensorTag
 
 
-TAG_NAME1 = "MyBeautifulTag1"
-TAG_NAME2 = "MyBeautifulTag2"
+NON_RESOLVABLE_TAG_NAME1 = "MyBeautifulTag1"
+NON_RESOLVABLE_TAG_NAME2 = "MyBeautifulTag2"
 asset_nonsense = "ImaginaryAsset"
 
 
 @pytest.mark.parametrize(
-    "good_input_tags,asset,expected_output_tags",
+    "good_input_tags,asset,default_asset,expected_output_tags",
     [
         (
             [
-                {"name": TAG_NAME1, "asset": asset_nonsense},
-                {"name": TAG_NAME2, "asset": asset_nonsense},
+                {"name": NON_RESOLVABLE_TAG_NAME1, "asset": asset_nonsense},
+                {"name": NON_RESOLVABLE_TAG_NAME2, "asset": asset_nonsense},
             ],
-            "ThisAssetCodeWillBeIgnored",
+            "ThisAssetCodeWillBeIgnoredSinceAssetMustBeProvidedInDict",
+            "AsWillThisSinceAssetMustBeProvidedInDict",
             [
-                SensorTag(TAG_NAME1, asset_nonsense),
-                SensorTag(TAG_NAME2, asset_nonsense),
+                SensorTag(NON_RESOLVABLE_TAG_NAME1, asset_nonsense),
+                SensorTag(NON_RESOLVABLE_TAG_NAME2, asset_nonsense),
             ],
         ),
         (
             ["TRC-123", "GRA-214", "ASGB-212"],
             "ThisWillBeTheAsset",
+            "AndThisWillBeIgnoredSinceAllTagsAreResolvable",
             [
                 SensorTag("TRC-123", "ThisWillBeTheAsset"),
                 SensorTag("GRA-214", "ThisWillBeTheAsset"),
@@ -38,6 +40,7 @@ asset_nonsense = "ImaginaryAsset"
         (
             ["TRC-123", "GRA-214", "ASGB-212"],
             None,  # Will deduce asset
+            None,
             [
                 SensorTag("TRC-123", "1776-troc"),
                 SensorTag("GRA-214", "1755-gra"),
@@ -51,6 +54,7 @@ asset_nonsense = "ImaginaryAsset"
                 SensorTag("ASGB-212", "1191-asgb"),
             ],
             "CouldWriteAssetHereButWeDontCare",
+            "WillBeIgnoredSinceInputIsSensorTags",
             [
                 SensorTag("TRC-123", "1776-troc"),
                 SensorTag("GRA-214", "1755-gra"),
@@ -58,21 +62,42 @@ asset_nonsense = "ImaginaryAsset"
             ],
         ),
         (
-            [[TAG_NAME1, asset_nonsense], [TAG_NAME2, asset_nonsense]],
-            None,
             [
-                SensorTag(TAG_NAME1, asset_nonsense),
-                SensorTag(TAG_NAME2, asset_nonsense),
+                [NON_RESOLVABLE_TAG_NAME1, asset_nonsense],
+                [NON_RESOLVABLE_TAG_NAME2, asset_nonsense],
+            ],
+            "WillBeIgnoredSinceInputIsList",
+            "WillBeIgnoredSinceInputIsList",
+            [
+                SensorTag(NON_RESOLVABLE_TAG_NAME1, asset_nonsense),
+                SensorTag(NON_RESOLVABLE_TAG_NAME2, asset_nonsense),
+            ],
+        ),
+        (
+            ["TRC-123", NON_RESOLVABLE_TAG_NAME2, "ASGB-212"],
+            None,
+            "fallbackkasset",
+            [
+                SensorTag("TRC-123", "1776-troc"),
+                SensorTag(NON_RESOLVABLE_TAG_NAME2, "fallbackkasset"),
+                SensorTag("ASGB-212", "1191-asgb"),
             ],
         ),
     ],
 )
-def test_normalize_sensor_tags_ok(good_input_tags, asset, expected_output_tags):
-    tag_list_as_list_of_sensor_tag = normalize_sensor_tags(good_input_tags, asset)
+def test_normalize_sensor_tags_ok(
+    good_input_tags, asset, default_asset, expected_output_tags
+):
+    tag_list_as_list_of_sensor_tag = normalize_sensor_tags(
+        good_input_tags, asset, default_asset=default_asset
+    )
     assert tag_list_as_list_of_sensor_tag == expected_output_tags
 
 
 def test_normalize_sensor_tags_not_ok():
     with pytest.raises(SensorTagNormalizationError):
-        tag_list_as_list_of_strings_nonsense = [TAG_NAME1, TAG_NAME2]
+        tag_list_as_list_of_strings_nonsense = [
+            NON_RESOLVABLE_TAG_NAME1,
+            NON_RESOLVABLE_TAG_NAME2,
+        ]
         normalize_sensor_tags(tag_list_as_list_of_strings_nonsense)


### PR DESCRIPTION
The key `default_asset` specifies a fallback which is used as the asset
if the tagname-to-asset resolving fails. It compliments the `asset`
keyword, which bypasses the resolving and forces the asset to be
`asset`.