### PR TITLE
Include log_level as key in template

### DIFF
--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -4,7 +4,6 @@
 CLI interfaces
 """
 
-import os
 import logging
 import sys
 import traceback
@@ -46,18 +45,28 @@ logger = logging.getLogger(__name__)
 
 @click.group("gordo-components")
 @click.version_option(version=__version__, message=__version__)
-def gordo():
+@click.option(
+    "--log-level",
+    type=str,
+    default="INFO",
+    help="Run workflow with custom log-level.",
+    envvar="GORDO_LOG_LEVEL",
+)
+@click.pass_context
+def gordo(gordo_ctx: click.Context, **ctx):
     """
     The main entry point for the CLI interface
     """
-
     # Set log level, defaulting to INFO
-    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-
     logging.basicConfig(
-        level=getattr(logging, log_level),
+        level=getattr(logging, str(gordo_ctx.params.get("log_level")).upper()),
         format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
     )
+
+    # Set matplotlib log level to INFO to avoid noise
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+
+    gordo_ctx.obj = gordo_ctx.params
 
 
 @click.command()

--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -79,6 +79,8 @@ spec:
         value: "{{project_name}}"
       - name: GORDO_PROJECT_REVISION
         value: "{{project_revision}}"
+      - name: GORDO_LOG_LEVEL
+        value: "{{log_level}}"
 
   - name: apply-with-retries
     retryStrategy:
@@ -654,6 +656,8 @@ spec:
           secretKeyRef:
             name: dlserviceauth
             key: tenant_id_secret
+      - name: GORDO_LOG_LEVEL
+        value: "{{log_level}}"
       volumeMounts:
       - name: azurefile
         mountPath: /gordo
@@ -876,6 +880,8 @@ spec:
                              env:
                                - name: MODEL_COLLECTION_DIR
                                  value: /gordo/models/{{project_name}}/{{project_revision}}
+                               - name: GORDO_LOG_LEVEL
+                                 value: "{{log_level}}"
 
                              resources:
                                requests:
@@ -1034,6 +1040,8 @@ spec:
           secretKeyRef:
             name: dlserviceauth
             key: tenant_id_secret
+      - name: GORDO_LOG_LEVEL
+        value: "{{log_level}}"
 
   - name: influx-cleanup
     activeDeadlineSeconds: 300

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import logging
+import re
 
 from click.testing import CliRunner
 from unittest import mock
@@ -441,3 +442,31 @@ def test_server_to_sql_cli():
     args = ["workflow", "server-to-sql", "--help"]
     result = runner.invoke(cli.gordo, args)
     assert result.exit_code == 0
+
+
+def test_log_level_cli():
+    """
+    Test that the --log-level option in the CLI sets the correct log-level in the genreated config file.
+    """
+
+    runner = CliRunner()
+    args = [
+        "--log-level",
+        "test_log_level",
+        "workflow",
+        "generate",
+        "--machine-config",
+        "examples/config_crd.yaml",
+        "--project-name",
+        "test",
+    ]
+
+    result = runner.invoke(cli.gordo, args)
+
+    # Find the value on the next line after the key GORDO_LOG_LEVEL
+    gordo_log_levels = re.findall(
+        r"(?<=GORDO_LOG_LEVEL\r|GORDO_LOG_LEVEL\n)[^\r\n]+", result.stdout
+    )
+
+    # Assert all the values to the GORDO_LOG_LEVEL key contains the correct log-level
+    assert all(["TEST_LOG_LEVEL" in value for value in gordo_log_levels])

--- a/tests/gordo_components/workflow/test_workflow_generator/data/config-test-with-log-key.yml
+++ b/tests/gordo_components/workflow/test_workflow_generator/data/config-test-with-log-key.yml
@@ -1,0 +1,28 @@
+machines:
+
+  - name: ct-23-0001 #1st machine
+    dataset:
+      tags: #list of tags for 1st machine
+        - GRA-TE  -23-0733.PV
+        - GRA-TT  -23-0719.PV
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+  - name: ct-23-0002 #2nd machine
+    dataset:
+      tags: #list of tags for 2nd machine
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+globals:
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.data.MinMaxScaler
+        - gordo_components.machine.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass
+  runtime:
+    log_level: debug


### PR DESCRIPTION
Let the user specify the log_level as a key in globals to override the default info log-level in the __init__ of gordo-components. Closes #658 