### PR TITLE
Make metadata/machine use more consistent. 

### DIFF
--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -63,7 +63,7 @@ class ModelBuilder:
         ...     project_name='test-proj',
         ... )
         >>> builder = ModelBuilder(machine=machine)
-        >>> model, metadata = builder.build()
+        >>> model, machine = builder.build()
         """
         # Avoid overwriting the passed machine, copy doesn't work if it holds
         # reference to a loaded Tensorflow model; .to_dict() serializes it to
@@ -137,7 +137,7 @@ class ModelBuilder:
             else:
                 model, machine = self._build()
                 self.cached_model_path = self._save_model(
-                    model=model, metadata=machine, output_dir=output_dir  # type: ignore
+                    model=model, machine=machine, output_dir=output_dir  # type: ignore
                 )
                 logger.info(f"Built model, and deposited at {self.cached_model_path}")
                 logger.info(f"Writing model-location to model registry")
@@ -148,7 +148,7 @@ class ModelBuilder:
         # Save model to disk, if we're not building for cv only purposes.
         if output_dir and (self.machine.evaluation.get("cv_mode") != "cross_val_only"):
             self.cached_model_path = self._save_model(
-                model=model, metadata=machine, output_dir=output_dir
+                model=model, machine=machine, output_dir=output_dir
             )
         return model, machine
 
@@ -419,7 +419,7 @@ class ModelBuilder:
     @staticmethod
     def _save_model(
         model: BaseEstimator,
-        metadata: Union[Machine, dict],
+        machine: Union[Machine, dict],
         output_dir: Union[os.PathLike, str],
     ):
         """
@@ -443,7 +443,7 @@ class ModelBuilder:
         serializer.dump(
             model,
             output_dir,
-            metadata=metadata.to_dict() if isinstance(metadata, Machine) else metadata,
+            metadata=machine.to_dict() if isinstance(machine, Machine) else machine,
         )
         return output_dir
 

--- a/gordo/builder/local_build.py
+++ b/gordo/builder/local_build.py
@@ -73,12 +73,12 @@ def local_build(
     Iterable[Tuple[Union[BaseEstimator, None], Machine]]
         A generator yielding tuples of models and their metadata.
     """
-    from gordo.builder.mlflow_utils import mlflow_context, log_metadata
+    from gordo.builder.mlflow_utils import mlflow_context, log_machine
 
     config = get_dict_from_yaml(io.StringIO(config_str))
     normed = NormalizedConfig(config, project_name="local-build")
     for machine in normed.machines:
-        model, metadata = ModelBuilder(machine=machine).build()
+        model, machine = ModelBuilder(machine=machine).build()
 
         if enable_mlflow:
             # This will enforce a single interactive login and automatically
@@ -86,6 +86,6 @@ def local_build(
             with mlflow_context(
                 name=machine.name, workspace_kwargs=workspace_kwargs
             ) as (mlflow_client, run_id):
-                log_metadata(mlflow_client, run_id, metadata)
+                log_machine(mlflow_client, run_id, machine)
 
-        yield model, metadata
+        yield model, machine

--- a/gordo/cli/cli.py
+++ b/gordo/cli/cli.py
@@ -161,7 +161,7 @@ def build(
                         workspace_kwargs,
                         service_principal_kwargs,
                     ) as (mlflow_client, run_id):
-                        mlflow_utils.log_metadata(mlflow_client, run_id, machine_out)
+                        mlflow_utils.log_machine(mlflow_client, run_id, machine_out)
 
     except Exception as e:
         exit_code = EXCEPTION_TO_EXITCODE.get(e.__class__, 1)

--- a/tests/gordo/builder/test_builder.py
+++ b/tests/gordo/builder/test_builder.py
@@ -33,7 +33,7 @@ def get_random_data():
     return data
 
 
-def metadata_check(machine: Machine, check_history):
+def machine_check(machine: Machine, check_history):
     """Helper to verify model builder metadata creation"""
     assert isinstance(machine.metadata.build_metadata.model.model_offset, int)
 
@@ -115,10 +115,10 @@ def test_output_dir(tmpdir):
         name="model-name", dataset=data_config, model=model_config, project_name="test"
     )
     builder = ModelBuilder(machine)
-    model, metadata = builder.build()
-    metadata_check(metadata, False)
+    model, machine_out = builder.build()
+    machine_check(machine_out, False)
 
-    builder._save_model(model=model, metadata=metadata, output_dir=output_dir)
+    builder._save_model(model=model, machine=machine_out, output_dir=output_dir)
 
     # Assert the model was saved at the location
     # Should be model file, and the metadata
@@ -186,9 +186,9 @@ def test_builder_metadata(raw_model_config):
     machine = Machine(
         name="model-name", dataset=data_config, model=model_config, project_name="test"
     )
-    model, metadata = ModelBuilder(machine).build()
+    model, machine_out = ModelBuilder(machine).build()
     # Check metadata, and only verify 'history' if it's a *Keras* type model
-    metadata_check(metadata, "Keras" in raw_model_config)
+    machine_check(machine_out, "Keras" in raw_model_config)
 
 
 @pytest.mark.parametrize(
@@ -333,8 +333,8 @@ def test_scores_metadata(raw_model_config):
     machine = Machine(
         dataset=data_config, model=model_config, name="model-name", project_name="test"
     )
-    model, metadata = ModelBuilder(machine).build()
-    metadata_check(metadata, False)
+    model, machine_out = ModelBuilder(machine).build()
+    machine_check(machine_out, False)
 
 
 def test_output_scores_metadata():
@@ -363,8 +363,8 @@ def test_output_scores_metadata():
     machine = Machine(
         name="model-name", dataset=data_config, model=model_config, project_name="test"
     )
-    model, metadata = ModelBuilder(machine).build()
-    scores_metadata = metadata.metadata.build_metadata.model.cross_validation.scores
+    model, machine_out = ModelBuilder(machine).build()
+    scores_metadata = machine_out.metadata.build_metadata.model.cross_validation.scores
     assert (
         scores_metadata["explained-variance-score-Tag-1"]["fold-mean"]
         + scores_metadata["explained-variance-score-Tag-2"]["fold-mean"]
@@ -627,14 +627,14 @@ def test_setting_seed(seed, model_config):
         evaluation=evaluation_config,
         project_name="test",
     )
-    _model, metadata1 = ModelBuilder(machine).build()
-    _model, metadata2 = ModelBuilder(machine).build()
+    _model, machine1 = ModelBuilder(machine).build()
+    _model, machine2 = ModelBuilder(machine).build()
 
     df1 = pd.DataFrame.from_dict(
-        metadata1.metadata.build_metadata.model.cross_validation.scores
+        machine1.metadata.build_metadata.model.cross_validation.scores
     )
     df2 = pd.DataFrame.from_dict(
-        metadata2.metadata.build_metadata.model.cross_validation.scores
+        machine2.metadata.build_metadata.model.cross_validation.scores
     )
 
     # Equality depends on the seed being set.

--- a/tests/gordo/builder/test_mlflow_utils.py
+++ b/tests/gordo/builder/test_mlflow_utils.py
@@ -233,11 +233,11 @@ def test_workspace_spauth_kwargs():
         mlu.get_spauth_kwargs()
 
 
-def test_DatetimeEncoder(metadata):
+def test_MachineEncoder(metadata):
     """
-    Test that metadata can dump successfully with MetadataEncoder
+    Test that metadata can dump successfully with MachineEncoder
     """
-    assert json.dumps(metadata, cls=mlu.MetadataEncoder)
+    assert json.dumps(metadata, cls=mlu.MachineEncoder)
 
 
 @mock.patch("gordo.builder.mlflow_utils.MlflowClient", autospec=True)
@@ -256,7 +256,7 @@ def test_mlflow_context_log_metadata(MockClient, tmpdir, metadata):
         mlflow_client,
         run_id,
     ):
-        mlu.log_metadata(mlflow_client, run_id, metadata)
+        mlu.log_machine(mlflow_client, run_id, metadata)
 
     assert mock_client.log_batch.called
 
@@ -275,4 +275,4 @@ def test_mlflow_context_log_error(MockClient, metadata):
             mlflow_client,
             run_id,
         ):
-            mlu.log_metadata(mlflow_client, run_id, metadata)
+            mlu.log_machine(mlflow_client, run_id, metadata)


### PR DESCRIPTION
Will close #830 

We use to return a semi-arbitrary 'metadata' object from `ModelBuilder.build` but now we return a complete `Machine`

Seems like good housekeeping to rename relevant variables/functions according to this.