### PR TITLE
Move logging config to CLI entry point

### DIFF
--- a/gordo_components/__init__.py
+++ b/gordo_components/__init__.py
@@ -51,12 +51,3 @@ try:
 except Exception:
     warnings.warn(f"Failed to fix absl logging bug {traceback.format_exc()}")
     pass
-
-
-# Set log level, defaulting to INFO
-log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-
-logging.basicConfig(
-    level=getattr(logging, log_level),
-    format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
-)

--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -4,6 +4,7 @@
 CLI interfaces
 """
 
+import os
 import logging
 import sys
 import traceback
@@ -44,7 +45,14 @@ def gordo():
     """
     The main entry point for the CLI interface
     """
-    pass
+
+    # Set log level, defaulting to INFO
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+
+    logging.basicConfig(
+        level=getattr(logging, log_level),
+        format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
+    )
 
 
 DEFAULT_MODEL_CONFIG = (


### PR DESCRIPTION
Will close #773 

Problem :clinking_glasses: 
---
As it stands now, tests which fail while attempting to log _after_ the test fails, like anything which uses the `influxdb` feature will create a massive stack trace of logging io errors. Causes by us setting the logging config on import when it should rather be set on some process, like our CLI.

Solution :milk_glass: 
---
So we move it into the CLI entry point so logging will only be configured to our desired level when using the project via CLI.