### PR TITLE
Update serializer & fix KerasRawModelRegressor

### DIFF
--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -312,7 +312,11 @@ class KerasRawModelRegressor(KerasAutoEncoder):
         logger.debug(f"Building model from spec: {self.kind}")
 
         model = serializer.pipeline_from_definition(self.kind["spec"])
-        model.compile(**self.kind["compile"])
+
+        # Load any compile kwargs as well, such as compile.optimizer which may map to class obj
+        kwargs = serializer.pipeline_from_definition(self.kind["compile"])
+
+        model.compile(**kwargs)
         return model
 
 

--- a/gordo/serializer/pipeline_from_definition.py
+++ b/gordo/serializer/pipeline_from_definition.py
@@ -120,9 +120,7 @@ def _build_step(
     if isinstance(step, dict):
 
         if len(step.keys()) != 1:
-            raise ValueError(
-                f"Step should have a single key, " f"found multiple: {step.keys()}"
-            )
+            return _load_param_classes(step)
 
         import_str = list(step.keys())[0]
         params = step.get(import_str, dict())
@@ -177,7 +175,7 @@ def _build_step(
     # ie. "sklearn.preprocessing.PCA"
     elif isinstance(step, str):
         Step = pydoc.locate(step)  # type: Union[FeatureUnion, Pipeline, BaseEstimator]
-        return Step()
+        return Step() if Step is not None else step
 
     else:
         raise ValueError(

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,6 @@ flakes-ignore =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
-timeout = 300
+timeout = 360
 junit_duration_report = call
 junit_suite_name = gordo

--- a/tests/gordo/machine/model/test_raw_keras.py
+++ b/tests/gordo/machine/model/test_raw_keras.py
@@ -14,7 +14,9 @@ from gordo.machine.model.models import KerasRawModelRegressor
         """
         compile:
             loss: mse
-            optimizer: sgd
+            optimizer: 
+              tensorflow.keras.optimizers.SGD:
+                learning_rate: 0.001
         spec:
             tensorflow.keras.models.Sequential:
                 layers:


### PR DESCRIPTION
Will close #873 
Support loading compile kwargs which may have loadable objects in the values.

..should probably rename `serializer.pipeline_from_definition` because we're so darn generic. :stuck_out_tongue_winking_eye: 