### PR TITLE
Cleanup filter_rows.py

### DIFF
--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -1,46 +1,8 @@
-import ast
 import logging
 import pandas as pd
 import numpy as np
 
 logger = logging.getLogger(__name__)
-
-
-class _DfNameInserter(ast.NodeTransformer):
-    def __init__(self, df_name="df"):
-        """
-        Constructs a ast.NodeTransformer which inserts df[X] around strings X.
-
-        So if it is given
-        ast.parse("('A' > 2) | (('B' < 10) & ('C' > 123.31))")
-        it will return the same as
-        ast.parse("(df['A'] > 2) | ((df['B'] < 10) & (df['C'] > 123.31))")
-
-        Parameters
-        ----------
-        df_name : str
-                  Name of the string to insert "around" strings.
-
-        Examples
-        --------
-        >>> ast.dump(_DfNameInserter().visit(ast.parse("'A' > 2"))) == ast.dump(ast.parse("df['A'] > 2"))
-        True
-
-        """
-        self.df_name = df_name
-        super().__init__()
-
-    def visit_Str(self, node):
-        return ast.fix_missing_locations(
-            ast.copy_location(
-                ast.Subscript(
-                    value=ast.Name(id=self.df_name, ctx=ast.Load()),
-                    slice=ast.Index(value=ast.copy_location(ast.Str(s=node.s), node)),
-                    ctx=ast.Load(),
-                ),
-                node,
-            )
-        )
 
 
 def apply_buffer(mask: pd.Series, buffer_size: int = 0):
@@ -91,9 +53,10 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
       String representing the filter. Can be a boolean combination of conditions,
       where conditions are comparisons of column names and either other columns
       or numeric values. The rows matching the filter are kept.
-      Column names can be quoted in single/double quotations or back ticks.
-      Example of legal filters are " `Tag A` > 5 " , " ('Tag B' > 1) | ('Tag C' > 4)"
-      '("Tag D" < 5) '
+      Column names with spaces must be quoted with backticks,
+      names without spaces could be quoted with backticks or be unquoted.
+      Example of legal filters are " `Tag A` > 5 " , " (`Tag B` > 1) | (`Tag C` > 4)"
+      '(`Tag D` < 5) ', " (TagB > 5) "
     buffer_size: int
       Area fore and aft of the application of ``fitler_str`` to also mark for removal.
 
@@ -123,7 +86,7 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     6  2  0
     7  2  1
     8  2  2
-    >>> pandas_filter_rows(df, "`A`>'B'")
+    >>> pandas_filter_rows(df, "`A`> B")
        A  B
     3  1  0
     6  2  0
@@ -137,61 +100,6 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     8  2  2
 
     """
-    filter_str = filter_str.replace("`", '"')
-    parsed_filter = ast.parse(filter_str, mode="eval")
-    if not _safe_ast(parsed_filter):
-        raise ValueError(f"Unsafe expression {filter_str}")
-    # Replaces strings (assumed to represent column names) with df[..]. df_name _must_
-    # match the parameter name of this function
-    parsed_filter = _DfNameInserter(df_name="df").visit(parsed_filter)
-    # The eval requires the dataframe to be called 'df'
-    pandas_filter = eval(compile(parsed_filter, filename=__name__, mode="eval"))
+    pandas_filter = df.eval(filter_str)
     apply_buffer(pandas_filter, buffer_size=buffer_size)
     return df[pandas_filter]
-
-
-# Contains all the legal AST nodes. The parsed expression below contains all components
-# allowed in a filter query.
-_LEGAL_AST_NODES = {
-    type(a)
-    for a in ast.walk(  # type: ignore
-        ast.parse(  # type: ignore
-            '("A"<6) | ("B" <= 2) & ("C" == 4.3) | ("A">-0.1 ) | ~("A">= (1-2)) '
-            '| ("A" < ("B"+1)) | ("A" < ("B" *1)) | ("A" < ("B"-1)) | ("A" < ("B"/2)) '
-            '| ("A" < ("B" **2))',
-            mode="eval",
-        ).body
-    )
-}
-
-
-def _safe_ast(some_ast):
-    """
-    Validates that the parameter AST only contain safe AST nodes, that is nodes which
-    are deemed to be safe to evaluate. Those are the nodes in _LEGAL_AST_NODES,
-    except that the top-level node is allowed to be _ast.Expression,
-
-
-    Parameters
-    ----------
-    some_ast: a parsed
-
-    Examples
-    --------
-    >>> _safe_ast(ast.parse('("A"<6) | ("B" <= 2)', mode="eval"))
-    True
-    >>> _safe_ast(ast.parse("sys.exit(0)", mode="eval"))
-    False
-    """
-    logger.debug(f"Validating AST: {ast.dump(some_ast)}")
-    if type(some_ast) is ast.Expression:
-        some_ast = some_ast.body
-
-    current_ast_nodes = {type(a) for a in list(ast.walk(some_ast))}
-    is_subset = current_ast_nodes.issubset(_LEGAL_AST_NODES)
-    if not is_subset:
-        logger.debug(
-            f"Found that AST contained illegal nodes: "
-            f"{current_ast_nodes.difference(_LEGAL_AST_NODES)}"
-        )
-    return is_subset

--- a/tests/gordo/machine/dataset/test_dataset.py
+++ b/tests/gordo/machine/dataset/test_dataset.py
@@ -193,11 +193,11 @@ def test_row_filter():
     X, _ = TimeSeriesDataset(**kwargs).get_data()
     assert 577 == len(X)
 
-    X, _ = TimeSeriesDataset(row_filter="'Tag 1' < 5000", **kwargs).get_data()
+    X, _ = TimeSeriesDataset(row_filter="`Tag 1` < 5000", **kwargs).get_data()
     assert 8 == len(X)
 
     X, _ = TimeSeriesDataset(
-        row_filter="'Tag 1' / 'Tag 3' < 0.999", **kwargs
+        row_filter="`Tag 1` / `Tag 3` < 0.999", **kwargs
     ).get_data()
     assert 3 == len(X)
 
@@ -362,4 +362,4 @@ def test_insufficient_data_after_row_filtering(n_samples_threshold, filter_value
     )
 
     with pytest.raises(InsufficientDataAfterRowFilteringError):
-        TimeSeriesDataset(row_filter=f"'Tag 1' < {filter_value}", **kwargs).get_data()
+        TimeSeriesDataset(row_filter=f"`Tag 1` < {filter_value}", **kwargs).get_data()

--- a/tests/gordo/machine/dataset/test_filter_rows.py
+++ b/tests/gordo/machine/dataset/test_filter_rows.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
+from pandas.core.computation.ops import UndefinedVariableError
 from gordo.machine.dataset.filter_rows import pandas_filter_rows, apply_buffer
 
 
@@ -10,7 +11,7 @@ def test_filter_rows_basic():
     assert len(pandas_filter_rows(df, "`Tag  1` <= `Tag 2`")) == 3
     assert len(pandas_filter_rows(df, "`Tag  1` == `Tag 2`")) == 2
     assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 2")) == 20
-    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 0.9")) == 9
+    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 0.9")) == 12
 
     assert_frame_equal(
         pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`)"),
@@ -20,9 +21,9 @@ def test_filter_rows_basic():
 
 def test_filter_rows_catches_illegal():
     df = pd.DataFrame(list(np.ndindex((10, 2))), columns=["Tag  1", "Tag 2"])
-    with pytest.raises(ValueError):
+    with pytest.raises(UndefinedVariableError):
         pandas_filter_rows(df, "sys.exit(0)")
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         pandas_filter_rows(df, "lambda x:x")
     with pytest.raises(ValueError):
         pandas_filter_rows(df, "__import__('os').system('clear')"), ValueError


### PR DESCRIPTION
Remove custom ast implementation to allow multiples spaces in column names, as it is supported in pandas 1.0.0. Cloeses #522 