### PR TITLE
Optimize argo lint of generated workflows

### DIFF
--- a/Dockerfile-GordoDeploy
+++ b/Dockerfile-GordoDeploy
@@ -23,7 +23,7 @@ RUN cat /code/requirements.txt | grep tensorflow== > /code/prereq.txt \
 
 ARG HTTPS_PROXY
 ARG KUBECTL_VERSION="v1.14.8"
-ARG ARGO_VERSION="v2.4.2"
+ARG ARGO_VERSION="v2.4.3"
 
 #donwload & install kubectl
 RUN curl -sSL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl &&\

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,17 @@ def influxdb(base_influxdb):
     base_influxdb.reset()
 
 
+@pytest.fixture(scope="session")
+def argo_version(repo_dir):
+    with open(os.path.join(repo_dir, "Dockerfile-GordoDeploy")) as f:
+        match = next(re.finditer(r'ARGO_VERSION="(\w\d+.\d+.\d+)"', f.read()), None)
+    if match is None:
+        raise LookupError(
+            "Failed to determine argo version from Dockerfile-GordoDeploy"
+        )
+    return match.groups()[0]
+
+
 @pytest.fixture(scope="module")
 def ml_server(
     model_collection_directory, trained_model_directory, gordo_host, gordo_project

--- a/tests/gordo/workflow/test_workflow_generator/test_workflow_generator.py
+++ b/tests/gordo/workflow/test_workflow_generator/test_workflow_generator.py
@@ -85,7 +85,7 @@ def _get_env_for_machine_build_serve_task(machine, expanded_template):
 
 @pytest.mark.parametrize("fp_config", ("config_legacy.yaml", "config_crd.yaml"))
 @pytest.mark.dockertest
-def test_argo_lint(fp_config, repo_dir, tmpdir):
+def test_argo_lint(fp_config, repo_dir, tmpdir, argo_version):
     """
     Test the example config files, assumed to be valid, produces a valid workflow via `argo lint`
     """
@@ -105,7 +105,7 @@ def test_argo_lint(fp_config, repo_dir, tmpdir):
 
     logger.info("Running workflow generator and argo lint on examples/config.yaml...")
     result = docker_client.containers.run(
-        "argoproj/argocli:v2.4.3",
+        f"argoproj/argocli:{argo_version}",
         command="lint /tmp/out.yml",
         auto_remove=True,
         stderr=True,


### PR DESCRIPTION
Instead of building our own docker image which tends to have timeout issues, we can use `argocli` image and mount in a workflow generated on the host machine.

Seems to reduce the argo lint tests from ~5mins to 5 seconds. :turtle::dash: 