### PR TITLE
Add aggregate-anomaly to Total Anomaly plot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: codecov/codecov-action@v1
         with:
-          token: 4d27c7df-480a-42ae-9a67-12408f06a109
+          token: fc2844a2-5a6c-43ef-a758-05bc50562b14
           fail_ci_if_error: true
 
   build-docs:

--- a/resources/grafana/dashboards/machines.json
+++ b/resources/grafana/dashboards/machines.json
@@ -978,7 +978,7 @@
             "group": [],
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "select \n  cast (threashold.value as float) as threshold, \n  date(machine.dataset->>'train_start_date') as time \nfrom machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'model_meta') as threashold \nwhere name='$Machine' and key='aggregate-threshold'\n\nunion\n\nselect \n  cast (threashold.value as float) as threshold, \n  current_date as time \nfrom machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'model_meta') as threashold \nwhere name='$Machine' and key='aggregate-threshold'",
+            "rawSql": "select \n  cast (threshold.value as float) as threshold, \n  date(machine.dataset->>'train_start_date') as time \nfrom machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'model_meta') as threshold \nwhere name='$Machine' and key='aggregate-threshold'\n\nunion\n\nselect \n  cast (threshold.value as float) as threshold, \n  current_date as time \nfrom machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'model_meta') as threshold \nwhere name='$Machine' and key='aggregate-threshold'",
             "refId": "A",
             "select": [
               [

--- a/resources/grafana/dashboards/machines.json
+++ b/resources/grafana/dashboards/machines.json
@@ -451,7 +451,7 @@
         "scroll": true,
         "showHeader": true,
         "sort": {
-          "col": 0,
+          "col": null,
           "desc": false
         },
         "styles": [
@@ -482,7 +482,7 @@
             "group": [],
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "select jsonb_each.key as metric, jsonb_each.value as scores from machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'cross_validation'->'scores'->'explained-variance-score') where name='$Machine'",
+            "rawSql": "select raw.metric, jsonb_each.key as label, jsonb_each.value as value \nfrom (\n  select jsonb_each.key as metric, jsonb_each.value as scores from machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'cross_validation'->'scores') where name='$Machine'\n) as raw,\njsonb_each(scores)\n",
             "refId": "A",
             "select": [
               [
@@ -506,7 +506,7 @@
         ],
         "timeFrom": null,
         "timeShift": null,
-        "title": "Metric scores - Explained variance",
+        "title": "Metric scores",
         "transform": "table",
         "type": "table",
         "options": {}

--- a/resources/grafana/dashboards/machines.json
+++ b/resources/grafana/dashboards/machines.json
@@ -885,12 +885,13 @@
         }
       },
       {
+        "datasource": "-- Mixed --",
         "aliasColors": {},
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "InfluxDB",
         "fill": 0,
+        "fillGradient": 0,
         "gridPos": {
           "h": 12,
           "w": 12,
@@ -912,6 +913,9 @@
         "linewidth": 1,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
         "paceLength": 10,
         "percentage": false,
         "pointradius": 1,
@@ -924,6 +928,7 @@
         "targets": [
           {
             "alias": "$col",
+            "datasource": "InfluxDB",
             "groupBy": [
               {
                 "params": [
@@ -941,8 +946,8 @@
             "measurement": "total-anomaly-scaled",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT mean(/^$Sensor$/) as \"field\" FROM \"original-input\" WHERE (\"machine\" =~ /^$Machine$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
-            "rawQuery": false,
+            "query": "SELECT mean(*) FROM \"total-anomaly-scaled\" WHERE (\"machine\" =~ /^$Machine$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+            "rawQuery": true,
             "refId": "B",
             "resultFormat": "time_series",
             "select": [
@@ -964,6 +969,33 @@
                 "key": "machine",
                 "operator": "=~",
                 "value": "/^$Machine$/"
+              }
+            ]
+          },
+          {
+            "datasource": "Postgres-metadata",
+            "format": "time_series",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "select \n  cast (threashold.value as float) as threshold, \n  date(machine.dataset->>'train_start_date') as time \nfrom machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'model_meta') as threashold \nwhere name='$Machine' and key='aggregate-threshold'\n\nunion\n\nselect \n  cast (threashold.value as float) as threshold, \n  current_date as time \nfrom machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'model_meta') as threashold \nwhere name='$Machine' and key='aggregate-threshold'",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "timeColumn": "time",
+            "where": [
+              {
+                "name": "$__timeFilter",
+                "params": [],
+                "type": "macro"
               }
             ]
           }

--- a/resources/grafana/dashboards/machines.json
+++ b/resources/grafana/dashboards/machines.json
@@ -435,9 +435,9 @@
         "valueName": "avg"
       },
       {
+        "datasource": "Postgres-metadata",
         "cacheTimeout": null,
         "columns": [],
-        "datasource": "Postgres-metadata",
         "fontSize": "100%",
         "gridPos": {
           "h": 6,
@@ -482,7 +482,7 @@
             "group": [],
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "select jsonb_each.key as metric, jsonb_each.value as scores from machine, jsonb_each(machine.metadata->'machine-metadata'->'build-metadata'->'model'->'cross-validation'->'scores'->'explained-variance-score') where name='$Machine'",
+            "rawSql": "select jsonb_each.key as metric, jsonb_each.value as scores from machine, jsonb_each(machine.metadata->'build_metadata'->'model'->'cross_validation'->'scores'->'explained-variance-score') where name='$Machine'",
             "refId": "A",
             "select": [
               [
@@ -508,7 +508,8 @@
         "timeShift": null,
         "title": "Metric scores - Explained variance",
         "transform": "table",
-        "type": "table"
+        "type": "table",
+        "options": {}
       },
       {
         "aliasColors": {},


### PR DESCRIPTION
Will close #848 

Adds a static plotting of the `aggregate-anomaly` calculated in the `DiffBasedAnomalyDetector` and plots it onto the existing _"TotalAnomaly"_ panel:

![image](https://user-images.githubusercontent.com/13764397/72140428-09729480-3391-11ea-8946-a6265bf054b6.png)

