### PR TITLE
Allow readthedocs to use system packages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,7 @@ formats: all
 
 python:
   version: 3.7
+  system_packages: true
   install:
     - method: pip
       path: .


### PR DESCRIPTION
This uses readthedocs pre-installed versions of several libraries, reducing the
memory consuption of the doc-build process.

https://docs.readthedocs.io/en/latest/guides/build-using-too-many-resources.html#use-system-site-packages-for-pre-installed-libs