### PR TITLE
[WIP] Adds filter periods

### DIFF
--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -264,7 +264,7 @@ class TimeSeriesDataset(GordoBaseDataset):
                 )
 
         if self.filter_periods:
-            data, drop_periods = self.filter_periods.filter_df(data)
+            data, drop_periods, _ = self.filter_periods.filter_data(data)
             self._metadata["filtered_periods"] = drop_periods
 
         x_tag_names = [tag.name for tag in self.tag_list]

--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -253,6 +253,15 @@ class TimeSeriesDataset(GordoBaseDataset):
                     f"specified required threshold for number of rows ({self.n_samples_threshold})."
                 )
 
+        if self.filter_periods:
+            filter_method = self.filter_periods.get("filter_method")
+
+            self.filter_periopds.get("filter")
+            filter_periods(data=X, method=self.filter_period_method)
+
+
+
+
         x_tag_names = [tag.name for tag in self.tag_list]
         y_tag_names = [tag.name for tag in self.target_tag_list]
 

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -88,7 +88,7 @@ class filter_periods:
         """
         data = self.data.copy()
         if self._iforest_smooth:
-            data = data.ewm(halflife=6).mean()
+            data = data.ewm(halflife=6).mean().round(4)
 
         logger.info("Fitting model")
         self._init_model()

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -191,7 +191,7 @@ class filter_periods:
                 )
 
         if row_filter:
-            n_prior = len(data)
+            n_prior = len(self.data)
             self.data = pandas_filter_rows(
                 df=self.data, filter_str=row_filter, buffer_size=0
             )

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -64,8 +64,7 @@ class filter_periods:
         self._filter_data()
 
     def _init_model(self):
-        """Return a new instance of the models.
-        """
+        """Return a new instance of the models."""
         self.isolationforest = IsolationForest(
             n_estimators=300,  # The number of base estimators in the ensemble.
             max_samples=min(
@@ -118,6 +117,7 @@ class filter_periods:
         logger.info("Anomaly ratio: %s", list(pred).count(-1) / pred.shape[0])
 
     def _rolling_median(self):
+        """Function for filtering using a rolling median approach."""
         logger.info("Calculating predictions for rolling median")
         roll = self.data.rolling(self._window, center=True)
         r_md = roll.median()
@@ -182,8 +182,7 @@ class filter_periods:
         self.drop_periods = drop_periods
 
     def _filter_data(self):
-        """Drops periods defined previously from dataset """
-
+        """Drops periods defined previously from dataset."""
         row_filter = []
         for drop_method, p in self.drop_periods.items():
             for line in p:
@@ -192,12 +191,15 @@ class filter_periods:
                 )
 
         if row_filter:
+            n_prior = len(data)
             self.data = pandas_filter_rows(
                 df=self.data, filter_str=row_filter, buffer_size=0
             )
+            logger.info(f"Dropped {n_prior - len(self.data)} rows")
+        else:
+            logger.info("No rows dropped")
 
     @staticmethod
     def _describe(score):
-        """Format array-like for logging summary statistics.
-        """
+        """Format array-like for logging summary statistics."""
         return pformat(pd.Series(score).describe().round(3).to_dict())

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -58,7 +58,7 @@ class FilterPeriods:
         self._iforest_smooth = iforest_smooth
         self._contamination = contamination
 
-    def filter_df(self, data):
+    def filter_data(self, data):
         predictions = {}
         if self.filter_method in ["median", "all"]:
             predictions["median"] = self._rolling_median(data)
@@ -69,7 +69,7 @@ class FilterPeriods:
 
         drop_periods = self._drop_periods(predictions)
         data = self._filter_data(data, drop_periods)
-        return data, drop_periods
+        return data, drop_periods, predictions
 
     def _init_model(self, data):
         """Return a new instance of the models."""
@@ -82,7 +82,7 @@ class FilterPeriods:
             max_features=1.0,  # Features to draw from X to train each base estimator.
             bootstrap=False,
             n_jobs=-1,  # ``-1`` means using all processors
-            random_state=0,
+            random_state=42,
             verbose=0,
         )
         self.minmaxscaler = MinMaxScaler()
@@ -188,7 +188,7 @@ class FilterPeriods:
 
         return drop_periods
 
-    def _filter_data(data, drop_periods):
+    def _filter_data(self, data, drop_periods):
         """Drops periods defined previously from dataset."""
         row_filter = []
         for drop_method, p in drop_periods.items():
@@ -201,8 +201,10 @@ class FilterPeriods:
             n_prior = len(data)
             data = pandas_filter_rows(df=data, filter_str=row_filter, buffer_size=0)
             logger.info(f"Dropped {n_prior - len(data)} rows")
+            return data
         else:
             logger.info("No rows dropped")
+            return data
 
     @staticmethod
     def _describe(score):

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -74,7 +74,7 @@ class filter_periods:
             max_features=1.0,  # Features to draw from X to train each base estimator.
             bootstrap=False,
             n_jobs=-1,  # ``-1`` means using all processors
-            random_state=42,
+            random_state=0,
             verbose=0,
         )
         self.minmaxscaler = MinMaxScaler()
@@ -87,7 +87,7 @@ class filter_periods:
         """
         data = self.data.copy()
         if self._iforest_smooth:
-            data = data.ewm(halflife=6).mean().round(4)
+            data = data.ewm(halflife=6).mean()
 
         logger.info("Fitting model")
         self._init_model()

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -1,0 +1,189 @@
+from pprint import pformat
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+from sklearn.preprocessing import MinMaxScaler
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class filter_periods:
+    """Model class with methods for data pre-processing.
+    Performs a series of algorithms that drops noisy data.
+
+    Either a rolling median or an isolation forest algorithm is executed.
+    Both provide drop periods in a dict-type element on the class object
+    `object.drop_periods["iforest"]` and `object.drop_periods["median"]`,
+    and data is filtered accordingly.
+
+    Parameters:
+    data: pandas.DataFrame
+        Data frame containing already filtered data (global max/min + dropped known periods).
+        Time consecutively is not required.
+
+    **kwargs:
+        See below.
+
+    Keyword arguments:
+    filter_method: str
+        Which method should be used for data cleaning, either "median" (default), "iforest" or "all" which returns
+        results for both methods.
+    iforest_smooth: bool
+        If exponential weighted smoothing should be applied to data before isolation forest
+        algorithm is run.
+    """
+
+    def __init__(
+        self,
+        data,
+        **kwargs
+
+    ):
+        self.data = data
+        self.filter_method = kwargs.get("filter_method", "median")
+        assert self.filter_method in ["median", "iforest", "all"]
+
+        self.predictions = {}
+        if self.filter_method in ["median", "all"]:
+            self._window = kwargs.get("window", 144)
+            self._n_iqr = kwargs.get("n_iqr", 5)
+            self._rolling_median()
+
+        if self.filter_method in ["iforest", "all"]:
+            self._iforest_smooth = kwargs.get("iforest_smooth", False)
+            self._contamination = kwargs.get("contamination", 0.03)
+            self._train()
+            self._predict()
+
+        self._drop_periods()
+
+    def _init_model(self):
+        """Return a new instance of the models.
+        """
+        self.isolationforest = IsolationForest(
+            n_estimators=300,  # The number of base estimators in the ensemble.
+            max_samples=min(
+                1000, self.data.shape[0]
+            ),  # Samples to draw from X to train each base estimator
+            contamination=self._contamination, # default = "auto"
+            max_features=1.0,  # Features to draw from X to train each base estimator.
+            bootstrap=False,
+            n_jobs=-1,  # ``-1`` means using all processors
+            random_state=42,
+            verbose=0,
+        )
+        self.minmaxscaler = MinMaxScaler()
+        logger.info("Initialized isolationforest: \n%s.", self.isolationforest)
+        logger.info("Initialized minmaxscaler: \n%s.", self.minmaxscaler)
+
+    def _train(self):
+        """Train the model.
+        Smooth if necessary.
+        """
+        data = self.data.copy()
+        if self._iforest_smooth:
+            data = data.ewm(halflife=6).mean()
+
+        logger.info("Fitting model")
+        self._init_model()
+        self.model = self.isolationforest.fit(data)
+
+        logger.info(
+            "Created new isolationforest model:\n%s\nFitted on data of shape '%s'.",
+            self.model,
+            self.data.shape,
+        )
+
+    def _predict(self):
+        """Make predictions.
+        """
+        logger.info("Calculating predictions for isolation forest")
+        assert isinstance(self.data, pd.DataFrame)
+
+        score = -self.model.decision_function(self.data)
+        self.iforest_scores = self._describe(score)
+        score = self.minmaxscaler.fit_transform(score.reshape(-1, 1)).squeeze()
+        self.iforest_scores_transformed = self._describe(score)
+
+        pred = self.model.predict(self.data)
+        self.predictions["iforest"] = pd.DataFrame(
+            {"pred": pred, "score": score, "timestamp": self.data.index}
+        )
+        logger.info("Anomaly ratio: %s", list(pred).count(-1) / pred.shape[0])
+
+    def _rolling_median(self):
+
+
+        logger.info("Calculating predictions for rolling median")
+        roll = self.data.rolling(self._window, center=True)
+        r_md = roll.median()
+        r_iqr = roll.quantile(0.75) - roll.quantile(0.25)
+        high = r_md + self._n_iqr * r_iqr
+        low = r_md - self._n_iqr * r_iqr
+        mask = ((self.data < low) | (self.data > high)).any(1).astype("int") * -1
+        pred = pd.DataFrame({"pred": mask})
+        pred.index.name = "timestamp"
+        pred = pred.reset_index()
+        self.predictions["median"] = pred
+        logger.info("Anomaly ratio: %s", list(pred).count(-1) / pred.shape[0])
+
+    def _drop_periods(self):
+        """Create drop period list.
+
+        Only keep anomaly flagged observations (-1), and create a time-diff between these.
+        Time consecutive anomalies will have a time-diff equal to the specified
+        granularity of the data, e.g. 10 minutes.
+        Minimum two consecutive anomalies must be flagged for a drop period to be initiated.
+        """
+        logger.info("Creating list of drop period dicts")
+        drop_periods = {}
+
+        if self.method == "all":
+            pred_types = ["iforest", "median"]
+
+        else:
+            pred_types = [self.method]
+
+        for pred_type in pred_types:
+            t = self.predictions[pred_type].query("pred == -1")[["timestamp"]]
+            t["delta_t"] = (
+                t["timestamp"]
+                .diff()
+                .fillna(pd.Timedelta(seconds=0))
+                .astype("timedelta64[m]")
+                .astype("int")
+            )
+            t = t.reset_index(drop=True)
+
+            granularity = int(
+                re.findall(r"\d+", self.config["dataset"].get("resolution", "10T"))[0]
+            )
+
+            start = []
+            end = []
+            for i in range(len(t)):
+                # start conditions:
+                # [i == 0 (start) OR
+                # time delta from previous > granularity (gap)]
+                if (i == 0) or (t["delta_t"][i] > granularity):
+                    start.append(str(t["timestamp"][i]))
+                # stop conditions:
+                # [i + 1 == len(t) (end of data) OR
+                # time delta to next > granularity (gap)]
+                if (i + 1 == len(t)) or (t["delta_t"][i + 1] > granularity):
+                    end.append(str(t["timestamp"][i]))
+            drop_periods[pred_type] = pd.DataFrame(
+                {"model_id": self.model_id, "drop_start": start, "drop_end": end}
+            ).to_dict("records")
+
+        if self.method == "all":
+            self.drop_periods = drop_periods
+        else:
+            self.drop_periods = drop_periods[self.method]
+
+    @staticmethod
+    def _describe(score):
+        """Format array-like for logging summary statistics.
+        """
+        return pformat(pd.Series(score).describe().round(3).to_dict())

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -59,6 +59,10 @@ class FilterPeriods:
         self._contamination = contamination
 
     def filter_data(self, data):
+        """Method for filtering data.
+        Returns the filtered dataset, a dict containing the different periods that have been dropped arranged
+        by filtering method and the actual predictions from the filter model.
+        """
         predictions = {}
         if self.filter_method in ["median", "all"]:
             predictions["median"] = self._rolling_median(data)

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 class WrongFilterMethodType(TypeError):
     pass
 
+
 class filter_periods:
     """Model class with methods for data pre-processing.
     Performs a series of algorithms that drops noisy data.

--- a/gordo/machine/dataset/filter_periods.py
+++ b/gordo/machine/dataset/filter_periods.py
@@ -55,8 +55,7 @@ class filter_periods:
             self._predict()
 
         self._drop_periods()
-        if len(self.drop_periods) > 0:
-            self._filter_data()
+        self._filter_data()
 
     def _init_model(self):
         """Return a new instance of the models.
@@ -174,19 +173,17 @@ class filter_periods:
                 {"drop_start": start, "drop_end": end}
             ).to_dict("records")
 
-        if self.filter_method == "all":
-            self.drop_periods = drop_periods
-        else:
-            self.drop_periods = drop_periods[self.filter_method]
+        self.drop_periods = drop_periods
 
     def _filter_data(self):
         """Drops periods defined previously from dataset"""
 
         row_filter = []
-        for row in self.drop_periods:
-            row_filter.append(
-                f"~('{row['drop_start']}' <= index <= '{row['drop_end']}')"
-            )
+        for drop_method, p in self.drop_periods.items():
+            for line in p:
+                row_filter.append(
+                    f"~('{line['drop_start']}' <= index <= '{line['drop_end']}')"
+                )
 
         self.data = pandas_filter_rows(
             df=self.data, filter_str=row_filter, buffer_size=0

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -42,17 +42,17 @@ def test_filter_periods_with_smoothing(dataset):
     data, _ = dataset.get_data()
 
     data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
+        data=data.round(2), granularity="10T", filter_method="iforest", iforest_smooth=True
     )
     assert data.shape == (2364, 2)
-    assert data_filtered.data.shape == (2008, 2)
+    assert data_filtered.data.shape == (2016, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):
     data, _ = dataset.get_data()
 
     data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
+        data=data.round(2), granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data.shape == (1837, 2)
     assert data_filtered.data.shape == (1317, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -34,9 +34,9 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1649, 2)
+    assert data_filtered.data.shape == (1663, 2)
 
     data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="all", n_iqr=1
+        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
     assert data_filtered.data.shape == (1588, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -46,7 +46,7 @@ def test_filter_periods_iforest(dataset):
     assert data["Tag 1"].mean() == 0.5144733352386245
 
     assert sum(predictions["iforest"]["pred"]) == 12066
-    assert len(drop_periods["iforest"]) == 51
+    assert len(drop_periods["iforest"]) == 61
     assert data_filtered.shape == (12452, 1)
 
 
@@ -62,7 +62,7 @@ def test_filter_periods_all(dataset):
     assert sum(predictions["median"]["pred"]) == -449
     assert sum(predictions["iforest"]["pred"]) == 7542
     assert len(drop_periods["median"]) == 39
-    assert len(drop_periods["iforest"]) == 30
+    assert len(drop_periods["iforest"]) == 29
     assert data_filtered.shape == (7356, 1)
 
 
@@ -75,7 +75,7 @@ def test_filter_periods_iforest_smoothing(dataset):
     assert data.shape == (9674, 1)
     assert data["Tag 1"].mean() == 0.5019862352609169
 
-    assert sum(predictions["iforest"]["pred"]) == 8546
+    assert sum(predictions["iforest"]["pred"]) == 8552
     assert len(drop_periods["iforest"]) == 38
     assert data_filtered.shape == (9110, 1)
 

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -17,6 +17,7 @@ def dataset():
 
 def test_filter_periods(dataset):
     data, _ = dataset.get_data()
+    assert data.shape == (1361, 2)
 
     with pytest.raises(TypeError):
         filter_periods(data=data, granularity="10T", filter_method="abc", n_iqr=1)
@@ -43,6 +44,7 @@ def test_filter_periods_with_smoothing(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
+    assert data.shape == (1361, 2)
     assert data_filtered.data.shape == (2008, 2)
 
 
@@ -52,4 +54,5 @@ def test_filter_periods_wiht_smoothing_all(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
+    assert data.shape == (1361, 2)
     assert data_filtered.data.shape == (1317, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -43,7 +43,7 @@ def test_filter_periods_with_smoothing(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (2016, 2)
+    assert data_filtered.data.shape == (2008, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -36,7 +36,7 @@ def test_filter_periods(dataset):
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
     print(len(data_filtered.data))
-    assert 1580 < len(data_filtered.data) > 1600
+    assert 1580 < len(data_filtered.data) < 1600
 
 
 def test_filter_periods_with_smoothing(dataset):

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -32,11 +32,24 @@ def test_filter_periods(dataset):
     assert data_filtered.data.shape == (1816, 2)
 
     data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="all", iforest_smooth=False
+    )
+    assert data_filtered.data.shape == (1816, 2)
+
+
+def test_filter_periods_with_smoothing(dataset):
+    data, _ = dataset.get_data()
+
+    data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert True  # data_filtered.data.shape == (1649, 2)
+    assert data_filtered.data.shape == (1649, 2)
+
+
+def test_filter_periods_wiht_smoothing_all(dataset):
+    data, _ = dataset.get_data()
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert True  # data_filtered.data.shape == (1589, 2)
+    assert data_filtered.data.shape == (1589, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -46,7 +46,7 @@ def test_filter_periods_iforest(dataset):
     assert tuple(data.mean().round(6)) == (0.519195, 0.550395)
 
     assert sum(predictions["iforest"]["pred"]) == 1725
-    assert len(drop_periods["iforest"]) == 19
+    assert len(drop_periods["iforest"]) == 16
     assert data_filtered.shape == (1781, 2)
 
 
@@ -62,7 +62,7 @@ def test_filter_periods_all(dataset):
     assert sum(predictions["median"]["pred"]) == -279
     assert sum(predictions["iforest"]["pred"]) == 1424
     assert len(drop_periods["median"]) == 16
-    assert len(drop_periods["iforest"]) == 11
+    assert len(drop_periods["iforest"]) == 10
     assert data_filtered.shape == (1219, 2)
 
 
@@ -75,7 +75,7 @@ def test_filter_periods_iforest_smoothing(dataset):
     assert data.shape == (1435, 2)
     assert tuple(data.mean().round(6)) == (0.504942, 0.47524)
 
-    assert sum(predictions["iforest"]["pred"]) == 959
+    assert sum(predictions["iforest"]["pred"]) == 985
     assert len(drop_periods["iforest"]) == 18
     assert data_filtered.shape == (1200, 2)
 
@@ -89,7 +89,7 @@ def test_filter_periods_all_smoothing(dataset):
     assert data.shape == (1080, 2)
     assert tuple(data.mean().round(6)) == (0.496644, 0.492348)
 
-    assert sum(predictions["iforest"]["pred"]) == 632
+    assert sum(predictions["iforest"]["pred"]) == 648
     assert len(drop_periods["median"]) == 15
     assert len(drop_periods["iforest"]) == 24
     assert data_filtered.shape == (767, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -63,7 +63,7 @@ def test_filter_periods_all(dataset):
     assert sum(predictions["iforest"]["pred"]) == 1424
     assert len(drop_periods["median"]) == 16
     assert len(drop_periods["iforest"]) == 11
-    assert data_filtered.shape == (1217, 2)
+    assert data_filtered.shape == (1219, 2)
 
 
 def test_filter_periods_iforest_smoothing(dataset):
@@ -75,7 +75,7 @@ def test_filter_periods_iforest_smoothing(dataset):
     assert data.shape == (1435, 2)
     assert tuple(data.mean().round(6)) == (0.47524, 0.504942)
 
-    assert sum(predictions["iforest"]["pred"]) == 969
+    assert sum(predictions["iforest"]["pred"]) == 959
     assert len(drop_periods["iforest"]) == 18
     assert data_filtered.shape == (1200, 2)
 
@@ -89,7 +89,7 @@ def test_filter_periods_all_smoothing(dataset):
     assert data.shape == (1080, 2)
     assert tuple(data.mean().round(6)) == (0.492348, 0.496644)
 
-    assert sum(predictions["iforest"]["pred"]) == 624
+    assert sum(predictions["iforest"]["pred"]) == 632
     assert len(drop_periods["median"]) == 15
     assert len(drop_periods["iforest"]) == 24
     assert data_filtered.shape == (767, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -34,7 +34,7 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1638, 2)
+    assert data_filtered.data.shape == (1663, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -35,4 +35,27 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1590, 2)
+    print(len(data_filtered.data))
+    assert 1580 < len(data_filtered.data) > 1600
+
+
+def test_filter_periods_with_smoothing(dataset):
+    data, _ = dataset.get_data()
+
+    data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
+    )
+    assert data.shape == (2364, 2)
+    print(len(data_filtered.data))
+    assert 2000 < len(data_filtered.data) < 2025
+
+
+def test_filter_periods_wiht_smoothing_all(dataset):
+    data, _ = dataset.get_data()
+
+    data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
+    )
+    assert data.shape == (1837, 2)
+    print(len(data_filtered.data))
+    assert 1315 < len(data_filtered.data) < 1330

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -32,7 +32,7 @@ def test_filter_periods(dataset):
     assert data_filtered.data.shape == (1816, 2)
 
     data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="all", iforest_smooth=False
+        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
     assert data_filtered.data.shape == (1816, 2)
 

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -63,7 +63,7 @@ def test_filter_periods_all(dataset):
     assert sum(predictions["iforest"]["pred"]) == 1424
     assert len(drop_periods["median"]) == 16
     assert len(drop_periods["iforest"]) == 10
-    assert data_filtered.shape == (1219, 2)
+    assert data_filtered.shape == (1218, 2)
 
 
 def test_filter_periods_iforest_smoothing(dataset):
@@ -77,7 +77,7 @@ def test_filter_periods_iforest_smoothing(dataset):
 
     assert sum(predictions["iforest"]["pred"]) == 985
     assert len(drop_periods["iforest"]) == 18
-    assert data_filtered.shape == (1200, 2)
+    assert data_filtered.shape == (1210, 2)
 
 
 def test_filter_periods_all_smoothing(dataset):
@@ -92,4 +92,4 @@ def test_filter_periods_all_smoothing(dataset):
     assert sum(predictions["iforest"]["pred"]) == 648
     assert len(drop_periods["median"]) == 15
     assert len(drop_periods["iforest"]) == 24
-    assert data_filtered.shape == (767, 2)
+    assert data_filtered.shape == (770, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -76,7 +76,7 @@ def test_filter_periods_iforest_smoothing(dataset):
     assert data["Tag 1"].mean() == 0.5019862352609169
 
     assert sum(predictions["iforest"]["pred"]) == 8552
-    assert len(drop_periods["iforest"]) == 38
+    assert len(drop_periods["iforest"]) == 41
     assert data_filtered.shape == (9110, 1)
 
 

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -35,7 +35,6 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    print(len(data_filtered.data))
     assert 1580 < len(data_filtered.data) < 1600
 
 
@@ -46,7 +45,6 @@ def test_filter_periods_with_smoothing(dataset):
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
     assert data.shape == (2364, 2)
-    print(len(data_filtered.data))
     assert 2000 < len(data_filtered.data) < 2025
 
 
@@ -57,5 +55,4 @@ def test_filter_periods_wiht_smoothing_all(dataset):
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data.shape == (1837, 2)
-    print(len(data_filtered.data))
     assert 1315 < len(data_filtered.data) < 1330

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -50,6 +50,6 @@ def test_filter_periods_wiht_smoothing_all(dataset):
     data, _ = dataset.get_data()
 
     data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
+        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data_filtered.data.shape == (1446, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -35,7 +35,7 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1589, 2)
+    assert data_filtered.data.shape == (1588, 2)
 
 
 def test_filter_periods_with_smoothing(dataset):
@@ -45,7 +45,7 @@ def test_filter_periods_with_smoothing(dataset):
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
     assert data.shape == (2364, 2)
-    assert data_filtered.data.shape == (2008, 2)
+    assert data_filtered.data.shape == (2011, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):
@@ -55,4 +55,4 @@ def test_filter_periods_wiht_smoothing_all(dataset):
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data.shape == (1837, 2)
-    assert data_filtered.data.shape == (1317, 2)
+    assert data_filtered.data.shape == (1305, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -29,7 +29,7 @@ def test_filter_periods_median(dataset):
     ).filter_data(data)
 
     assert data.shape == (2364, 2)
-    assert tuple(data.mean().round(6)) == (0.516027, 0.496113)
+    assert tuple(data.mean().round(6)) == (0.496113, 0.516027)
 
     assert sum(predictions["median"]["pred"]) == -402
     assert len(drop_periods["median"]) == 35
@@ -43,7 +43,7 @@ def test_filter_periods_iforest(dataset):
     ).filter_data(data)
 
     assert data.shape == (1837, 2)
-    assert tuple(data.mean().round(6)) == (0.550395, 0.519195)
+    assert tuple(data.mean().round(6)) == (0.519195, 0.550395)
 
     assert sum(predictions["iforest"]["pred"]) == 1725
     assert len(drop_periods["iforest"]) == 19
@@ -57,7 +57,7 @@ def test_filter_periods_all(dataset):
     ).filter_data(data)
 
     assert data.shape == (1516, 2)
-    assert tuple(data.mean().round(6)) == (0.498725, 0.486544)
+    assert tuple(data.mean().round(6)) == (0.486544, 0.498725)
 
     assert sum(predictions["median"]["pred"]) == -279
     assert sum(predictions["iforest"]["pred"]) == 1424
@@ -73,7 +73,7 @@ def test_filter_periods_iforest_smoothing(dataset):
     ).filter_data(data)
 
     assert data.shape == (1435, 2)
-    assert tuple(data.mean().round(6)) == (0.47524, 0.504942)
+    assert tuple(data.mean().round(6)) == (0.504942, 0.47524)
 
     assert sum(predictions["iforest"]["pred"]) == 959
     assert len(drop_periods["iforest"]) == 18
@@ -87,7 +87,7 @@ def test_filter_periods_all_smoothing(dataset):
     ).filter_data(data)
 
     assert data.shape == (1080, 2)
-    assert tuple(data.mean().round(6)) == (0.492348, 0.496644)
+    assert tuple(data.mean().round(6)) == (0.496644, 0.492348)
 
     assert sum(predictions["iforest"]["pred"]) == 632
     assert len(drop_periods["median"]) == 15

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -17,7 +17,7 @@ def dataset():
 
 def test_filter_periods(dataset):
     data, _ = dataset.get_data()
-    assert data.shape == (1361, 2)
+    assert data.shape == (1873, 2)
 
     with pytest.raises(TypeError):
         filter_periods(data=data, granularity="10T", filter_method="abc", n_iqr=1)
@@ -44,7 +44,7 @@ def test_filter_periods_with_smoothing(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data.shape == (1361, 2)
+    assert data.shape == (2364, 2)
     assert data_filtered.data.shape == (2008, 2)
 
 
@@ -54,5 +54,5 @@ def test_filter_periods_wiht_smoothing_all(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
-    assert data.shape == (1361, 2)
+    assert data.shape == (1837, 2)
     assert data_filtered.data.shape == (1317, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -34,9 +34,9 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert True #data_filtered.data.shape == (1649, 2)
+    assert True  # data_filtered.data.shape == (1649, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert True #data_filtered.data.shape == (1589, 2)
+    assert True  # data_filtered.data.shape == (1589, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -77,7 +77,7 @@ def test_filter_periods_iforest_smoothing(dataset):
 
     assert sum(predictions["iforest"]["pred"]) == 8552
     assert len(drop_periods["iforest"]) == 41
-    assert data_filtered.shape == (9110, 1)
+    assert data_filtered.shape == (9113, 1)
 
 
 def test_filter_periods_all_smoothing(dataset):

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -36,23 +36,3 @@ def test_filter_periods(dataset):
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
     assert data_filtered.data.shape == (1589, 2)
-
-
-def test_filter_periods_with_smoothing(dataset):
-    data, _ = dataset.get_data()
-
-    data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
-    )
-    assert data.shape == (2364, 2)
-    assert data_filtered.data.shape == (2020, 2)
-
-
-def test_filter_periods_wiht_smoothing_all(dataset):
-    data, _ = dataset.get_data()
-
-    data_filtered = filter_periods(
-        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
-    )
-    assert data.shape == (1837, 2)
-    assert data_filtered.data.shape == (1323, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -5,6 +5,7 @@ from gordo.machine.dataset.datasets import RandomDataset
 from gordo.machine.dataset.filter_periods import filter_periods
 from gordo.machine.dataset.sensor_tag import SensorTag
 
+
 @pytest.fixture
 def dataset():
     return RandomDataset(
@@ -17,18 +18,25 @@ def dataset():
 def test_filter_periods(dataset):
     data, _ = dataset.get_data()
 
-
     with pytest.raises(TypeError):
         filter_periods(data=data, granularity="10T", filter_method="abc", n_iqr=1)
 
-    data_filtered = filter_periods(data=data, granularity="10T", filter_method="median", n_iqr=1)
+    data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="median", n_iqr=1
+    )
     assert data_filtered.data.shape == (1460, 2)
 
-    data_filtered = filter_periods(data=data, granularity="10T", filter_method="iforest", iforest_smooth=False)
+    data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="iforest", iforest_smooth=False
+    )
     assert data_filtered.data.shape == (1775, 2)
 
-    data_filtered = filter_periods(data=data, granularity="10T", filter_method="iforest", iforest_smooth=True)
+    data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
+    )
     assert data_filtered.data.shape == (1584, 2)
 
-    data_filtered = filter_periods(data=data, granularity="10T", filter_method="all", n_iqr=1)
+    data_filtered = filter_periods(
+        data=data, granularity="10T", filter_method="all", n_iqr=1
+    )
     assert data_filtered.data.shape == (1436, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -35,4 +35,4 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1589, 2)
+    assert data_filtered.data.shape == (1590, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -34,7 +34,7 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1663, 2)
+    assert data_filtered.data.shape == (1649, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -34,7 +34,7 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1816, 2)
+    assert data_filtered.data.shape == (1589, 2)
 
 
 def test_filter_periods_with_smoothing(dataset):
@@ -43,7 +43,7 @@ def test_filter_periods_with_smoothing(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1649, 2)
+    assert data_filtered.data.shape == (2008, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):
@@ -52,4 +52,4 @@ def test_filter_periods_wiht_smoothing_all(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1446, 2)
+    assert data_filtered.data.shape == (1317, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -45,7 +45,7 @@ def test_filter_periods_with_smoothing(dataset):
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
     assert data.shape == (2364, 2)
-    assert data_filtered.data.shape == (2016, 2)
+    assert data_filtered.data.shape == (2020, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):
@@ -55,4 +55,4 @@ def test_filter_periods_wiht_smoothing_all(dataset):
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data.shape == (1837, 2)
-    assert data_filtered.data.shape == (1317, 2)
+    assert data_filtered.data.shape == (1323, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -43,7 +43,7 @@ def test_filter_periods_with_smoothing(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (2008, 2)
+    assert data_filtered.data.shape == (2016, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -39,4 +39,4 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1588, 2)
+    assert data_filtered.data.shape == (1589, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -34,9 +34,9 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1663, 2)
+    assert True #data_filtered.data.shape == (1649, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1589, 2)
+    assert True #data_filtered.data.shape == (1589, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -11,13 +11,13 @@ def dataset():
     return RandomDataset(
         train_start_date="2017-01-01 00:00:00Z",
         train_end_date="2018-01-01 00:00:00Z",
-        tag_list=[SensorTag("Tag 1", None), SensorTag("Tag 2", None)],
+        tag_list=[SensorTag("Tag 1", None)],
     )
 
 
 def test_filter_periods_typerror(dataset):
     data, _ = dataset.get_data()
-    assert data.shape == (1873, 2)
+    assert data.shape == (9760, 1)
     with pytest.raises(TypeError):
         FilterPeriods(granularity="10T", filter_method="abc", n_iqr=1)
 
@@ -28,12 +28,12 @@ def test_filter_periods_median(dataset):
         granularity="10T", filter_method="median", n_iqr=1
     ).filter_data(data)
 
-    assert data.shape == (2364, 2)
-    assert tuple(data.mean().round(6)) == (0.496113, 0.516027)
+    assert data.shape == (9063, 1)
+    assert data["Tag 1"].mean() == 0.5113691034704841
 
-    assert sum(predictions["median"]["pred"]) == -402
-    assert len(drop_periods["median"]) == 35
-    assert data_filtered.shape == (1962, 2)
+    assert sum(predictions["median"]["pred"]) == -493
+    assert len(drop_periods["median"]) == 44
+    assert data_filtered.shape == (8570, 1)
 
 
 def test_filter_periods_iforest(dataset):
@@ -42,12 +42,12 @@ def test_filter_periods_iforest(dataset):
         granularity="10T", filter_method="iforest", iforest_smooth=False
     ).filter_data(data)
 
-    assert data.shape == (1837, 2)
-    assert tuple(data.mean().round(6)) == (0.519195, 0.550395)
+    assert data.shape == (12838, 1)
+    assert data["Tag 1"].mean() == 0.5144733352386245
 
-    assert sum(predictions["iforest"]["pred"]) == 1725
-    assert len(drop_periods["iforest"]) == 16
-    assert data_filtered.shape == (1781, 2)
+    assert sum(predictions["iforest"]["pred"]) == 12066
+    assert len(drop_periods["iforest"]) == 51
+    assert data_filtered.shape == (12452, 1)
 
 
 def test_filter_periods_all(dataset):
@@ -56,14 +56,14 @@ def test_filter_periods_all(dataset):
         granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     ).filter_data(data)
 
-    assert data.shape == (1516, 2)
-    assert tuple(data.mean().round(6)) == (0.486544, 0.498725)
+    assert data.shape == (8024, 1)
+    assert data["Tag 1"].mean() == 0.500105748646813
 
-    assert sum(predictions["median"]["pred"]) == -279
-    assert sum(predictions["iforest"]["pred"]) == 1424
-    assert len(drop_periods["median"]) == 16
-    assert len(drop_periods["iforest"]) == 10
-    assert data_filtered.shape == (1218, 2)
+    assert sum(predictions["median"]["pred"]) == -449
+    assert sum(predictions["iforest"]["pred"]) == 7542
+    assert len(drop_periods["median"]) == 39
+    assert len(drop_periods["iforest"]) == 30
+    assert data_filtered.shape == (7356, 1)
 
 
 def test_filter_periods_iforest_smoothing(dataset):
@@ -72,12 +72,12 @@ def test_filter_periods_iforest_smoothing(dataset):
         granularity="10T", filter_method="iforest", iforest_smooth=True
     ).filter_data(data)
 
-    assert data.shape == (1435, 2)
-    assert tuple(data.mean().round(6)) == (0.504942, 0.47524)
+    assert data.shape == (9674, 1)
+    assert data["Tag 1"].mean() == 0.5019862352609169
 
-    assert sum(predictions["iforest"]["pred"]) == 985
-    assert len(drop_periods["iforest"]) == 18
-    assert data_filtered.shape == (1210, 2)
+    assert sum(predictions["iforest"]["pred"]) == 8546
+    assert len(drop_periods["iforest"]) == 38
+    assert data_filtered.shape == (9110, 1)
 
 
 def test_filter_periods_all_smoothing(dataset):
@@ -86,10 +86,10 @@ def test_filter_periods_all_smoothing(dataset):
         granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     ).filter_data(data)
 
-    assert data.shape == (1080, 2)
-    assert tuple(data.mean().round(6)) == (0.496644, 0.492348)
+    assert data.shape == (8595, 1)
+    assert data["Tag 1"].mean() == 0.512856120233814
 
-    assert sum(predictions["iforest"]["pred"]) == 648
-    assert len(drop_periods["median"]) == 15
-    assert len(drop_periods["iforest"]) == 24
-    assert data_filtered.shape == (770, 2)
+    assert sum(predictions["iforest"]["pred"]) == 7471
+    assert len(drop_periods["median"]) == 39
+    assert len(drop_periods["iforest"]) == 29
+    assert data_filtered.shape == (7522, 1)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from gordo.machine.dataset.datasets import RandomDataset
+from gordo.machine.dataset.filter_periods import filter_periods
+from gordo.machine.dataset.sensor_tag import SensorTag
+
+@pytest.fixture
+def dataset():
+    return RandomDataset(
+        train_start_date="2017-01-01 00:00:00Z",
+        train_end_date="2018-01-01 00:00:00Z",
+        tag_list=[SensorTag("Tag 1", None), SensorTag("Tag 2", None)],
+    )
+
+
+def test_filter_periods(dataset):
+    data, _ = dataset.get_data()
+
+
+    with pytest.raises(TypeError):
+        filter_periods(data=data, granularity="10T", filter_method="abc", n_iqr=1)
+
+    data_filtered = filter_periods(data=data, granularity="10T", filter_method="median", n_iqr=1)
+    assert data_filtered.data.shape == (1460, 2)
+
+    data_filtered = filter_periods(data=data, granularity="10T", filter_method="iforest", iforest_smooth=False)
+    assert data_filtered.data.shape == (1775, 2)
+
+    data_filtered = filter_periods(data=data, granularity="10T", filter_method="iforest", iforest_smooth=True)
+    assert data_filtered.data.shape == (1584, 2)
+
+    data_filtered = filter_periods(data=data, granularity="10T", filter_method="all", n_iqr=1)
+    assert data_filtered.data.shape == (1436, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -35,7 +35,7 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1588, 2)
+    assert data_filtered.data.shape == (1589, 2)
 
 
 def test_filter_periods_with_smoothing(dataset):
@@ -45,7 +45,7 @@ def test_filter_periods_with_smoothing(dataset):
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
     assert data.shape == (2364, 2)
-    assert data_filtered.data.shape == (2011, 2)
+    assert data_filtered.data.shape == (2008, 2)
 
 
 def test_filter_periods_wiht_smoothing_all(dataset):
@@ -55,4 +55,4 @@ def test_filter_periods_wiht_smoothing_all(dataset):
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data.shape == (1837, 2)
-    assert data_filtered.data.shape == (1305, 2)
+    assert data_filtered.data.shape == (1317, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -52,4 +52,4 @@ def test_filter_periods_wiht_smoothing_all(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1589, 2)
+    assert data_filtered.data.shape == (1446, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -42,7 +42,7 @@ def test_filter_periods_with_smoothing(dataset):
     data, _ = dataset.get_data()
 
     data_filtered = filter_periods(
-        data=data.round(2), granularity="10T", filter_method="iforest", iforest_smooth=True
+        data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
     assert data.shape == (2364, 2)
     assert data_filtered.data.shape == (2016, 2)
@@ -52,7 +52,7 @@ def test_filter_periods_wiht_smoothing_all(dataset):
     data, _ = dataset.get_data()
 
     data_filtered = filter_periods(
-        data=data.round(2), granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
+        data=data, granularity="10T", filter_method="all", n_iqr=1, iforest_smooth=True
     )
     assert data.shape == (1837, 2)
     assert data_filtered.data.shape == (1317, 2)

--- a/tests/gordo/machine/dataset/test_filter_periods.py
+++ b/tests/gordo/machine/dataset/test_filter_periods.py
@@ -24,19 +24,19 @@ def test_filter_periods(dataset):
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="median", n_iqr=1
     )
-    assert data_filtered.data.shape == (1460, 2)
+    assert data_filtered.data.shape == (1634, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=False
     )
-    assert data_filtered.data.shape == (1775, 2)
+    assert data_filtered.data.shape == (1816, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="iforest", iforest_smooth=True
     )
-    assert data_filtered.data.shape == (1584, 2)
+    assert data_filtered.data.shape == (1638, 2)
 
     data_filtered = filter_periods(
         data=data, granularity="10T", filter_method="all", n_iqr=1
     )
-    assert data_filtered.data.shape == (1436, 2)
+    assert data_filtered.data.shape == (1588, 2)

--- a/tests/gordo/workflow/test_config_elements.py
+++ b/tests/gordo/workflow/test_config_elements.py
@@ -136,6 +136,8 @@ def test_machine_from_config(default_globals: dict):
                 "type": "DataLakeProvider",
             },
             "default_asset": None,
+
+
             "high_threshold": 50000,
             "interpolation_limit": "8H",
             "interpolation_method": "linear_interpolation",

--- a/tests/gordo/workflow/test_config_elements.py
+++ b/tests/gordo/workflow/test_config_elements.py
@@ -136,6 +136,7 @@ def test_machine_from_config(default_globals: dict):
                 "type": "DataLakeProvider",
             },
             "default_asset": None,
+            "filter_periods": {},
             "high_threshold": 50000,
             "interpolation_limit": "8H",
             "interpolation_method": "linear_interpolation",

--- a/tests/gordo/workflow/test_config_elements.py
+++ b/tests/gordo/workflow/test_config_elements.py
@@ -97,6 +97,10 @@ def test_machine_from_config(default_globals: dict):
           target_tag_list: [GRA-TE -123-456]
           train_start_date: 2018-01-01T09:00:30Z
           train_end_date: 2018-01-02T09:00:30Z
+          filter_periods:
+            filter_method: "median"
+            n_iqr: 1
+            window: 72
         model:
           sklearn.pipeline.Pipeline:
             steps:
@@ -136,7 +140,7 @@ def test_machine_from_config(default_globals: dict):
                 "type": "DataLakeProvider",
             },
             "default_asset": None,
-            "filter_periods": {},
+            "filter_periods": {"filter_method": "median", "window": 72, "n_iqr": 1},
             "high_threshold": 50000,
             "interpolation_limit": "8H",
             "interpolation_method": "linear_interpolation",

--- a/tests/gordo/workflow/test_config_elements.py
+++ b/tests/gordo/workflow/test_config_elements.py
@@ -136,8 +136,6 @@ def test_machine_from_config(default_globals: dict):
                 "type": "DataLakeProvider",
             },
             "default_asset": None,
-
-
             "high_threshold": 50000,
             "interpolation_limit": "8H",
             "interpolation_method": "linear_interpolation",


### PR DESCRIPTION
Median and isolation forest filtering directly available in Gordo.

Resolves #1031

There seem to be some randomness or rounding issues coming from the isolation forest algorithm and/or the exponential weighting function.
The isolation forest has its `random_state` parameter sat.
At every execution, the shape of the resulting filtered data frame changes, making it impossible to set a fixed assert.

In addition to this, evaluating it I get different results for using
- local `pytest` direct on file (e.g. `pytest tests/gordo/machine/dataset/test_filter_periods.py`)
- local `pytest`on testset (e.g. `python setup.py testmachine`)
- direct console execution
- CircleCI jobs via commit to GitHub

Base functions used:
https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.ewm.html


**Reviewers:**
- Please check if the placement of the code seems reasonable.
- Please do a quick overlook over the logic, and comment if the functions could be written more understandable or efficient.
- Please rapport if the attached test scheme is sufficient or not.
- Any insight on the issues with the always-changing filtered data shape