### PR TITLE
Add 1904-JSV to asset_to_path

### DIFF
--- a/gordo_components/data_provider/ncs_reader.py
+++ b/gordo_components/data_provider/ncs_reader.py
@@ -36,6 +36,7 @@ class NcsReader(GordoBaseDataProvider):
         "1901-jsv": "/raw/corporate/PI System Operation Johan Sverdrup/sensordata/1901-JSV",
         "1902-jsv": "/raw/corporate/PI System Operation Johan Sverdrup/sensordata/1902-JSV",
         "1903-jsv": "/raw/corporate/PI System Operation Johan Sverdrup/sensordata/1903-JSV",
+        "1904-jsv": "/raw/corporate/PI System Operation Johan Sverdrup/sensordata/1904-JSV",
     }
 
     def __init__(


### PR DESCRIPTION
Add 1904-JSV to asset_to_path in ncs_reader. It is not added yet, but I assume that the path will be following the same structure as the other JSV-paths. But we can put it on hold until it is there.
Closes #719 