### PR TITLE
Use PyPI token instead of username/password for pushing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish
         env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           pip install twine
-          twine upload -u statoil-travis --skip-existing dist/*
+          twine upload -u __token__ --skip-existing dist/*


### PR DESCRIPTION
Better to generate a token with _only_ access to the Gordo project on PyPI. Have added the referenced secret (the token) to the Github project (and naturally to PyPI).