### PR TITLE
[MRG] Bug fix: Different index type caused problems when filtering

### DIFF
--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -134,7 +134,7 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     else:
         pandas_filter = df.eval(filter_str)
     apply_buffer(pandas_filter, buffer_size=buffer_size)
-    return df[pandas_filter]
+    return df[list(pandas_filter)]
 
 
 def _batch(iterable, n: int):


### PR DESCRIPTION
Casting as list ignores the index of the filtering conditions/mask.
Original df has datetime index, the filter has integer.

`pandas.core.indexing.IndexingError: Unalignable boolean Series provided as indexer (index of the boolean Series and of the indexed object do not match)`