### PR TITLE
Roll back anomaly confidence calculation

### DIFF
--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -417,23 +417,23 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
 
         # If we have `thresholds_` values, then we can calculate anomaly confidence
         confidence, index = None, None
-        if (
-            hasattr(self, "smooth_feature_thresholds_")
-            and self.smooth_feature_thresholds_ is not None
-        ):
-            confidence = (
-                data["smooth-tag-anomaly-scaled"].to_numpy()
-                / self.smooth_feature_thresholds_.to_numpy()
-            )
-            index = data["smooth-tag-anomaly-scaled"].index
-        elif hasattr(self, "feature_thresholds_") and self.window is not None:
-            confidence = (
-                data["smooth-tag-anomaly-scaled"].to_numpy()
-                / self.feature_thresholds_.to_numpy()
-            )
-            index = data["smooth-tag-anomaly-scaled"].index
+        # if (
+        #     hasattr(self, "smooth_feature_thresholds_")
+        #     and self.smooth_feature_thresholds_ is not None
+        # ):
+        #     confidence = (
+        #         data["smooth-tag-anomaly-scaled"].to_numpy()
+        #         / self.smooth_feature_thresholds_.to_numpy()
+        #     )
+        #     index = data["smooth-tag-anomaly-scaled"].index
+        # elif hasattr(self, "feature_thresholds_") and self.window is not None:
+        #     confidence = (
+        #         data["smooth-tag-anomaly-scaled"].to_numpy()
+        #         / self.feature_thresholds_.to_numpy()
+        #     )
+        #     index = data["smooth-tag-anomaly-scaled"].index
 
-        elif hasattr(self, "feature_thresholds_"):
+        if hasattr(self, "feature_thresholds_"):
             confidence = tag_anomaly_scaled.values / self.feature_thresholds_.to_numpy()
             index = tag_anomaly_scaled.index
 
@@ -450,20 +450,20 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             data = data.join(anomaly_confidence_scores)
 
         total_anomaly_confidence = None
-        if (
-            hasattr(self, "smooth_aggregate_threshold_")
-            and self.smooth_aggregate_threshold_ is not None
-        ):
-            total_anomaly_confidence = (
-                data["smooth-total-anomaly-scaled"] / self.smooth_aggregate_threshold_
-            )
+        # if (
+        #     hasattr(self, "smooth_aggregate_threshold_")
+        #     and self.smooth_aggregate_threshold_ is not None
+        # ):
+        #     total_anomaly_confidence = (
+        #         data["smooth-total-anomaly-scaled"] / self.smooth_aggregate_threshold_
+        #     )
 
-        elif hasattr(self, "aggregate_threshold_") and self.window is not None:
-            total_anomaly_confidence = (
-                data["smooth-total-anomaly-scaled"] / self.aggregate_threshold_
-            )
+        # elif hasattr(self, "aggregate_threshold_") and self.window is not None:
+        #     total_anomaly_confidence = (
+        #         data["smooth-total-anomaly-scaled"] / self.aggregate_threshold_
+        #     )
 
-        elif hasattr(self, "aggregate_threshold_"):
+        if hasattr(self, "aggregate_threshold_"):
             total_anomaly_confidence = (
                 data["total-anomaly-scaled"] / self.aggregate_threshold_
             )

--- a/gordo/machine/model/anomaly/diff.py
+++ b/gordo/machine/model/anomaly/diff.py
@@ -417,21 +417,6 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
 
         # If we have `thresholds_` values, then we can calculate anomaly confidence
         confidence, index = None, None
-        # if (
-        #     hasattr(self, "smooth_feature_thresholds_")
-        #     and self.smooth_feature_thresholds_ is not None
-        # ):
-        #     confidence = (
-        #         data["smooth-tag-anomaly-scaled"].to_numpy()
-        #         / self.smooth_feature_thresholds_.to_numpy()
-        #     )
-        #     index = data["smooth-tag-anomaly-scaled"].index
-        # elif hasattr(self, "feature_thresholds_") and self.window is not None:
-        #     confidence = (
-        #         data["smooth-tag-anomaly-scaled"].to_numpy()
-        #         / self.feature_thresholds_.to_numpy()
-        #     )
-        #     index = data["smooth-tag-anomaly-scaled"].index
 
         if hasattr(self, "feature_thresholds_"):
             confidence = tag_anomaly_scaled.values / self.feature_thresholds_.to_numpy()
@@ -450,18 +435,6 @@ class DiffBasedAnomalyDetector(AnomalyDetectorBase):
             data = data.join(anomaly_confidence_scores)
 
         total_anomaly_confidence = None
-        # if (
-        #     hasattr(self, "smooth_aggregate_threshold_")
-        #     and self.smooth_aggregate_threshold_ is not None
-        # ):
-        #     total_anomaly_confidence = (
-        #         data["smooth-total-anomaly-scaled"] / self.smooth_aggregate_threshold_
-        #     )
-
-        # elif hasattr(self, "aggregate_threshold_") and self.window is not None:
-        #     total_anomaly_confidence = (
-        #         data["smooth-total-anomaly-scaled"] / self.aggregate_threshold_
-        #     )
 
         if hasattr(self, "aggregate_threshold_"):
             total_anomaly_confidence = (

--- a/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
+++ b/tests/gordo/machine/model/anomaly/test_anomaly_detectors.py
@@ -25,7 +25,7 @@ from gordo.machine.model.anomaly.diff import (
 
 @pytest.mark.parametrize("scaler", (MinMaxScaler(), RobustScaler()))
 @pytest.mark.parametrize(
-    "index", (range(10), pd.date_range("2019-01-01", "2019-01-30", periods=10))
+    "index", (range(300), pd.date_range("2019-01-01", "2019-01-30", periods=300))
 )
 @pytest.mark.parametrize("with_thresholds", (True, False))
 @pytest.mark.parametrize("shuffle", (True, False))
@@ -36,8 +36,8 @@ def test_diff_detector(scaler, index, with_thresholds: bool, shuffle: bool):
 
     # Some dataset.
     X, y = (
-        pd.DataFrame(np.random.random((10, 3))),
-        pd.DataFrame(np.random.random((10, 3))),
+        pd.DataFrame(np.random.random((300, 3))),
+        pd.DataFrame(np.random.random((300, 3))),
     )
 
     base_estimator = MultiOutputRegressor(estimator=LinearRegression())
@@ -110,13 +110,16 @@ def test_diff_detector(scaler, index, with_thresholds: bool, shuffle: bool):
     if with_thresholds:
         assert "anomaly-confidence" in anomaly_df.columns
         assert "total-anomaly-confidence" in anomaly_df.columns
+        assert anomaly_df["anomaly-confidence"].notnull().to_numpy().any()
+        assert anomaly_df["total-anomaly-confidence"].notnull().to_numpy().all()
+
     else:
         assert "anomaly-confidence" not in anomaly_df.columns
         assert "total-anomaly-confidence" not in anomaly_df.columns
 
 
 @pytest.mark.parametrize("scaler", (MinMaxScaler(), RobustScaler()))
-@pytest.mark.parametrize("len_x_y", (100, 144, 1440))
+@pytest.mark.parametrize("len_x_y", (100, 144, 300))
 @pytest.mark.parametrize("time_index", (True, False))
 @pytest.mark.parametrize("with_thresholds", (True, False))
 @pytest.mark.parametrize("shuffle", (True, False))
@@ -358,6 +361,8 @@ def test_diff_detector_with_window(
     if with_thresholds:
         assert "anomaly-confidence" in anomaly_df.columns
         assert "total-anomaly-confidence" in anomaly_df.columns
+        assert anomaly_df["anomaly-confidence"].notnull().to_numpy().all()
+        assert anomaly_df["total-anomaly-confidence"].notnull().to_numpy().all()
     else:
         assert "anomaly-confidence" not in anomaly_df.columns
         assert "total-anomaly-confidence" not in anomaly_df.columns
@@ -365,7 +370,7 @@ def test_diff_detector_with_window(
 
 @pytest.mark.parametrize("scaler", (MinMaxScaler(), RobustScaler()))
 @pytest.mark.parametrize(
-    "index", (range(10), pd.date_range("2019-01-01", "2019-01-30", periods=10))
+    "index", (range(300), pd.date_range("2019-01-01", "2019-01-30", periods=300))
 )
 @pytest.mark.parametrize("with_thresholds", (True, False))
 @pytest.mark.parametrize("shuffle", (True, False))
@@ -387,8 +392,8 @@ def test_diff_kfcv_detector(
 
     # Some dataset.
     X, y = (
-        pd.DataFrame(np.random.random((10, 3))),
-        pd.DataFrame(np.random.random((10, 3))),
+        pd.DataFrame(np.random.random((300, 3))),
+        pd.DataFrame(np.random.random((300, 3))),
     )
 
     base_estimator = MultiOutputRegressor(estimator=LinearRegression())
@@ -469,6 +474,8 @@ def test_diff_kfcv_detector(
     if with_thresholds:
         assert "anomaly-confidence" in anomaly_df.columns
         assert "total-anomaly-confidence" in anomaly_df.columns
+        assert anomaly_df["anomaly-confidence"].notnull().to_numpy().all()
+        assert anomaly_df["total-anomaly-confidence"].notnull().to_numpy().all()
     else:
         assert "anomaly-confidence" not in anomaly_df.columns
         assert "total-anomaly-confidence" not in anomaly_df.columns


### PR DESCRIPTION
Total anomaly confidence and tag anomaly confidence are now calculated using the unsmoothed total anomaly score and unsmoothed tag anomaly scores, divided by the respective thresholds.
This should remove the issue where they would be NaN when delivering predictions on small batches of data.