### PR TITLE
Update TimeSeriesDataset metadata

### DIFF
--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -228,21 +228,14 @@ class TimeSeriesDataset(GordoBaseDataset):
         X = data[x_tag_names]
         y = data[y_tag_names] if self.target_tag_list else None
 
+        if X.first_valid_index():
+            self._metadata["train_start_date_actual"] = X.index[0]
+            self._metadata["train_end_date_actual"] = X.index[-1]
+
         return X, y
 
     def get_metadata(self):
-        metadata = {
-            "tag_list": self.tag_list,
-            "target_tag_list": self.target_tag_list,
-            "train_start_date": self.train_start_date,
-            "train_end_date": self.train_end_date,
-            "resolution": self.resolution,
-            "filter": self.row_filter,
-            "row_filter_buffer_size": self.row_filter_buffer_size,
-            "data_provider": self.data_provider.to_dict(),
-            "asset": self.asset,
-        }
-        return metadata
+        return self._metadata.copy()
 
 
 class RandomDataset(TimeSeriesDataset):
@@ -255,8 +248,8 @@ class RandomDataset(TimeSeriesDataset):
     @capture_args
     def __init__(
         self,
-        train_start_date: datetime,
-        train_end_date: datetime,
+        train_start_date: Union[datetime, str],
+        train_end_date: Union[datetime, str],
         tag_list: list,
         **kwargs,
     ):

--- a/tests/gordo/machine/dataset/data_provider/test_data_provider_datalake.py
+++ b/tests/gordo/machine/dataset/data_provider/test_data_provider_datalake.py
@@ -47,22 +47,6 @@ def test_init():
     ), f"Failed to create dataset object of type {config['type']}"
 
 
-def test_get_metadata():
-    dataset_config = _get_default_dataset_config()
-    dl_backed = dataset._get_dataset(dataset_config)
-    metadata = dl_backed.get_metadata()
-
-    assert metadata["train_start_date"] == dataset_config["train_start_date"]
-    assert metadata["train_end_date"] == dataset_config["train_end_date"]
-    assert metadata["tag_list"] == dataset_config["tag_list"]
-    assert metadata["resolution"] == "10T"
-
-    dataset_config["resolution"] = "10M"
-    dl_backed = dataset._get_dataset(dataset_config)
-    metadata = dl_backed.get_metadata()
-    assert metadata["resolution"] == dataset_config["resolution"]
-
-
 @pytest.mark.skipif(
     os.getenv("INTERACTIVE") is None,
     reason="Skipping test, INTERACTIVE not set in environment variable",


### PR DESCRIPTION
Will close #779 

Remove current metadata, as it is basically a duplicate
of what `.to_dict()` does in the resulting machine.dataset
storage.

Updates the underlying `.join_timeseries` to record
information about each series which is loaded along with
the final joining of those series.