### PR TITLE
Include features' thresholds per fold in metadata

### DIFF
--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -160,12 +160,14 @@ def test_diff_detector_threshold(n_features_y: int, n_features_x: int):
     # When initialized it should not have a threshold calculated.
     assert not hasattr(model, "feature_thresholds_")
     assert not hasattr(model, "aggregate_threshold_")
+    assert not hasattr(model, "feature_thresholds_per_fold_")
 
     model.fit(X, y)
 
     # Until it has done cross validation, it has no threshold.
     assert not hasattr(model, "feature_thresholds_")
     assert not hasattr(model, "aggregate_threshold_")
+    assert not hasattr(model, "feature_thresholds_per_fold_")
 
     # Calling cross validate should set the threshold for it.
     model.cross_validate(X=X, y=y)
@@ -173,9 +175,11 @@ def test_diff_detector_threshold(n_features_y: int, n_features_x: int):
     # Now we have calculated thresholds based on cross validation folds
     assert hasattr(model, "feature_thresholds_")
     assert hasattr(model, "aggregate_threshold_")
+    assert hasattr(model, "feature_thresholds_per_fold_")
     assert isinstance(model.feature_thresholds_, pd.Series)
     assert len(model.feature_thresholds_) == y.shape[1]
     assert all(model.feature_thresholds_.notna())
+    assert isinstance(model.feature_thresholds_per_fold_, pd.DataFrame)
 
 
 @pytest.mark.parametrize("return_estimator", (True, False))


### PR DESCRIPTION
We currently log into metadata the calculated thresholds per feature and the aggregate. It has been requested to additionally log the existing intermediate calculations of the "feature thresholds per fold" as well.


Example:


```python
>>> machine.metadata.build_metadata.model.model_meta['feature-thresholds-per-fold']
{'tag-0': {'fold-0': 0.5027252655852338,
           'fold-1': 0.4664650358022078,
           'fold-2': 0.5429959691823347},
 'tag-1': {'fold-0': 0.562261042573828,
           'fold-1': 0.6089732143556913,
           'fold-2': 0.5880519662881121},
 'tag-2': {'fold-0': 0.5893215013091214,
           'fold-1': 0.47895224187839747,
           'fold-2': 0.22596768265410738},
 'tag-3': {'fold-0': 0.4760469371831675,
           'fold-1': 0.6181816933881628,
           'fold-2': 0.5593841253053533}}

```