### PR TITLE
Add cv fold timestamps and n points to metadata

### DIFF
--- a/gordo_components/builder/mlflow_utils.py
+++ b/gordo_components/builder/mlflow_utils.py
@@ -265,11 +265,12 @@ def get_batch_kwargs(metadata: dict) -> dict:
     # Parse cross-validation split metadata
     try:
         splits = build_metadata["model"]["cross-validation"]["splits"]
-        param_list += get_params(splits, splits.keys())
     except KeyError:
         logger.debug(
-            "Key 'metadata.model.cross-validation.splits' not found found in metadata."
+            "Key 'build-metadata.model.cross-validation.splits' not found found in metadata."
         )
+    else:
+        param_list += get_params(splits, splits.keys())
 
     # Parse cross-validation metrics
     try:
@@ -277,6 +278,11 @@ def get_batch_kwargs(metadata: dict) -> dict:
             metadata["dataset"]["tag_list"], asset=metadata["dataset"]["asset"]
         )
         scores = build_metadata["model"]["cross-validation"]["scores"]
+    except KeyError:
+        logger.debug(
+            "Key 'build-metadata.model.cross-validation.scores' not found found in metadata."
+        )
+    else:
         keys = sorted(list(scores.keys()))
         subkeys = ["mean", "max", "min", "std"]
 
@@ -296,15 +302,15 @@ def get_batch_kwargs(metadata: dict) -> dict:
                 Metric(k, scores[k][f"fold-{i+1}"], epoch_now(), i)
                 for i in range(n_folds)
             ]
-    except KeyError:
-        logger.debug(
-            "Key 'metadata.model.cross-validation.scores' not found found in metadata."
-        )
 
     # Parse fit metrics
     try:
         meta_params = build_metadata["model"]["history"]["params"]
-
+    except KeyError:
+        logger.debug(
+            "Key 'build-metadata.model.history.params' not found found in metadata."
+        )
+    else:
         metric_list += get_metrics(
             build_metadata["model"],
             ["data-query-duration-sec", "model-training-duration-sec"],
@@ -318,8 +324,6 @@ def get_batch_kwargs(metadata: dict) -> dict:
                 Metric(m, float(x), timestamp=epoch_now(), step=i)
                 for i, x in enumerate(data)
             ]
-    except KeyError:
-        logger.debug("Key 'metadata.model.history.params' not found found in metadata.")
 
     return {"metrics": metric_list, "params": param_list}
 

--- a/tests/gordo_components/builder/test_mlflow_utils.py
+++ b/tests/gordo_components/builder/test_mlflow_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 
 import mlflow
 from mlflow.entities import Metric, Param
@@ -166,9 +166,9 @@ def test_get_run_id_external_calls(
 @pytest.mark.parametrize(
     "x,expected",
     [
-        (datetime(1970, 1, 1), 0),
-        (datetime(1970, 1, 1, 0, 0, 1), 1000),
-        (datetime(1970, 1, 1, 0, 0, 0, 1000), 1),
+        (datetime.datetime(1970, 1, 1), 0),
+        (datetime.datetime(1970, 1, 1, 0, 0, 1), 1000),
+        (datetime.datetime(1970, 1, 1, 0, 0, 0, 1000), 1),
     ],
 )
 def test_datetime_to_ms_since_epoch(x, expected):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,26 +16,32 @@ from nbconvert.exporters import PythonExporter
 
 from gordo_components.machine.dataset.data_provider.providers import DataLakeProvider
 from gordo_components.machine.dataset.datasets import TimeSeriesDataset
+from gordo_components.machine.dataset.sensor_tag import SensorTag
 
 logger = logging.getLogger(__name__)
 
+CONFIG = dict(
+    train_start_date=dateutil.parser.isoparse("2014-07-01T00:10:00+00:00"),
+    train_end_date=dateutil.parser.isoparse("2015-01-01T00:00:00+00:00"),
+    tag_list=[SensorTag(name=f"Tag {i}", asset=None) for i in range(10)],
+)
+
 
 def _fake_data():
-    data = pd.DataFrame({f"sensor_{i}": np.random.random(size=100) for i in range(10)})
+    data = pd.DataFrame(
+        {
+            f"sensor_{i}": np.random.random(size=100)
+            for i in range(len(CONFIG["tag_list"]))
+        }
+    )
     return data, data
 
 
 @mock.patch.object(TimeSeriesDataset, "get_data", return_value=_fake_data())
 def test_faked_DataLakeBackedDataset(MockDataset):
 
-    config = dict(
-        train_start_date=dateutil.parser.isoparse("2014-07-01T00:10:00+00:00"),
-        train_end_date=dateutil.parser.isoparse("2015-01-01T00:00:00+00:00"),
-        tag_list=["asgb.19ZT3950%2FY%2FPRIM", "asgb.19PST3925%2FDispMeasOut%2FPRIM"],
-    )
-
     provider = DataLakeProvider(storename="dataplatformdlsprod", interactive=True)
-    dataset = TimeSeriesDataset(data_provider=provider, **config)
+    dataset = TimeSeriesDataset(data_provider=provider, **CONFIG)
 
     # Should be able to call get_data without being asked to authenticate in tests
     X, y = dataset.get_data()


### PR DESCRIPTION
# Problem :fire: :european_castle:  :fire: :dragon_face: 
Folks want some information on the start/end of each CV fold

# Solution :bow_and_arrow:  :crown: :crossed_swords: 
Add the following to the metadata:
* start/end timestamps per set (train, test), per fold
* n_samples per set (train, test), per fold

closes #783
also the last tickbox on #649 