### PR TITLE
Dropping 'smooth_' columns from anomaly detection response in gordo-server

### DIFF
--- a/gordo/machine/dataset/base.py
+++ b/gordo/machine/dataset/base.py
@@ -22,9 +22,11 @@ class ConfigurationError(Exception):
 
 
 class GordoBaseDataset:
-
-    _params: Dict[Any, Any] = dict()  # provided by @capture_args on child's __init__
-    _metadata: Dict[Any, Any] = dict()
+    def __init__(self):
+        self._metadata: Dict[Any, Any] = dict()
+        # provided by @capture_args on child's __init__
+        if not hasattr(self, "_params"):
+            self._params = dict()
 
     @abc.abstractmethod
     def get_data(

--- a/gordo/machine/dataset/datasets.py
+++ b/gordo/machine/dataset/datasets.py
@@ -198,6 +198,8 @@ class TimeSeriesDataset(GordoBaseDataset):
                 f"information"
             )
 
+        super().__init__()
+
     def to_dict(self):
         params = super().to_dict()
         to_str = lambda dt: str(dt) if not hasattr(dt, "isoformat") else dt.isoformat()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,9 @@ def gordo_project():
 def gordo_name():
     return "machine-1"
 
+@pytest.fixture(scope="session")
+def second_gordo_name():
+    return "machine-2"
 
 @pytest.fixture(scope="session")
 def gordo_single_target(gordo_name):
@@ -130,6 +133,11 @@ def base_route(api_version, gordo_project, gordo_name):
 
 
 @pytest.fixture(scope="session")
+def second_base_route(api_version, gordo_project, second_gordo_name):
+    return f"/gordo/{api_version}/{gordo_project}/{second_gordo_name}"
+
+
+@pytest.fixture(scope="session")
 def model_collection_directory(gordo_revision: str):
     with tempfile.TemporaryDirectory() as tmp_dir:
         collection_dir = os.path.join(tmp_dir, gordo_revision)
@@ -138,7 +146,7 @@ def model_collection_directory(gordo_revision: str):
 
 
 @pytest.fixture(scope="session")
-def config_str(gordo_name: str, sensors: List[SensorTag]):
+def config_str(gordo_name: str, second_gordo_name: str, sensors: List[SensorTag]):
     """
     Fixture: Default config for testing
     """
@@ -172,12 +180,41 @@ def config_str(gordo_name: str, sensors: List[SensorTag]):
                         - gordo.machine.model.models.KerasAutoEncoder:
                             kind: feedforward_hourglass
                 name: {gordo_name}
+              - dataset:
+                  tags:
+                    - {sensors[0].name}
+                    - {sensors[1].name}
+                    - {sensors[2].name}
+                    - {sensors[3].name}
+                  target_tag_list:
+                    - {sensors[0].name}
+                    - {sensors[1].name}
+                    - {sensors[2].name}
+                    - {sensors[3].name}
+                  train_start_date: '2019-01-01T00:00:00+00:00'
+                  train_end_date: '2019-10-01T00:00:00+00:00'
+                  asset: asgb
+                  data_provider:
+                    type: RandomDataProvider
+                metadata:
+                  information: Some sweet information about the model
+                model:
+                  gordo.machine.model.anomaly.diff.DiffBasedAnomalyDetector:
+                    window: 144
+                    require_thresholds: false
+                    base_estimator:
+                      sklearn.pipeline.Pipeline:
+                        steps:
+                        - sklearn.preprocessing.MinMaxScaler
+                        - gordo.machine.model.models.KerasAutoEncoder:
+                            kind: feedforward_hourglass
+                name: {second_gordo_name}
              """
 
 
 @pytest.fixture(scope="session")
-def trained_model_directory(
-    model_collection_directory: str, config_str: str, gordo_name: str
+def trained_model_directories(
+    model_collection_directory: str, config_str: str
 ):
     """
     Fixture: Train a basic AutoEncoder and save it to a given directory
@@ -185,17 +222,25 @@ def trained_model_directory(
     """
 
     # Model specific to the model being trained here
-    model_dir = os.path.join(model_collection_directory, gordo_name)
-    os.makedirs(model_dir, exist_ok=True)
-
     builder = local_build(config_str=config_str)
-    model, metadata = next(builder)  # type: ignore
-    serializer.dump(model, model_dir, metadata=metadata.to_dict())
-    yield model_dir
+    model_directories = {}
+    for model, metadata in builder:
+        metadata_dict = metadata.to_dict()
+        model_name = metadata_dict.get('name')
+        model_dir = os.path.join(model_collection_directory, model_name)
+        os.makedirs(model_dir, exist_ok=True)
+        serializer.dump(model, model_dir, metadata=metadata.to_dict())
+        model_directories[model_name] = model_dir
+    yield model_directories
+
+
+@pytest.fixture(scope="session")
+def trained_model_directory(trained_model_directories, gordo_name):
+    return trained_model_directories[gordo_name]
 
 
 @pytest.fixture
-def metadata(trained_model_directory):
+def metadata(trained_model_directories, trained_model_directory):
     return serializer.load_metadata(trained_model_directory)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,9 +63,11 @@ def gordo_project():
 def gordo_name():
     return "machine-1"
 
+
 @pytest.fixture(scope="session")
 def second_gordo_name():
     return "machine-2"
+
 
 @pytest.fixture(scope="session")
 def gordo_single_target(gordo_name):
@@ -213,9 +215,7 @@ def config_str(gordo_name: str, second_gordo_name: str, sensors: List[SensorTag]
 
 
 @pytest.fixture(scope="session")
-def trained_model_directories(
-    model_collection_directory: str, config_str: str
-):
+def trained_model_directories(model_collection_directory: str, config_str: str):
     """
     Fixture: Train a basic AutoEncoder and save it to a given directory
     will also save some metadata with the model
@@ -226,7 +226,7 @@ def trained_model_directories(
     model_directories = {}
     for model, metadata in builder:
         metadata_dict = metadata.to_dict()
-        model_name = metadata_dict.get('name')
+        model_name = metadata_dict.get("name")
         model_dir = os.path.join(model_collection_directory, model_name)
         os.makedirs(model_dir, exist_ok=True)
         serializer.dump(model, model_dir, metadata=metadata.to_dict())

--- a/tests/gordo/client/test_client.py
+++ b/tests/gordo/client/test_client.py
@@ -143,12 +143,12 @@ def test_client_predictions_diff_batch_sizes(
         parallelism=10,
     )
 
-    assert len(prediction_client.get_machine_names()) == 1
+    assert len(prediction_client.get_machine_names()) == 2
 
     # Get predictions
     predictions = prediction_client.predict(start=start, end=end)
     assert isinstance(predictions, list)
-    assert len(predictions) == 1
+    assert len(predictions) == 2
 
     name, predictions, error_messages = predictions[0]  # First dict of predictions
     assert isinstance(name, str)

--- a/tests/gordo/server/test_anomaly_view.py
+++ b/tests/gordo/server/test_anomaly_view.py
@@ -65,3 +65,45 @@ def test_anomaly_prediction_endpoint(
             "model-output",
         )
     )
+
+
+@pytest.mark.parametrize("resp_format", ("json", "parquet", None))
+def test_second_anomaly_prediction_endpoint(
+        second_base_route,
+        sensors_str,
+        influxdb,
+        gordo_ml_server_client,
+        sensors,
+        resp_format,
+):
+    """
+    Anomaly GET and POST responses are the same
+    """
+
+    data_to_post = {
+        "X": np.random.random(size=(10, len(sensors_str))).tolist(),
+        "y": np.random.random(size=(10, len(sensors_str))).tolist(),
+    }
+
+    endpoint = f"{second_base_route}/anomaly/prediction"
+    if resp_format is not None:
+        endpoint += f"?format={resp_format}"
+
+    resp = gordo_ml_server_client.post(endpoint, json=data_to_post)
+
+    assert resp.status_code == 200
+    if resp_format in (None, "json"):
+        assert "data" in resp.json
+        data = server_utils.dataframe_from_dict(resp.json["data"])
+    else:
+        data = server_utils.dataframe_from_parquet_bytes(resp.data)
+
+    assert all(
+        key in data
+        for key in (
+            "smooth-tag-anomaly-scaled",
+            "smooth-tag-anomaly-unscaled",
+            "smooth-total-anomaly-scaled",
+            "smooth-total-anomaly-unscaled"
+        )
+    )


### PR DESCRIPTION
Droping this columns from anomaly detection response: 
```
    "smooth-tag-anomaly-scaled"
    "smooth-total-anomaly-scaled"
    "smooth-tag-anomaly-unscaled"
    "smooth-total-anomaly-unscaled"
```
If you wants to get all of columns just pass `all_columns` as get parameter