### PR TITLE
Daily window smoothed threshold + anomaly score

### DIFF
--- a/gordo/cli/workflow_generator.py
+++ b/gordo/cli/workflow_generator.py
@@ -105,7 +105,7 @@ def workflow_cli(gordo_ctx):
 @click.option(
     "--split-workflows",
     type=int,
-    default=50,
+    default=30,
     help="Split workflows containg more than this number of models into several "
     "workflows, where each workflow contains at most this nr of models. The "
     "workflows are outputted sequentially with '---' in between, which allows "

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -80,14 +80,14 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         if hasattr(self, "window_"):
             metadata["window"] = self.window_
         if hasattr(self, "smooth_feature_thresholds_"):
-            metadata["smooth_feature-thresholds"] = self.smooth_feature_thresholds_.tolist()
+            metadata["smooth-feature-thresholds"] = self.smooth_feature_thresholds_.tolist()
         if hasattr(self, "smooth_aggregate_threshold_"):
-            metadata["smooth_aggregate-threshold"] = self.smooth_aggregate_threshold_
+            metadata["smooth-aggregate-threshold"] = self.smooth_aggregate_threshold_
 
         if hasattr(self, "smooth_feature_thresholds_per_fold_"):
-            metadata["smooth_feature-thresholds-per-fold"] = self.smooth_feature_thresholds_per_fold_.to_dict()
+            metadata["smooth-feature-thresholds-per-fold"] = self.smooth_feature_thresholds_per_fold_.to_dict()
         if hasattr(self, "smooth_aggregate_thresholds_per_fold_"):
-            metadata["smooth_aggregate-thresholds-per-fold"] = self.smooth_aggregate_thresholds_per_fold_
+            metadata["smooth-aggregate-thresholds-per-fold"] = self.smooth_aggregate_thresholds_per_fold_
 
         if isinstance(self.base_estimator, GordoBase):
             metadata.update(self.base_estimator.get_metadata())

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -372,13 +372,21 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             )
             data = data.join(anomaly_confidence_scores)
 
+        total_anomaly_confidence = None
         if (
             hasattr(self, "smooth_aggregate_threshold_")
             and self.smooth_aggregate_threshold_ is not None
         ):
-            data["total-anomaly-confidence"] = (
+            total_anomaly_confidence = (
                 data["smooth-total-anomaly-scaled"] / self.smooth_aggregate_threshold_
             )
+        elif hasattr(self, "aggregate_threshold_"):
+            total_anomaly_confidence = (
+                data["total-anomaly-scaled"] / self.aggregate_threshold_
+            )
+
+        if total_anomaly_confidence is not None:
+            data["total-anomaly-confidence"] = total_anomaly_confidence
 
         # Explicitly raise error if we were required to do threshold based calculations
         # should would have required a call to .cross_validate before .anomaly

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -22,6 +22,7 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         base_estimator: BaseEstimator = KerasAutoEncoder(kind="feedforward_hourglass"),
         scaler: TransformerMixin = RobustScaler(),
         require_thresholds: bool = True,
+        window = 144
     ):
         """
         Classifier which wraps a ``base_estimator`` and provides a diff error
@@ -50,7 +51,7 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
         self.base_estimator = base_estimator
         self.scaler = scaler
         self.require_thresholds = require_thresholds
-        self.window = 144
+        self.window = window
 
     def __getattr__(self, item):
         """

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
-
 import numpy as np
 import pandas as pd
 

--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -45,7 +45,10 @@ def test_diff_detector(
 
     base_estimator = MultiOutputRegressor(estimator=LinearRegression())
     model = DiffBasedAnomalyDetector(
-        base_estimator=base_estimator, scaler=scaler, require_thresholds=False
+        base_estimator=base_estimator,
+        scaler=scaler,
+        require_thresholds=False,
+        window=144,
     )
 
     assert isinstance(model, AnomalyDetectorBase)
@@ -220,7 +223,7 @@ def test_diff_detector_threshold(n_features_y: int, n_features_x: int, len_x_y: 
     y = np.random.random((len_x_y, n_features_y))
 
     model = DiffBasedAnomalyDetector(
-        base_estimator=MultiOutputRegressor(estimator=LinearRegression())
+        base_estimator=MultiOutputRegressor(estimator=LinearRegression()), window=144
     )
 
     # Model has own implementation of cross_validate


### PR DESCRIPTION
Adds the smoothed threshold and anomaly calculation as discussed with the SMEs. In summary:
* keep the current threshold as it is, at least until we decide to officially adopt the method below
* define a time window that should for now be defaulted to 1 day: 144 time steps @ 10T resolution
* calculate another threshold using the same logic here but with that window: `scaled_mse.rolling(144).min().max()`
* make sure another that threshold is set to the third fold like the current one here
* also calculate the feature_thresholds using the same method
* add the new thresholds to the metadata. keep the current ones in there for now
* calculate a scaled and unscaled version of the smoothed total_anomaly using the same rolling window and the median, e.g. `data["smooth-total-anomaly-scaled"] = data["total-anomaly-scaled"].rolling(144).median()`. Do the same for tag-level anomalies.
* recalculate anomaly confidence with the new threshold and the new total_anomaly, also for the tag-level anomaly confidence.