### PR TITLE
Workflow: Remove gordo-mdl from the model-names

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -798,7 +798,7 @@ spec:
                   apiVersion: equinor.com/v1
                   kind: Model
                   metadata:
-                    name: "gordo-mdl-{{project_name}}-{% raw %}{{inputs.parameters.model-name}}{% endraw %}"
+                    name: "{{project_name}}-{% raw %}{{inputs.parameters.model-name}}{% endraw %}"
                     labels:
                       app: "model-stache-{{'{{inputs.parameters.model-name}}'}}"
                       app.kubernetes.io/name: model-server


### PR DESCRIPTION
I dont think they provide any value really, since all the `models` are gordo models. 