### PR TITLE
Replace tests/utils globals with fixtures

### DIFF
--- a/tests/gordo_components/machine/dataset/data_provider/test_data_provider_influx.py
+++ b/tests/gordo_components/machine/dataset/data_provider/test_data_provider_influx.py
@@ -7,13 +7,13 @@ from gordo_components.machine.dataset.data_provider.providers import InfluxDataP
 from gordo_components.client.utils import influx_client_from_uri
 from gordo_components.machine.dataset.dataset import _get_dataset
 
-from tests import utils as tu
-
 
 logger = logging.getLogger(__name__)
 
 
-def test_read_single_sensor_empty_data_time_range_indexerror(influxdb, caplog):
+def test_read_single_sensor_empty_data_time_range_indexerror(
+    influxdb, influxdb_uri, sensors_str, caplog
+):
     """
     Asserts that an IndexError is raised because the dates requested are outside the existing time period
     """
@@ -23,7 +23,7 @@ def test_read_single_sensor_empty_data_time_range_indexerror(influxdb, caplog):
     ds = InfluxDataProvider(
         measurement="sensors",
         value_name="Value",
-        client=influx_client_from_uri(uri=tu.INFLUXDB_URI, dataframe_client=True),
+        client=influx_client_from_uri(uri=influxdb_uri, dataframe_client=True),
     )
 
     with caplog.at_level(logging.CRITICAL):
@@ -31,12 +31,14 @@ def test_read_single_sensor_empty_data_time_range_indexerror(influxdb, caplog):
             ds.read_single_sensor(
                 train_start_date=train_start_date,
                 train_end_date=train_end_date,
-                tag=tu.SENSORS_STR_LIST[0],
+                tag=sensors_str[0],
                 measurement="sensors",
             )
 
 
-def test_read_single_sensor_empty_data_invalid_tag_name_valueerror(influxdb):
+def test_read_single_sensor_empty_data_invalid_tag_name_valueerror(
+    influxdb, influxdb_uri
+):
     """
     Asserts that a ValueError is raised because the tag name inputted is invalid
     """
@@ -46,7 +48,7 @@ def test_read_single_sensor_empty_data_invalid_tag_name_valueerror(influxdb):
     ds = InfluxDataProvider(
         measurement="sensors",
         value_name="Value",
-        client=influx_client_from_uri(uri=tu.INFLUXDB_URI, dataframe_client=True),
+        client=influx_client_from_uri(uri=influxdb_uri, dataframe_client=True),
     )
     with pytest.raises(ValueError):
         ds.read_single_sensor(
@@ -57,30 +59,32 @@ def test_read_single_sensor_empty_data_invalid_tag_name_valueerror(influxdb):
         )
 
 
-def test__list_of_tags_from_influx_validate_tag_names(influxdb):
+def test__list_of_tags_from_influx_validate_tag_names(
+    influxdb, influxdb_uri, sensors_str
+):
     """
     Test expected tags in influx match the ones actually in influx.
     """
     ds = InfluxDataProvider(
         measurement="sensors",
         value_name="Value",
-        client=influx_client_from_uri(uri=tu.INFLUXDB_URI, dataframe_client=True),
+        client=influx_client_from_uri(uri=influxdb_uri, dataframe_client=True),
     )
     list_of_tags = ds._list_of_tags_from_influx()
-    expected_tags = tu.SENSORS_STR_LIST
+    expected_tags = sensors_str
     tags = set(list_of_tags)
     assert set(expected_tags) == tags, (
         f"Expected tags = {expected_tags}" f"outputted {tags}"
     )
 
 
-def test_get_list_of_tags(influxdb):
+def test_get_list_of_tags(influxdb, influxdb_uri, sensors_str):
     ds = InfluxDataProvider(
         measurement="sensors",
         value_name="Value",
-        client=influx_client_from_uri(uri=tu.INFLUXDB_URI, dataframe_client=True),
+        client=influx_client_from_uri(uri=influxdb_uri, dataframe_client=True),
     )
-    expected_tags = set(tu.SENSORS_STR_LIST)
+    expected_tags = set(sensors_str)
 
     tags = set(ds.get_list_of_tags())
     assert expected_tags == tags
@@ -90,13 +94,13 @@ def test_get_list_of_tags(influxdb):
     assert expected_tags == tags
 
 
-def test_influx_dataset_attrs(influxdb):
+def test_influx_dataset_attrs(influxdb, influxdb_uri, sensors):
     """
     Test expected attributes
     """
     train_start_date = dateutil.parser.isoparse("2016-01-01T09:11:00+00:00")
     train_end_date = dateutil.parser.isoparse("2016-01-01T10:30:00+00:00")
-    tag_list = tu.SENSORTAG_LIST
+    tag_list = sensors
     config = {
         "type": "TimeSeriesDataset",
         "train_start_date": train_start_date,
@@ -106,7 +110,7 @@ def test_influx_dataset_attrs(influxdb):
     config["data_provider"] = InfluxDataProvider(
         measurement="sensors",
         value_name="Value",
-        client=influx_client_from_uri(uri=tu.INFLUXDB_URI, dataframe_client=True),
+        client=influx_client_from_uri(uri=influxdb_uri, dataframe_client=True),
     )
     dataset = _get_dataset(config)
     assert hasattr(dataset, "get_metadata")
@@ -115,11 +119,11 @@ def test_influx_dataset_attrs(influxdb):
     assert isinstance(metadata, dict)
 
 
-def test_influx_load_series_dry_run_raises():
+def test_influx_load_series_dry_run_raises(sensors):
     ds = InfluxDataProvider(measurement="sensors", value_name="Value", client=None)
     train_start_date = dateutil.parser.isoparse("2016-01-01T09:11:00+00:00")
     train_end_date = dateutil.parser.isoparse("2016-01-01T10:30:00+00:00")
-    tag_list = tu.SENSORTAG_LIST
+    tag_list = sensors
     with pytest.raises(NotImplementedError):
         ds.load_series(
             train_start_date=train_start_date,

--- a/tests/gordo_components/server/test_anomaly_view.py
+++ b/tests/gordo_components/server/test_anomaly_view.py
@@ -3,29 +3,32 @@
 import pytest
 import numpy as np
 from gordo_components.server import utils as server_utils
-import tests.utils as tu
 
 
 @pytest.mark.parametrize(
-    "data_to_post",
-    [
-        {
-            "X": np.random.random(size=(10, len(tu.SENSORS_STR_LIST))).tolist(),
-            "y": np.random.random(size=(10, len(tu.SENSORS_STR_LIST))).tolist(),
-        },  # Nested records
-        {
-            "X": np.random.random(size=(1, len(tu.SENSORS_STR_LIST))).tolist(),
-            "y": np.random.random(size=(1, len(tu.SENSORS_STR_LIST))).tolist(),
-        },  # Single record
-    ],
+    # Nested records and single record
+    "data_size",
+    [10, 1],
 )
 @pytest.mark.parametrize("resp_format", ("json", "parquet", None))
 def test_anomaly_prediction_endpoint(
-    base_route, influxdb, gordo_ml_server_client, data_to_post, sensors, resp_format
+    base_route,
+    sensors_str,
+    influxdb,
+    gordo_ml_server_client,
+    data_size,
+    sensors,
+    resp_format,
 ):
     """
     Anomaly GET and POST responses are the same
     """
+
+    data_to_post = {
+        "X": np.random.random(size=(data_size, len(sensors_str))).tolist(),
+        "y": np.random.random(size=(data_size, len(sensors_str))).tolist(),
+    }
+
     endpoint = f"{base_route}/anomaly/prediction"
     if resp_format is not None:
         endpoint += f"?format={resp_format}"

--- a/tests/gordo_components/server/test_base_view.py
+++ b/tests/gordo_components/server/test_base_view.py
@@ -8,35 +8,21 @@ import pandas as pd
 import numpy as np
 
 from gordo_components.server import utils as server_utils
-import tests.utils as tu
 
 
 @pytest.mark.parametrize(
-    "data_to_post",
-    [
-        np.random.random(size=(10, len(tu.SENSORS_STR_LIST))).tolist(),
-        np.random.random(size=(1, len(tu.SENSORS_STR_LIST))).tolist(),
-        pd.DataFrame(
-            np.random.random((10, len(tu.SENSORS_STR_LIST))),
-            columns=tu.SENSORS_STR_LIST,
-        ).to_dict("records"),
-        pd.DataFrame(
-            np.random.random((10, len(tu.SENSORS_STR_LIST))),
-            columns=tu.SENSORS_STR_LIST,
-        ).to_dict("list"),
-        pd.DataFrame(
-            np.random.random((10, len(tu.SENSORS_STR_LIST))),
-            columns=tu.SENSORS_STR_LIST,
-        ).to_dict("dict"),
-    ],
+    "data_size,to_dict_arg",
+    [(10, None), (1, None), (10, "records"), (10, "list"), (10, "dict")],
 )
 @pytest.mark.parametrize("resp_format", ("json", "parquet", None))
 @pytest.mark.parametrize("send_as_parquet", (True, False))
 def test_prediction_endpoint_post_ok(
     base_route,
     sensors,
+    sensors_str,
     gordo_ml_server_client,
-    data_to_post,
+    data_size,
+    to_dict_arg,
     resp_format,
     send_as_parquet,
 ):
@@ -44,6 +30,12 @@ def test_prediction_endpoint_post_ok(
     Test the expected successful data posts, by sending a variety of valid
     JSON formats of a dataframe, as well as parquet serializations.
     """
+    data_to_post = np.random.random(size=(data_size, len(sensors))).tolist()
+
+    if to_dict_arg is not None:
+        df = pd.DataFrame(data_to_post, columns=sensors_str)
+        data_to_post = df.to_dict(to_dict_arg)
+
     endpoint = f"{base_route}/prediction"
     if resp_format is not None:
         endpoint += f"?format={resp_format}"
@@ -68,22 +60,25 @@ def test_prediction_endpoint_post_ok(
     assert all(key in data for key in ("model-output", "model-input"))
 
 
-@pytest.mark.parametrize(
-    "data_to_post",
-    [
-        {"X": [list(range(len(tu.SENSORTAG_LIST) - 1))]},  # Not enough features
-        {"no-x-here": True},  # No X
-        {"X": [[1, 2, [1, 2]]]},  # Badly formatted data
-    ],
-)
 def test_prediction_endpoint_post_fail(
-    caplog, base_route, sensors, gordo_ml_server_client, data_to_post
+    caplog, base_route, sensors, gordo_ml_server_client
 ):
     """
     Test expected failures when posting certain types of data
     """
-    with caplog.at_level(logging.CRITICAL):
-        resp = gordo_ml_server_client.post(
-            f"{base_route}/prediction", json=data_to_post
-        )
-    assert resp.status_code == 400
+    erroneous_datasets = [
+        # Not enough features
+        {"X": [list(range(len(sensors) - 1))]},
+        # No X
+        {"no-X-here": True},
+        # Badly formatted data
+        {"X": [[1, 2, [1, 2]]]},
+    ]
+    for i, data_to_post in enumerate(erroneous_datasets):
+        with caplog.at_level(logging.CRITICAL):
+            resp = gordo_ml_server_client.post(
+                f"{base_route}/prediction", json=data_to_post
+            )
+        assert (
+            resp.status_code == 400
+        ), f"Prediction did not fail with data, {str(data_to_post)}."

--- a/tests/gordo_components/server/test_gordo_server.py
+++ b/tests/gordo_components/server/test_gordo_server.py
@@ -46,7 +46,7 @@ def test_response_header_timing(base_route, gordo_ml_server_client):
     assert "request_walltime_s" in resp.headers["Server-Timing"]
 
 
-def test_metadata_endpoint(base_route, gordo_ml_server_client):
+def test_metadata_endpoint(base_route, gordo_single_target, gordo_ml_server_client):
     """
     Test the expected behavior of /metadata
     """
@@ -55,7 +55,7 @@ def test_metadata_endpoint(base_route, gordo_ml_server_client):
 
     data = resp.get_json()
     assert "metadata" in data
-    assert data["metadata"]["name"] == tu.GORDO_SINGLE_TARGET
+    assert data["metadata"]["name"] == gordo_single_target
 
 
 def test_download_model(base_route, gordo_ml_server_client):

--- a/tests/gordo_components/workflow/test_server_to_sql/test_server_to_sql.py
+++ b/tests/gordo_components/workflow/test_server_to_sql/test_server_to_sql.py
@@ -1,10 +1,9 @@
-import tests.utils as tu
 from gordo_components.workflow.server_to_sql import server_to_sql as sts
 
 
-def test_get_machines_from_server(ml_server):
+def test_get_machines_from_server(gordo_project, gordo_targets, ml_server):
     machines = sts.get_machines_from_server(
-        tu.GORDO_PROJECT, f"https://localhost/gordo/v0/{tu.GORDO_PROJECT}/"
+        gordo_project, f"https://localhost/gordo/v0/{gordo_project}/"
     )
     assert isinstance(machines, list)
-    assert len(machines) == len(tu.GORDO_TARGETS)
+    assert len(machines) == len(gordo_targets)


### PR DESCRIPTION
# Problem :no_mouth: 
Parameters used for the configuration of a test project, used across a number of tests, are currently defined as globals in `tests/utils.py` and imported into a few test modules.

# Solution :lips: 
To make this improvement, the following must be done:

* Make new fixtures that return these parameters
* Replace the use of the globals to the new fixtures
* Refactor tests that used the globals in a `parametrize` decorator for use with the fixtures
* Remove redundant fixtures and methods

closes #803 