### PR TITLE
[WIP] adds filtering of global thresholds

### DIFF
--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -32,8 +32,10 @@ logger = logging.getLogger(__name__)
 class InsufficientDataAfterRowFilteringError(InsufficientDataError):
     pass
 
+
 class InsufficientDataAfterGlobalFilteringError(InsufficientDataError):
     pass
+
 
 def compat(init):
     """

--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 class InsufficientDataAfterRowFilteringError(InsufficientDataError):
     pass
 
+class InsufficientDataAfterGlobalFilteringError(InsufficientDataError):
+    pass
 
 def compat(init):
     """
@@ -83,6 +85,8 @@ class TimeSeriesDataset(GordoBaseDataset):
         asset: Optional[str] = None,
         default_asset: Optional[str] = None,
         n_samples_threshold: int = 0,
+        low_threshold=-1000,
+        high_threshold=50000,
         **_kwargs,
     ):
         """
@@ -162,6 +166,8 @@ class TimeSeriesDataset(GordoBaseDataset):
         self.row_filter_buffer_size = row_filter_buffer_size
         self.asset = asset
         self.n_samples_threshold = n_samples_threshold
+        self.low_threshold = low_threshold
+        self.high_threshold = high_threshold
 
         if not self.train_start_date.tzinfo or not self.train_end_date.tzinfo:
             raise ValueError(
@@ -221,6 +227,17 @@ class TimeSeriesDataset(GordoBaseDataset):
                     f"The length of the genrated DataFrame ({len(data)}) does not exceed the "
                     f"specified required threshold for the number of rows ({self.n_samples_threshold}), "
                     f" after applying the specified row-filter."
+                )
+
+        if self.low_threshold and self.high_threshold:
+            logger.info("Applying global min/max filtering")
+            mask = ((data > self.low_threshold) & (data < self.high_threshold)).all(1)
+            data = data[mask]
+            logger.info("Shape of data after global min/max filtering: %s", self.data.shape)
+            if len(data) <= self.n_samples_threshold:
+                raise InsufficientDataAfterGlobalFilteringError(
+                    f"The length of the generated DataFrame ({len(data)}) does not exceed the "
+                    f"specified required threshold for number of rows ({self.n_samples_threshold})."
                 )
 
         x_tag_names = [tag.name for tag in self.tag_list]

--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -233,7 +233,7 @@ class TimeSeriesDataset(GordoBaseDataset):
             logger.info("Applying global min/max filtering")
             mask = ((data > self.low_threshold) & (data < self.high_threshold)).all(1)
             data = data[mask]
-            logger.info("Shape of data after global min/max filtering: %s", self.data.shape)
+            logger.info("Shape of data after global min/max filtering: %s", data.shape)
             if len(data) <= self.n_samples_threshold:
                 raise InsufficientDataAfterGlobalFilteringError(
                     f"The length of the generated DataFrame ({len(data)}) does not exceed the "

--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -138,10 +138,6 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     apply_buffer(pandas_filter, buffer_size=buffer_size)
     df = df[list(pandas_filter)]
     logger.info("Shape of data after numerical filtering: %s", df.shape)
-    logger.info("Applying global min/max filtering")
-    mask = ((df > -1000) & (df < 50000)).all(1)
-    df = df[mask]
-    logger.info("Shape of data after global min/max filtering: %s", df.shape)
     return df
 
 

--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -120,6 +120,7 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     7  2  1
     8  2  2
     """
+    logger.info("Applying numerical filtering to data of shape %s", df.shape)
     # pd.DataFrame.eval of a list returns a numpy.ndarray and is limited to 100 list items
     # therefore split in n=30 (to be safe) and evaluate iterative, keeping the sparse evaluation with numexpr
     if isinstance(filter_str, list):
@@ -133,8 +134,15 @@ def pandas_filter_rows(df, filter_str: str, buffer_size: int = 0):
     # and returns a pd.Series
     else:
         pandas_filter = df.eval(filter_str)
+
     apply_buffer(pandas_filter, buffer_size=buffer_size)
-    return df[list(pandas_filter)]
+    df = df[list(pandas_filter)]
+    logger.info("Shape of data after numerical filtering: %s", df.shape)
+    logger.info("Applying global min/max filtering")
+    mask = ((df > -1000) & (df < 50000)).all(1)
+    df = df[mask]
+    logger.info("Shape of data after global min/max filtering: %s", df.shape)
+    return df
 
 
 def _batch(iterable, n: int):

--- a/tests/gordo/machine/dataset/test_dataset.py
+++ b/tests/gordo/machine/dataset/test_dataset.py
@@ -191,7 +191,7 @@ def test_row_filter():
         train_end_date=dateutil.parser.isoparse("2017-12-29 06:00:00Z"),
     )
     X, _ = TimeSeriesDataset(**kwargs).get_data()
-    assert 577 == len(X)
+    assert 83 == len(X)
 
     X, _ = TimeSeriesDataset(row_filter="`Tag 1` < 5000", **kwargs).get_data()
     assert 8 == len(X)
@@ -218,7 +218,7 @@ def test_aggregation_methods():
 
     # Default aggregation gives no extra columns
     X, _ = TimeSeriesDataset(**kwargs).get_data()
-    assert (577, 3) == X.shape
+    assert (83, 3) == X.shape
 
     # The default single aggregation method gives the tag-names as columns
     assert list(X.columns) == ["Tag 1", "Tag 2", "Tag 3"]
@@ -227,7 +227,7 @@ def test_aggregation_methods():
     # on top and aggregation_method as second level
     X, _ = TimeSeriesDataset(aggregation_methods=["mean", "max"], **kwargs).get_data()
 
-    assert (577, 6) == X.shape
+    assert (83, 6) == X.shape
     assert list(X.columns) == [
         ("Tag 1", "mean"),
         ("Tag 1", "max"),
@@ -255,7 +255,7 @@ def test_metadata_statistics():
     # Default aggregation gives no extra columns
     dataset = TimeSeriesDataset(**kwargs)
     X, _ = dataset.get_data()
-    assert (577, 3) == X.shape
+    assert (83, 3) == X.shape
     metadata = dataset.get_metadata()
     assert isinstance(metadata["x_hist"], dict)
     assert len(metadata["x_hist"].keys()) == 3

--- a/tests/gordo/workflow/test_config_elements.py
+++ b/tests/gordo/workflow/test_config_elements.py
@@ -136,6 +136,8 @@ def test_machine_from_config(default_globals: dict):
                 "type": "DataLakeProvider",
             },
             "default_asset": None,
+            "high_threshold": 50000,
+            "low_threshold": -1000,
             "n_samples_threshold": 0,
             "resolution": "10T",
             "row_filter": "",


### PR DESCRIPTION
There is a need to filter training data based on a global threshold.
This is meant as a pure sanity-check of the data, as extremely high/low values have been seen (e.g. 7e+80). 

Alternatively, such a filtering could be done on the data, and drop-periods could be added to the model specific model filter list in a separate step.
To simply handle it directly in the filter-step seems simpler.
Disadvantage is that one does not know wether or not there has been removed data due to global threshold filtering criteria.
I do, however, not see this as a big problem.