### PR TITLE
 Builder: Use un-cached runtime properties

### DIFF
--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -133,6 +133,9 @@ class ModelBuilder:
                 metadata["metadata"][
                     "user_defined"
                 ] = self.machine.metadata.user_defined
+
+                metadata["runtime"] = self.machine.runtime
+
                 machine = Machine(**metadata)
 
             # Otherwise build and cache the model

--- a/gordo/machine/machine.py
+++ b/gordo/machine/machine.py
@@ -132,7 +132,7 @@ class Machine:
         # Avoid circular dependency with reporters which import Machine
         from gordo.reporters.base import BaseReporter
 
-        for reporter in map(BaseReporter.from_dict, self.runtime["reporters"]):
+        for reporter in map(BaseReporter.from_dict, self.runtime.get("reporters", [])):
             logger.debug(f"Using reporter: {reporter}")
             reporter.report(self)
 

--- a/tests/gordo/builder/test_builder.py
+++ b/tests/gordo/builder/test_builder.py
@@ -511,6 +511,7 @@ def test_provide_saved_model_caching(
             model=model_config,
             metadata=metadata,
             project_name="test",
+            runtime={"something": True},
         )
     ).build(
         output_dir=new_output_dir,
@@ -524,6 +525,8 @@ def test_provide_saved_model_caching(
     model2_creation_date = (
         second_machine.metadata.build_metadata.model.model_creation_date
     )
+    assert "something" in second_machine.runtime
+
     if should_be_equal:
         assert model1_creation_date == model2_creation_date
     else:


### PR DESCRIPTION
This closes #935