### PR TITLE
Change client dependencies in argo template

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1364,7 +1364,7 @@ spec:
           dependencies:
             - gordo-server
             - gordo-influx
-            - model-builder-{{ machine.name }}
+            - gordo-mdl-{{ machine.name }}
         {% endif %}
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
This PR update the dependencies for the the client from using the model notification step (gordo-mdl) instead of the model builder step.

The test project completed successfully with this, with the clients kicking off with the completion of the mdl step. :checkered_flag: 

Closes #718 