### PR TITLE
[MRG] List filtering

### DIFF
--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -141,4 +141,4 @@ def _batch(iterable, n: int):
     """Helper function for creating batches on list items"""
     l = len(iterable)
     for ndx in range(0, l, n):
-        yield iterable[ndx:min(ndx + n, l)]
+        yield iterable[ndx : min(ndx + n, l)]

--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -133,7 +133,6 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     # and returns a pd.Series
     else:
         pandas_filter = df.eval(filter_str)
-    print(pandas_filter)
     apply_buffer(pandas_filter, buffer_size=buffer_size)
     return df[pandas_filter]
 

--- a/tests/gordo/machine/dataset/test_filter_rows.py
+++ b/tests/gordo/machine/dataset/test_filter_rows.py
@@ -10,8 +10,10 @@ def test_filter_rows_basic():
     df = pd.DataFrame(list(np.ndindex((10, 2))), columns=["Tag  1", "Tag 2"])
     assert len(pandas_filter_rows(df, "`Tag  1` <= `Tag 2`")) == 3
     assert len(pandas_filter_rows(df, "`Tag  1` == `Tag 2`")) == 2
-    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 2")) == 20
-    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | `Tag 2` < 0.9")) == 12
+    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | (`Tag 2` < 2)")) == 20
+    assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | (`Tag 2` < 0.9)")) == 12
+    assert len(pandas_filter_rows(df, "(`Tag  1` > 0) & (`Tag 2` > 0)")) == 9
+    assert len(pandas_filter_rows(df, ["`Tag  1` > 0",  "`Tag 2` > 0"])) == 9
 
     assert_frame_equal(
         pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`)"),

--- a/tests/gordo/machine/dataset/test_filter_rows.py
+++ b/tests/gordo/machine/dataset/test_filter_rows.py
@@ -13,7 +13,7 @@ def test_filter_rows_basic():
     assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | (`Tag 2` < 2)")) == 20
     assert len(pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`) | (`Tag 2` < 0.9)")) == 12
     assert len(pandas_filter_rows(df, "(`Tag  1` > 0) & (`Tag 2` > 0)")) == 9
-    assert len(pandas_filter_rows(df, ["`Tag  1` > 0",  "`Tag 2` > 0"])) == 9
+    assert len(pandas_filter_rows(df, ["`Tag  1` > 0", "`Tag 2` > 0"])) == 9
 
     assert_frame_equal(
         pandas_filter_rows(df, "(`Tag  1` <= `Tag 2`)"),


### PR DESCRIPTION
This will augment the function `pandas_filter_rows` to also handle a list of filtering criteria.

We met some limitations when using the concatenated string logic on `pd.DataFrame.eval` and the number of logical parts would exceed 32 (current dependency of numpy and pandas ) or 242 (latest release).

Using a list instead, `pd.DataFrame.eval` can handle 100 items (both in current dependency and latest release) and returns a `numpy.ndarray`.