### PR TITLE
Total anomaly change

### DIFF
--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -161,7 +161,7 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             )
 
         # Final thresholds are the thresholds from the last cv split/fold
-        self.feature_thresholds = tag_thresholds_fold
+        self.feature_thresholds_ = tag_thresholds_fold
 
         # For the aggregate also use the thresholds from the last split/fold
         self.aggregate_threshold_ = aggregate_threshold_fold
@@ -235,11 +235,10 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             index=data.index,
         )
 
-        # Calculate the scaled tag anomalies
+        # Calculate the absolute scaled tag anomaly
         # Ensure to offset the y to match model out, which could be less if it was an LSTM
         scaled_y = self.scaler.transform(y)
-        scaled_diff = model_out_scaled - scaled_y[-len(data) :, :]
-        tag_anomaly_scaled = np.abs(scaled_diff)
+        tag_anomaly_scaled = np.abs(model_out_scaled - scaled_y[-len(data) :, :])
         tag_anomaly_scaled.columns = pd.MultiIndex.from_product(
             (("tag-anomaly-scaled",), tag_anomaly_scaled.columns)
         )
@@ -250,7 +249,7 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             axis=1
         )
 
-        # Calculate the unscaled tag anomalies
+        # Calculate the absolute unscaled tag anomalies
         unscaled_abs_diff = pd.DataFrame(
             data=np.abs(data["model-output"].values - y.values[-len(data) :, :]),
             index=data.index,

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -256,6 +256,8 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         )
         data = data.join(unscaled_abs_diff)
 
+        # Calculate the scaled total anomaly
+        data["total-anomaly-unscaled"] = np.square(data["tag-anomaly-unscaled"]).mean(axis=1)
 
         # If we have `thresholds_` values, then we can calculate anomaly confidence
         if hasattr(self, "feature_thresholds_"):
@@ -272,8 +274,7 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             data = data.join(anomaly_confidence_scores)
 
         if hasattr(self, "aggregate_threshold_"):
-            scaled_mse = (scaled_diff ** 2).mean(axis=1)
-            data["total-anomaly-confidence"] = scaled_mse / self.aggregate_threshold_
+            data["total-anomaly-confidence"] = data["total-anomaly-scaled"] / self.aggregate_threshold_
 
         # Explicitly raise error if we were required to do threshold based calculations
         # should would have required a call to .cross_validate before .anomaly

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -152,7 +152,9 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             self.aggregate_thresholds_per_fold_[f"fold-{i}"] = aggregate_threshold_fold
 
             # Accumulate the rolling mins of diffs into common df
-            tag_thresholds_fold = pd.DataFrame(np.abs(y_pred - y_true)).rolling(6).min().max()
+            tag_thresholds_fold = (
+                pd.DataFrame(np.abs(y_pred - y_true)).rolling(6).min().max()
+            )
             tag_thresholds_fold.name = f"fold-{i}"
             self.feature_thresholds_per_fold_ = self.feature_thresholds_per_fold_.append(
                 tag_thresholds_fold
@@ -162,7 +164,7 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         self.feature_thresholds = tag_thresholds_fold
 
         # For the aggregate also use the thresholds from the last split/fold
-        self.aggregate_threshold_= aggregate_threshold_fold
+        self.aggregate_threshold_ = aggregate_threshold_fold
 
         return cv_output
 
@@ -244,7 +246,9 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         data = data.join(tag_anomaly_scaled)
 
         # Calculate scaled total anomaly
-        data["total-anomaly-scaled"] = np.square(data["tag-anomaly-scaled"]).mean(axis=1)
+        data["total-anomaly-scaled"] = np.square(data["tag-anomaly-scaled"]).mean(
+            axis=1
+        )
 
         # Calculate the unscaled tag anomalies
         unscaled_abs_diff = pd.DataFrame(
@@ -257,7 +261,9 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         data = data.join(unscaled_abs_diff)
 
         # Calculate the scaled total anomaly
-        data["total-anomaly-unscaled"] = np.square(data["tag-anomaly-unscaled"]).mean(axis=1)
+        data["total-anomaly-unscaled"] = np.square(data["tag-anomaly-unscaled"]).mean(
+            axis=1
+        )
 
         # If we have `thresholds_` values, then we can calculate anomaly confidence
         if hasattr(self, "feature_thresholds_"):
@@ -274,7 +280,9 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             data = data.join(anomaly_confidence_scores)
 
         if hasattr(self, "aggregate_threshold_"):
-            data["total-anomaly-confidence"] = data["total-anomaly-scaled"] / self.aggregate_threshold_
+            data["total-anomaly-confidence"] = (
+                data["total-anomaly-scaled"] / self.aggregate_threshold_
+            )
 
         # Explicitly raise error if we were required to do threshold based calculations
         # should would have required a call to .cross_validate before .anomaly

--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -208,28 +208,6 @@ def test_diff_detector_cross_validate(return_estimator: bool):
 
     assert cv_results_da.keys() == cv_results_sk.keys()
 
-
-# simulate LSTM outptu shorter than input
-@pytest.mark.parametrize("y_pred_shape", ((100, 2), (100, 2)))
-@pytest.mark.parametrize("y_true_shape", ((100, 2),))
-def test_diff_detector_fold_thresholds(y_pred_shape: tuple, y_true_shape: tuple):
-    """
-    Calculation of intermediate folds from y predicted and y true
-    """
-    y_pred = np.random.random(y_pred_shape)
-    y_true = np.random.random(y_true_shape)
-
-    expected = (
-        pd.DataFrame(np.abs(y_pred - y_true[-len(y_pred) :])).rolling(6).min().max()
-    )
-    output = DiffBasedAnomalyDetector._feature_fold_thresholds(
-        y_true=y_true, y_pred=y_pred, fold=1
-    )
-
-    assert np.allclose(expected.values, output.values)
-    assert output.name == "fold-1"
-
-
 @pytest.mark.parametrize("require_threshold", (True, False))
 def test_diff_detector_require_thresholds(require_threshold: bool):
     """

--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -208,6 +208,7 @@ def test_diff_detector_cross_validate(return_estimator: bool):
 
     assert cv_results_da.keys() == cv_results_sk.keys()
 
+
 @pytest.mark.parametrize("require_threshold", (True, False))
 def test_diff_detector_require_thresholds(require_threshold: bool):
     """

--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -95,7 +95,7 @@ def test_diff_detector(scaler, index, lookback, with_thresholds: bool):
     feature_error_scaled = np.abs(
         scaler.transform(base_df["model-output"].values) - scaler.transform(y)
     )
-    total_anomaly_scaled = np.linalg.norm(feature_error_scaled, axis=1)
+    total_anomaly_scaled = np.square(feature_error_scaled).mean(axis=1)
     assert np.allclose(feature_error_scaled, anomaly_df["tag-anomaly-scaled"].values)
     assert np.allclose(total_anomaly_scaled, anomaly_df["total-anomaly-scaled"].values)
 

--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -83,7 +83,7 @@ def test_diff_detector(scaler, index, lookback, with_thresholds: bool):
 
     # Verify calculation for unscaled data
     feature_error_unscaled = np.abs(base_df["model-output"].values - y.values)
-    total_anomaly_unscaled = np.linalg.norm(feature_error_unscaled, axis=1)
+    total_anomaly_unscaled = np.square(feature_error_unscaled).mean(axis=1)
     assert np.allclose(
         feature_error_unscaled, anomaly_df["tag-anomaly-unscaled"].values
     )


### PR DESCRIPTION
This PR will apply the following changes:

- remove unnecessary function for the calculation for the feature thresholds (easier to read)
- new calculation of total anomaly (scaled and unscaled analogue):
from 

`data["total-anomaly-scaled"] = np.linalg.norm(data["tag-anomaly-scaled"], axis=1)`
to
`data["total-anomaly-scaled"] = np.square(data["tag-anomaly-scaled"]).mean(axis=1)`

- the total model threshold validation is simplified