### PR TITLE
Add 'dataset' key for build metadata

### DIFF
--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -31,6 +31,7 @@ from gordo.machine import Machine
 from gordo.machine.metadata import (
     BuildMetadata,
     ModelBuildMetadata,
+    DatasetBuildMetadata,
     CrossValidationMetaData,
 )
 
@@ -261,7 +262,11 @@ class ModelBuilder:
                             scores=scores,
                             splits=split_metadata,
                         )
-                    )
+                    ),
+                    dataset=DatasetBuildMetadata(
+                        query_duration_sec=time_elapsed_data,
+                        dataset_meta=dataset.get_metadata(),
+                    ),
                 )
                 return model, machine
 
@@ -279,7 +284,6 @@ class ModelBuilder:
                     datetime.datetime.now(datetime.timezone.utc).astimezone()
                 ),
                 model_builder_version=__version__,
-                data_query_duration_sec=time_elapsed_data,
                 model_training_duration_sec=time_elapsed_model,
                 cross_validation=CrossValidationMetaData(
                     cv_duration_sec=cv_duration_sec,
@@ -287,7 +291,11 @@ class ModelBuilder:
                     splits=split_metadata,
                 ),
                 model_meta=self._extract_metadata_from_model(model),
-            )
+            ),
+            dataset=DatasetBuildMetadata(
+                query_duration_sec=time_elapsed_data,
+                dataset_meta=dataset.get_metadata(),
+            ),
         )
         return model, machine
 

--- a/gordo/machine/metadata/metadata.py
+++ b/gordo/machine/metadata/metadata.py
@@ -4,7 +4,13 @@ from dataclasses_json import dataclass_json
 from gordo import __version__
 
 
-__all__ = ["Metadata", "BuildMetadata", "ModelBuildMetadata", "CrossValidationMetaData"]
+__all__ = [
+    "Metadata",
+    "BuildMetadata",
+    "ModelBuildMetadata",
+    "CrossValidationMetaData",
+    "DatasetBuildMetadata",
+]
 
 
 @dataclass_json
@@ -21,7 +27,6 @@ class ModelBuildMetadata:
     model_offset: int = 0
     model_creation_date: Optional[str] = None
     model_builder_version: str = __version__
-    data_query_duration_sec: Optional[float] = None
     cross_validation: CrossValidationMetaData = field(
         default_factory=CrossValidationMetaData
     )
@@ -31,8 +36,16 @@ class ModelBuildMetadata:
 
 @dataclass_json
 @dataclass
+class DatasetBuildMetadata:
+    query_duration_sec: Optional[float] = None  # How long it took to get the data
+    dataset_meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass_json
+@dataclass
 class BuildMetadata:
     model: ModelBuildMetadata = field(default_factory=ModelBuildMetadata)
+    dataset: DatasetBuildMetadata = field(default_factory=DatasetBuildMetadata)
 
 
 @dataclass_json

--- a/gordo/reporters/mlflow.py
+++ b/gordo/reporters/mlflow.py
@@ -268,7 +268,7 @@ def get_batch_kwargs(machine: Machine) -> dict:
     else:
         metric_list.extend(
             Metric(k, float(getattr(build_metadata.model, k)), epoch_now(), 0)
-            for k in ["data_query_duration_sec", "model_training_duration_sec"]
+            for k in ["model_training_duration_sec"]
         )
         for m in meta_params["metrics"]:
             data = build_metadata.model.model_meta["history"][m]

--- a/tests/gordo/machine/metadata/test_metadata.py
+++ b/tests/gordo/machine/metadata/test_metadata.py
@@ -15,7 +15,10 @@ def test_metadata_dataclass():
                 model_builder_version="v1",
                 data_query_duration_sec=1.0,
                 cross_validation=m.CrossValidationMetaData(),
-            )
+            ),
+            dataset=m.DatasetBuildMetadata(
+                query_duration_sec=1, dataset_meta=dict(key="value")
+            ),
         ),
     )
     m.Metadata.from_dict(metadata.to_dict())

--- a/tests/gordo/machine/metadata/test_metadata.py
+++ b/tests/gordo/machine/metadata/test_metadata.py
@@ -13,7 +13,6 @@ def test_metadata_dataclass():
                 model_offset=0,
                 model_creation_date="2016-01-01",
                 model_builder_version="v1",
-                data_query_duration_sec=1.0,
                 cross_validation=m.CrossValidationMetaData(),
             ),
             dataset=m.DatasetBuildMetadata(

--- a/tests/gordo/workflow/test_config_elements.py
+++ b/tests/gordo/workflow/test_config_elements.py
@@ -168,13 +168,13 @@ def test_machine_from_config(default_globals: dict):
                         "scores": {},
                         "splits": {},
                     },
-                    "data_query_duration_sec": None,
                     "model_builder_version": __version__,
                     "model_creation_date": None,
                     "model_meta": {},
                     "model_offset": 0,
                     "model_training_duration_sec": None,
-                }
+                },
+                "dataset": {"query_duration_sec": None, "dataset_meta": {}},
             },
             "user_defined": {
                 "global-metadata": {},


### PR DESCRIPTION
Part of #779 
This sets up the ability to add more explicit `dataset` build metadata as its own key withing `BuildMetadata`. 

In a seperate PR(?), should probably change the metadata that is returned from `TimeSeriesDataset.get_metadata` as it basically gives what `.to_dict()` gives; as well as additional stuff about the dataset itself which happened during the build.