### PR TITLE
Bump bleach version for security patch

### DIFF
--- a/requirements/full_requirements.txt
+++ b/requirements/full_requirements.txt
@@ -4,12 +4,8 @@
 #
 #    pip-compile --output-file=full_requirements.txt mlflow_requirements.in postgres_requirements.in requirements.in
 #
-absl-py==0.9.0            # via tensorboard, tensorflow
-adal==1.2.2               # via azure-datalake-store, azureml-core, msrestazure
+adal==1.2.2               # via azureml-core, msrestazure
 alembic==1.3.3            # via mlflow
-aniso8601==8.0.0          # via flask-restplus
-astor==0.8.1              # via tensorflow
-attrs==19.3.0             # via jsonschema
 azure-common==1.1.24      # via azure-graphrbac, azure-mgmt-authorization, azure-mgmt-containerregistry, azure-mgmt-keyvault, azure-mgmt-resource, azure-mgmt-storage, azureml-core
 azure-datalake-store==0.0.48
 azure-graphrbac==0.61.1   # via azureml-core
@@ -27,7 +23,6 @@ cachetools==4.0.0
 catboost==0.20.2
 cchardet==2.1.5
 certifi==2019.11.28       # via msrest, requests
-cffi==1.13.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
 click==7.0
 cloudpickle==1.2.2        # via mlflow
@@ -42,95 +37,70 @@ docker==4.1.0             # via azureml-core, mlflow
 entrypoints==0.3          # via mlflow
 flask-restplus==0.13.0
 flask==1.1.1
-gast==0.2.2               # via tensorflow
 gitdb2==2.0.6             # via gitpython
 gitpython==3.0.5          # via mlflow
-google-auth-oauthlib==0.4.1  # via tensorboard
-google-auth==1.10.1       # via google-auth-oauthlib, tensorboard
-google-pasta==0.1.8       # via tensorflow
 gorilla==0.3.0            # via mlflow
 graphviz==0.13.2          # via catboost
-grpcio==1.26.0            # via tensorboard, tensorflow
 gunicorn==20.0.4
 h5py==2.10.0
 idna==2.8                 # via requests
-importlib-metadata==1.4.0  # via jsonschema
 influxdb==5.2.3
 isodate==0.6.0            # via msrest
-itsdangerous==1.1.0       # via flask
 jeepney==0.4.2            # via secretstorage
 jinja2==2.10.3
 jmespath==0.9.4           # via azureml-core
-joblib==0.14.1            # via scikit-learn
 jsonpickle==1.2           # via azureml-core, azureml-mlflow
-jsonschema==3.2.0         # via flask-restplus
-keras-applications==1.0.8  # via tensorflow
-keras-preprocessing==1.1.0  # via tensorflow
 kiwisolver==1.1.0         # via matplotlib
 mako==1.1.1               # via alembic
-markdown==3.1.1           # via tensorboard
 markupsafe==1.1.1         # via jinja2, mako
 marshmallow-enum==1.5.1   # via dataclasses-json
-marshmallow==3.3.0        # via dataclasses-json, marshmallow-enum
+marshmallow==3.3.0        # via dataclasses-json
 matplotlib==3.1.2         # via catboost
 mlflow==1.5.0
-more-itertools==8.1.0     # via zipp
 msrest==0.6.10            # via azure-graphrbac, azure-mgmt-authorization, azure-mgmt-containerregistry, azure-mgmt-keyvault, azure-mgmt-resource, azure-mgmt-storage, azureml-core, msrestazure
 msrestazure==0.6.2        # via azure-graphrbac, azure-mgmt-authorization, azure-mgmt-containerregistry, azure-mgmt-keyvault, azure-mgmt-resource, azure-mgmt-storage, azureml-core
-mypy-extensions==0.4.3    # via typing-inspect
 ndg-httpsclient==0.5.1    # via azureml-core
 numexpr==2.7.1
 numpy==1.18.1
-oauthlib==3.1.0           # via requests-oauthlib
-opt-einsum==3.1.0         # via tensorflow
 pandas==1.0.0
 pathspec==0.7.0           # via azureml-core
 peewee==3.13.1
 plotly==4.4.1             # via catboost
 prometheus-client==0.7.1  # via prometheus-flask-exporter
 prometheus-flask-exporter==0.12.1  # via mlflow
-protobuf==3.11.2          # via mlflow, tensorboard, tensorflow
+protobuf==3.11.2          # via mlflow
 psycopg2-binary==2.8.4
 pyarrow==0.15.1
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.8             # via ndg-httpsclient, pyasn1-modules, rsa
-pycparser==2.19           # via cffi
+pyasn1==0.4.8             # via ndg-httpsclient
 pyjwt==1.7.1              # via adal, azureml-core
 pyopenssl==19.1.0         # via azureml-core, ndg-httpsclient
 pyparsing==2.4.6          # via matplotlib
-pyrsistent==0.15.7        # via jsonschema
 python-dateutil==2.8.1
 python-editor==1.0.4      # via alembic
-pytz==2019.3              # via azureml-core, flask-restplus, influxdb, pandas
+pytz==2019.3              # via azureml-core, pandas
 pyyaml==5.3
 querystring-parser==1.2.4  # via mlflow
-requests-oauthlib==1.3.0  # via google-auth-oauthlib, msrest
+requests-oauthlib==1.3.0  # via msrest
 requests==2.22.0
 retrying==1.3.3           # via plotly
-rsa==4.0                  # via google-auth
 ruamel.yaml==0.15.89      # via azureml-core
 scikit-learn==0.22.1
-scipy==1.4.1              # via catboost, scikit-learn, tensorflow
+scipy==1.4.1              # via catboost
 secretstorage==3.1.2      # via azureml-core
 simplejson==3.17.0
-six==1.14.0               # via absl-py, azureml-core, catboost, cryptography, cycler, databricks-cli, docker, flask-restplus, google-auth, google-pasta, grpcio, h5py, influxdb, isodate, jsonschema, keras-preprocessing, mlflow, plotly, protobuf, pyarrow, pyopenssl, pyrsistent, python-dateutil, querystring-parser, retrying, tensorboard, tensorflow, websocket-client
+six==1.14.0               # via azureml-core, catboost, databricks-cli, docker, isodate, mlflow, plotly, protobuf, pyarrow, pyopenssl, querystring-parser, websocket-client
 smmap2==2.0.5             # via gitdb2
 sqlalchemy==1.3.13        # via alembic, mlflow
 sqlparse==0.3.0           # via mlflow
 stringcase==1.2.0         # via dataclasses-json
 tabulate==0.8.6           # via databricks-cli
-tensorboard==2.1.0        # via tensorflow
-tensorflow-estimator==2.1.0  # via tensorflow
 tensorflow==2.1.0
-termcolor==1.1.0          # via tensorflow
 typing-extensions==3.7.4.1
 typing-inspect==0.5.0     # via dataclasses-json
 urllib3==1.25.7
 websocket-client==0.57.0  # via docker
 werkzeug==0.16.1
-wheel==0.33.6             # via tensorboard, tensorflow
 wrapt==1.11.2
-zipp==2.0.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test_requirements.in
+++ b/requirements/test_requirements.in
@@ -13,6 +13,8 @@ adal~=1.2
 jupyter~=1.0.0
 notebook~=6.0
 nbconvert~=5.6
+# Force latest version for security patch until nbconvert is updated
+bleach>=3.1.1
 urllib3>=1.24.2,<2.0
 pytest-benchmark~=3.2
 mock~=3.0

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -7,91 +7,84 @@
 adal==1.2.2
 apipkg==1.5               # via execnet
 appdirs==1.4.3            # via black
-attrs==19.3.0             # via black, jsonschema, pytest
+attrs==19.3.0             # via black, pytest
 backcall==0.1.0           # via ipython
 black==19.10b0
-bleach==3.1.0             # via nbconvert
-certifi==2019.11.28       # via requests
-cffi==1.13.2              # via cryptography
-chardet==3.0.4            # via requests
+bleach==3.1.1
 click==7.0                # via black
 coverage==5.0.3           # via pytest-cov
 cryptography==2.8         # via adal
 decorator==4.4.1          # via ipython, traitlets
 defusedxml==0.6.0         # via nbconvert
-docker==4.1.0
+docker==4.2.0
 entrypoints==0.3          # via nbconvert
 execnet==1.7.1            # via pytest-xdist
-idna==2.8                 # via requests
-importlib-metadata==1.4.0  # via jsonschema, pluggy, pytest
-ipykernel==5.1.3          # via ipywidgets, jupyter, jupyter-console, notebook, qtconsole
+filelock==3.0.12          # via pytest-mypy
+importlib-metadata==1.5.0  # via pluggy, pytest
+ipykernel==5.1.4          # via ipywidgets, jupyter, jupyter-console, notebook, qtconsole
 ipython-genutils==0.2.0   # via nbformat, notebook, qtconsole, traitlets
-ipython==7.11.1           # via ipykernel, ipywidgets, jupyter-console
+ipython==7.12.0           # via ipykernel, ipywidgets, jupyter-console
 ipywidgets==7.5.1         # via jupyter
-jedi==0.15.2              # via ipython
-jinja2==2.10.3            # via nbconvert, notebook
+jedi==0.16.0              # via ipython
+jinja2==2.11.1            # via nbconvert, notebook
 jsonschema==3.2.0         # via nbformat
-jupyter-client==5.3.4     # via ipykernel, jupyter-console, notebook, qtconsole
-jupyter-console==6.0.0    # via jupyter
-jupyter-core==4.6.1       # via jupyter-client, nbconvert, nbformat, notebook, qtconsole
+jupyter-client==6.0.0     # via ipykernel, jupyter-console, notebook, qtconsole
+jupyter-console==6.1.0    # via jupyter
+jupyter-core==4.6.3       # via jupyter-client, nbconvert, nbformat, notebook, qtconsole
 jupyter==1.0.0
-markupsafe==1.1.1         # via jinja2
 mistune==0.8.4            # via nbconvert
 mock==3.0.5
-more-itertools==8.1.0     # via pytest, zipp
+more-itertools==8.2.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
 mypy==0.761               # via pytest-mypy
 nbconvert==5.6.1
-nbformat==5.0.3           # via ipywidgets, nbconvert, notebook
-notebook==6.0.2
-packaging==20.0           # via pytest
+nbformat==5.0.4           # via ipywidgets, nbconvert, notebook
+notebook==6.0.3
+packaging==20.1           # via pytest
 pandocfilters==1.4.2      # via nbconvert
-parso==0.5.2              # via jedi
+parso==0.6.1              # via jedi
 pathspec==0.7.0           # via black
-pexpect==4.7.0            # via ipython
+pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pluggy==0.13.1            # via pytest
 prometheus-client==0.7.1  # via notebook
-prompt-toolkit==2.0.10    # via ipython, jupyter-console
+prompt-toolkit==3.0.3     # via ipython, jupyter-console
 ptyprocess==0.6.0         # via pexpect, terminado
 py-cpuinfo==5.0.0         # via pytest-benchmark
 py==1.8.1                 # via pytest
-pycparser==2.19           # via cffi
 pyflakes==2.1.1           # via pytest-flakes
 pygments==2.5.2           # via ipython, jupyter-console, nbconvert, qtconsole
 pyjwt==1.7.1              # via adal
 pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.7        # via jsonschema
 pytest-benchmark==3.2.3
 pytest-cov==2.8.1
 pytest-flakes==4.0.0
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-mock==1.13.0
-pytest-mypy==0.4.2
+pytest-mypy==0.5.0
 pytest-timeout==1.3.4
 pytest-xdist==1.31.0
-pytest==5.3.2
+pytest==5.3.5
 python-dateutil==2.8.1    # via adal, jupyter-client
 pyzmq==18.1.1             # via jupyter-client, notebook
 qtconsole==4.6.0          # via jupyter
-regex==2020.1.8           # via black
-requests==2.22.0          # via adal, docker, responses
-responses==0.10.9
+regex==2020.2.20          # via black
+requests==2.23.0          # via adal, docker, responses
+responses==0.10.11
 send2trash==1.5.0         # via notebook
-six==1.14.0               # via bleach, cryptography, docker, jsonschema, mock, packaging, prompt-toolkit, pyrsistent, pytest-xdist, python-dateutil, responses, traitlets, websocket-client
+six==1.14.0               # via bleach, docker, mock, packaging, pytest-xdist, responses, traitlets, websocket-client
 terminado==0.8.3          # via notebook
 testpath==0.4.4           # via nbconvert
 toml==0.10.0              # via black
 tornado==6.0.3            # via ipykernel, jupyter-client, notebook, terminado
 traitlets==4.3.3          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbconvert, nbformat, notebook, qtconsole
-typed-ast==1.4.0          # via black, mypy
+typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.1  # via mypy
-urllib3==1.25.7
+urllib3==1.25.8
 wcwidth==0.1.8            # via prompt-toolkit, pytest
 webencodings==0.5.1       # via bleach
 websocket-client==0.57.0  # via docker
 widgetsnbextension==3.5.1  # via ipywidgets
-zipp==2.0.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
There is a moderate severity security alert for the version of `bleach` we end up with via `nbconvert`.

Until that gets updated on their side, add `bleach` with the patched version as a minimum requirement in our `test_requirements.in`,