### PR TITLE
add model-builder labels

### DIFF
--- a/gordo/cli/workflow_generator.py
+++ b/gordo/cli/workflow_generator.py
@@ -284,6 +284,14 @@ def workflow_generator_cli(gordo_ctx, **ctx):
     context["model_builder_resources_limits_cpu"] = builder_resources["limits"]["cpu"]
 
     context["model_builder_image"] = config.globals["runtime"]["builder"]["image"]
+    # Add builder lables if they exists
+    if (
+        "metadata" in config.globals["runtime"]["builder"]
+        and "labels" in config.globals["runtime"]["builder"]["metadata"]
+    ):
+        context["model_builder_metadata_labels"] = config.globals["runtime"]["builder"][
+            "metadata"
+        ]["labels"]
 
     context["server_resources"] = config.globals["runtime"]["server"]["resources"]
     context["server_image"] = config.globals["runtime"]["server"]["image"]

--- a/gordo/workflow/workflow_generator/resources/argo-workflow.yml.template
+++ b/gordo/workflow/workflow_generator/resources/argo-workflow.yml.template
@@ -663,6 +663,10 @@ spec:
         applications.gordo.equinor.com/project-revision: "{{project_revision}}"{% if project_workflow %}
         applications.gordo.equinor.com/project-workflow: "{{project_workflow}}"{% endif %}
         applications.gordo.equinor.com/model-name: "{{'{{inputs.parameters.machine-name}}'}}"
+        {% if model_builder_metadata_labels is defined %}
+        {% for key, value in model_builder_metadata_labels.items() %}
+        "{{key}}" : {{value}}
+        {% endfor %} {% endif %}
     tolerations:
       - effect: NoSchedule
         key: kubernetes.azure.com/scalesetpriority

--- a/tests/gordo/workflow/test_workflow_generator/data/config-test-runtime-labels.yaml
+++ b/tests/gordo/workflow/test_workflow_generator/data/config-test-runtime-labels.yaml
@@ -1,0 +1,26 @@
+machines:
+
+  - name: ct-23-0002 #Uses defaults of everything
+    dataset:
+      tags:
+        - CT/1
+        - CT/2
+        - CT/3
+      train_start_date: 2016-11-07T09:11:30+01:00
+      train_end_date: 2018-09-15T03:01:00+01:00
+
+globals:
+  runtime: #We add metadata lables to builder step
+    builder: # We want different builder settings
+      metadata:
+        labels:
+          key1: "value1"
+          key2: "2"
+          key3/withslash: "value3"
+          key4/withslash.dot: "value4"
+  model:
+    sklearn.pipeline.Pipeline:
+      steps:
+        - sklearn.preprocessing.MinMaxScaler
+        - gordo.machine.model.models.KerasAutoEncoder:
+            kind: feedforward_hourglass

--- a/tests/gordo/workflow/test_workflow_generator/test_workflow_generator.py
+++ b/tests/gordo/workflow/test_workflow_generator/test_workflow_generator.py
@@ -244,6 +244,27 @@ def test_overrides_builder_datasource(path_to_config_files):
     )["dataset"]["data_provider"]
 
 
+def test_builder_labels(path_to_config_files):
+    expanded_template = _generate_test_workflow_yaml(
+        path_to_config_files, "config-test-runtime-labels.yaml"
+    )
+    templates = expanded_template["spec"]["templates"]
+    model_builder_task = [
+        task for task in templates if task["name"] == "model-builder"
+    ][0]
+    assert "key1" in model_builder_task["metadata"]["labels"]
+    assert "value1" == model_builder_task["metadata"]["labels"]["key1"]
+
+    assert "key2" in model_builder_task["metadata"]["labels"]
+    assert 2 == model_builder_task["metadata"]["labels"]["key2"]
+
+    assert "key3/withslash" in model_builder_task["metadata"]["labels"]
+    assert "value3" == model_builder_task["metadata"]["labels"]["key3/withslash"]
+
+    assert "key4/withslash.dot" in model_builder_task["metadata"]["labels"]
+    assert "value4" == model_builder_task["metadata"]["labels"]["key4/withslash.dot"]
+
+
 def test_runtime_image_override(path_to_config_files):
     expanded_template = _generate_test_workflow_yaml(
         path_to_config_files, "config-test-runtime-images.yaml"


### PR DESCRIPTION
During gordo deployment, sometimes there is a need to pass on specific user-defined labels to model-builder step.