### PR TITLE
Fix python identifiers escaping for triggered tags

### DIFF
--- a/gordo/client/client.py
+++ b/gordo/client/client.py
@@ -35,6 +35,8 @@ DEFAULT_ENFORCED_DATASET_KWARGS = {
         "n_samples_threshold": 0,
         "known_filter_periods": [],
         "filter_periods": {},
+        "low_threshold": None,
+        "high_threshold": None,
     }
 }
 

--- a/gordo/machine/dataset/filter_rows.py
+++ b/gordo/machine/dataset/filter_rows.py
@@ -60,11 +60,15 @@ _escaped_chars = (
     ("}", "RBRACE"),
     ("~", "TILDE"),
     ("^", "CIRCUMFLEX"),
-    ("@", "AT")
+    ("@", "AT"),
 )
 
-_escaping_chars_dict = {escape_char: "_%s_" % escape_str for escape_char, escape_str in _escaped_chars}
-_unescaping_strings_dict = {escape_str: escape_char for escape_char, escape_str in _escaped_chars}
+_escaping_chars_dict = {
+    escape_char: "_%s_" % escape_str for escape_char, escape_str in _escaped_chars
+}
+_unescaping_strings_dict = {
+    escape_str: escape_char for escape_char, escape_str in _escaped_chars
+}
 
 _unescaping_re = re.compile(r"_([A-Z]+)_")
 
@@ -86,7 +90,7 @@ def _unescape_python_identifier(name: str) -> str:
         return m.group(0)
 
     if name.find(_escaped_prefix) == 0:
-        name = name[len(_escaped_prefix):]
+        name = name[len(_escaped_prefix) :]
     return _unescaping_re.sub(unescape_repl, name)
 
 

--- a/tests/gordo/client/test_client.py
+++ b/tests/gordo/client/test_client.py
@@ -59,9 +59,10 @@ def test_client_get_dataset(gordo_project, metadata, ml_server):
     machine.dataset.row_filter_buffer_size = 12
     machine.dataset.n_samples_threshold = 10
     dataset = client._get_dataset(machine, start, end)
-    # DEFAULT_ENFORCED_DATASET_KWARGS should be {"row_filter_buffer_size": 0}
     assert dataset.row_filter_buffer_size == 0
     assert dataset.n_samples_threshold == 0
+    assert dataset.low_threshold is None
+    assert dataset.high_threshold is None
 
 
 def test_client_predict_specific_targets(gordo_project, gordo_single_target, ml_server):

--- a/tests/gordo/machine/dataset/test_filter_rows.py
+++ b/tests/gordo/machine/dataset/test_filter_rows.py
@@ -7,7 +7,20 @@ from gordo.machine.dataset.filter_rows import (
     pandas_filter_rows,
     parse_pandas_filter_vars,
     apply_buffer,
+    _escape_python_identifier,
+    _unescape_python_identifier,
 )
+
+test_tag = "1821.N-25LZ777-D01-U.LA_Y"
+expected_escaped_tag = "BACKTICK_QUOTED_STRING_1821_DOT_N_MINUS_25LZ777_MINUS_D01_MINUS_U_DOT_LA_UNDERSCORE_Y"
+
+
+def test_escape_python_identifier():
+    assert _escape_python_identifier(test_tag) == expected_escaped_tag
+
+
+def test_unescape_python_identifier():
+    assert _unescape_python_identifier(expected_escaped_tag) == test_tag
 
 
 def test_parse_filter_vars():
@@ -34,10 +47,6 @@ def test_parse_filter_vars():
     expr = "0 < index < 100"
     result = set(parse_pandas_filter_vars(expr))
     assert result == set()
-
-    with pytest.raises(SyntaxError):
-        expr = "`|tag` > 0"
-        parse_pandas_filter_vars(expr)
 
     expr = "sin(col1) > 10 & 0 < index < 100"
     result = set(parse_pandas_filter_vars(expr, with_special_vars=True))


### PR DESCRIPTION
Also, drop `low_threshold` and `high_threshold` filtering for prediction