### PR TITLE
Raise better error on missing data

### DIFF
--- a/gordo/cli/cli.py
+++ b/gordo/cli/cli.py
@@ -10,10 +10,8 @@ import traceback
 
 from gordo.machine.dataset.data_provider.providers import NoSuitableDataProviderError
 from gordo.machine.dataset.sensor_tag import SensorTagNormalizationError
-from gordo.machine.dataset.datasets import (
-    InsufficientDataError,
-    InsufficientDataAfterRowFilteringError,
-)
+from gordo.machine.dataset.datasets import InsufficientDataAfterRowFilteringError
+from gordo.machine.dataset.base import InsufficientDataError
 from gordo.reporters.mlflow import MlflowLoggingError
 from gunicorn.glogging import Logger
 

--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -12,7 +12,7 @@ from gordo.machine.dataset.data_provider.providers import (
     RandomDataProvider,
     DataLakeProvider,
 )
-from gordo.machine.dataset.base import GordoBaseDataset
+from gordo.machine.dataset.base import GordoBaseDataset, InsufficientDataError
 from gordo.machine.dataset.data_provider.base import GordoBaseDataProvider
 from gordo.machine.dataset.filter_rows import pandas_filter_rows
 from gordo.machine.dataset.sensor_tag import SensorTag
@@ -28,11 +28,7 @@ from gordo.machine.validators import (
 logger = logging.getLogger(__name__)
 
 
-class InsufficientDataError(ValueError):
-    pass
-
-
-class InsufficientDataAfterRowFilteringError(ValueError):
+class InsufficientDataAfterRowFilteringError(InsufficientDataError):
     pass
 
 
@@ -198,18 +194,13 @@ class TimeSeriesDataset(GordoBaseDataset):
 
         # Resample if we have a resolution set, otherwise simply join the series.
         if self.resolution:
-            try:
-                data = self.join_timeseries(
-                    series_iter,
-                    self.train_start_date,
-                    self.train_end_date,
-                    self.resolution,
-                    aggregation_methods=self.aggregation_methods,
-                )
-            except IndexError:
-                raise InsufficientDataError(
-                    f"One or more series in the tag list is missing data for the specified period."
-                )
+            data = self.join_timeseries(
+                series_iter,
+                self.train_start_date,
+                self.train_end_date,
+                self.resolution,
+                aggregation_methods=self.aggregation_methods,
+            )
         else:
             data = pd.concat(series_iter, axis=1, join="inner")
 

--- a/tests/gordo/machine/dataset/test_dataset.py
+++ b/tests/gordo/machine/dataset/test_dataset.py
@@ -12,10 +12,9 @@ from gordo.machine.dataset.data_provider.base import GordoBaseDataProvider
 from gordo.machine.dataset.datasets import (
     RandomDataset,
     TimeSeriesDataset,
-    InsufficientDataError,
     InsufficientDataAfterRowFilteringError,
 )
-from gordo.machine.dataset.base import GordoBaseDataset
+from gordo.machine.dataset.base import GordoBaseDataset, InsufficientDataError
 from gordo.machine.dataset.sensor_tag import SensorTag
 
 


### PR DESCRIPTION
Will close #890 

Catch individual `IndexError`s during `join_timeseries` and accumulate a list of the series name's that caused the errors and reflect those back out in the final `InsufficientDataError`