### PR TITLE
Add InsufficientDataAfterRowFilteringError to row_filter

### DIFF
--- a/gordo/cli/cli.py
+++ b/gordo/cli/cli.py
@@ -10,7 +10,10 @@ import traceback
 
 from gordo.machine.dataset.data_provider.providers import NoSuitableDataProviderError
 from gordo.machine.dataset.sensor_tag import SensorTagNormalizationError
-from gordo.machine.dataset.datasets import InsufficientDataError
+from gordo.machine.dataset.datasets import (
+    InsufficientDataError,
+    InsufficientDataAfterRowFilteringError,
+)
 from gordo.builder.mlflow_utils import MlflowLoggingError
 from gunicorn.glogging import Logger
 
@@ -34,8 +37,9 @@ EXCEPTION_TO_EXITCODE: Dict[Type[Exception], int] = {
     FileNotFoundError: 30,
     SensorTagNormalizationError: 60,
     NoSuitableDataProviderError: 70,
-    InsufficientDataError: 71,
-    MlflowLoggingError: 80,
+    InsufficientDataError: 80,
+    InsufficientDataAfterRowFilteringError: 81,
+    MlflowLoggingError: 90,
 }
 
 logger = logging.getLogger(__name__)

--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -32,6 +32,10 @@ class InsufficientDataError(ValueError):
     pass
 
 
+class InsufficientDataAfterRowFilteringError(ValueError):
+    pass
+
+
 def compat(init):
     """
     __init__ decorator for compatibility where the Gordo config file's ``dataset`` keys have
@@ -219,6 +223,13 @@ class TimeSeriesDataset(GordoBaseDataset):
             data = pandas_filter_rows(
                 data, self.row_filter, buffer_size=self.row_filter_buffer_size
             )
+
+            if len(data) <= self.n_samples_threshold:
+                raise InsufficientDataAfterRowFilteringError(
+                    f"The length of the genrated DataFrame ({len(data)}) does not exceed the "
+                    f"specified required threshold for the number of rows ({self.n_samples_threshold}), "
+                    f" after applying the specified row-filter."
+                )
 
         x_tag_names = [tag.name for tag in self.tag_list]
         y_tag_names = [tag.name for tag in self.target_tag_list]


### PR DESCRIPTION
The new error is raised if the row_filtering ends up with less (or equal) rows than the n_samples_threshold. Used to differentiate between not enough data and the row_filtering beeing to strict, removing to many values.