### PR TITLE
Watchman list then watch

### DIFF
--- a/gordo_components/watchman/endpoints_status.py
+++ b/gordo_components/watchman/endpoints_status.py
@@ -95,8 +95,8 @@ class EndpointStatuses:
                     "`listen_to_kubernetes`==True"
                 )
             # If we are listening to kubernetes events
-            # we only do a "manual" update of every endpoint every 20 min
-            self.happy_update_model_interval = 1200
+            # we only do a "manual" update of every endpoint every hour
+            self.happy_update_model_interval = 3600
             watcher = watch_for_model_resource(
                 namespace=namespace,
                 project_name=self.project_name,

--- a/gordo_components/watchman/gordo_k8s_interface.py
+++ b/gordo_components/watchman/gordo_k8s_interface.py
@@ -130,7 +130,7 @@ def watch_namespaced_custom_object(
     selectors: Optional[Dict[str, str]] = None,
 ) -> ThreadedListWatcher:
     """Watches changes to k8s services in a given namespace, and executed
-    `event_handler` for each event, pluss for all initial objects in the cluster.
+    `event_handler` for each event, plus for all initial objects in the cluster.
 
     Returns the watching thread, which must be started by the caller.
 


### PR DESCRIPTION
Sometimes watchman ends up getting these kinds of errors:
```
[2019-11-25 13:32:10,305] WARNING [gordo_components.watchman.endpoints_status._handle_k8s_model_service_event:176] Got model-server service notification, but found no model-name. Full event: {'type': 'ERROR', 'object': {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'too old resource version: 1267589 (1485291)', 'reason': 'Gone', 'code': 410}, 'raw_object': {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'too old resource version: 1267589 (1485291)', 'reason': 'Gone', 'code': 410}} 
```

After some googling it turns out that "the right thing to do" is not to just `watch` for events changed, but to first list the events, process them, and get the resource_version from *that response*, and use that in the watch. 

IDK if this will fix things. Seems to have done for the cases I tested it on though.