### PR TITLE
Set workflow failfast

### DIFF
--- a/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo_components/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -1319,6 +1319,7 @@ spec:
 
   - name: do-all
     dag:
+      failFast: false
       tasks:
         - name: ensure-single-workflow
           template: ensure-single-workflow


### PR DESCRIPTION
This ensures it tries to build all models even if some fail. Today it has kind of accidantially worked since our model-building things are themselves a step-template. Ref https://github.com/argoproj/argo/issues/1442