### PR TITLE
Bump pytest-mock from 1.12.1 to 1.13.0

### DIFF
--- a/test_requirements.in
+++ b/test_requirements.in
@@ -2,7 +2,7 @@
 docker~=4.0
 pytest~=5.3
 pytest-xdist~=1.26  # Parallelises the test-runs
-pytest-mock~=1.11
+pytest-mock~=1.13
 pytest-mypy~=0.4
 pytest-timeout~=1.3
 pytest-cov~=2.8


### PR DESCRIPTION
This PR does the following (the second occured alongside the first):
* Bump pytest mock version

closes #764