### PR TITLE
added transformer function to calculate the difference of a time series

### DIFF
--- a/gordo/machine/model/transformer_funcs/general.py
+++ b/gordo/machine/model/transformer_funcs/general.py
@@ -25,3 +25,9 @@ def multiply_by(X, factor):
     Multiplies X by a given factor
     """
     return X * factor
+
+def calc_diff(X, period):
+    """
+    Multiplies X by a given factor
+    """
+    return X.diff(period).fillna(method="bfill")

--- a/tests/gordo/machine/model/test_transformers.py
+++ b/tests/gordo/machine/model/test_transformers.py
@@ -41,6 +41,17 @@ class GordoFunctionTransformerFuncsTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             self._validate_transformer(tf)
 
+    def test_calculate_difference_function_transformer(self):
+        from gordo.machine.model.transformer_funcs.general import calc_diff
+
+        # Provide a require argument
+        tf = FunctionTransformer(func=calc_diff, kw_args={"period": 2})
+        self._validate_transformer(tf)
+
+        # Ignore the required argument
+        tf = FunctionTransformer(func=calc_diff)
+        with self.assertRaises(TypeError):
+            self._validate_transformer(tf)
 
 @pytest.mark.parametrize("strategy", ["extremes", "minmax"])
 def test_infimputer_basic(strategy):


### PR DESCRIPTION
Some models for the NES IOC will need to have features using the diff() method
Created a function in transformer_funcs that transforms the time series using .diff() with a given period as input

The function is tested in tests/gordo/machine/model/test_transformers.py in the same way as the other functions (multiply_by)