### PR TITLE
Feat: Upgrade `tensorflow` to `2.16.1` and `keras` to `3.4.0`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,8 +128,6 @@ autodoc_typehints = "signature"
 
 autodoc_typehints_description_target = "documented"
 
-autodoc_mock_imports = ["tensorflow"]
-
 # Document both class doc (default) and documentation in __init__
 autoclass_content = "both"
 

--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -556,7 +556,9 @@ class ModelBuilder:
         # which also had a GordoBase as a parameter/attribute, but will satisfy BaseEstimators
         # which can take a GordoBase model as a parameter, which will then have metadata to get
         for key, val in model.__dict__.items():
-            if key == "regressor":  # keras3 clones the regressor into regressor_ and never updates original regressor
+            # keras3 clones the regressor into regressor_ and never updates original regressor,
+            # but still stores both in attributes
+            if key == "regressor":
                 continue
             if isinstance(val, Pipeline):
                 metadata.update(

--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -557,7 +557,7 @@ class ModelBuilder:
         # which can take a GordoBase model as a parameter, which will then have metadata to get
         for key, val in model.__dict__.items():
             if key.endswith(
-                    "_"
+                "_"
             ):  # keras3 clones the regressor into regressor_ and never updates original regressor
                 if isinstance(val, Pipeline):
                     metadata.update(

--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -555,13 +555,16 @@ class ModelBuilder:
         # Continue to look at object values in case, we decided to have a GordoBase
         # which also had a GordoBase as a parameter/attribute, but will satisfy BaseEstimators
         # which can take a GordoBase model as a parameter, which will then have metadata to get
-        for val in model.__dict__.values():
-            if isinstance(val, Pipeline):
-                metadata.update(
-                    ModelBuilder._extract_metadata_from_model(val.steps[-1][1])
-                )
-            elif isinstance(val, GordoBase) or isinstance(val, BaseEstimator):
-                metadata.update(ModelBuilder._extract_metadata_from_model(val))
+        for key, val in model.__dict__.items():
+            if key.endswith(
+                    "_"
+            ):  # keras3 clones the regressor into regressor_ and never updates original regressor
+                if isinstance(val, Pipeline):
+                    metadata.update(
+                        ModelBuilder._extract_metadata_from_model(val.steps[-1][1])
+                    )
+                elif isinstance(val, GordoBase) or isinstance(val, BaseEstimator):
+                    metadata.update(ModelBuilder._extract_metadata_from_model(val))
         return metadata
 
     @property

--- a/gordo/builder/build_model.py
+++ b/gordo/builder/build_model.py
@@ -556,15 +556,14 @@ class ModelBuilder:
         # which also had a GordoBase as a parameter/attribute, but will satisfy BaseEstimators
         # which can take a GordoBase model as a parameter, which will then have metadata to get
         for key, val in model.__dict__.items():
-            if key.endswith(
-                "_"
-            ):  # keras3 clones the regressor into regressor_ and never updates original regressor
-                if isinstance(val, Pipeline):
-                    metadata.update(
-                        ModelBuilder._extract_metadata_from_model(val.steps[-1][1])
-                    )
-                elif isinstance(val, GordoBase) or isinstance(val, BaseEstimator):
-                    metadata.update(ModelBuilder._extract_metadata_from_model(val))
+            if key == "regressor":  # keras3 clones the regressor into regressor_ and never updates original regressor
+                continue
+            if isinstance(val, Pipeline):
+                metadata.update(
+                    ModelBuilder._extract_metadata_from_model(val.steps[-1][1])
+                )
+            elif isinstance(val, GordoBase) or isinstance(val, BaseEstimator):
+                metadata.update(ModelBuilder._extract_metadata_from_model(val))
         return metadata
 
     @property

--- a/gordo/machine/model/factories/feedforward_autoencoder.py
+++ b/gordo/machine/model/factories/feedforward_autoencoder.py
@@ -49,7 +49,7 @@ def feedforward_model(
         If str then the name of the optimizer must be provided (e.x. "Adam").
         The arguments of the optimizer can be supplied in optimize_kwargs.
         If a Keras optimizer call the instance of the respective
-        class (e.x. Adam(lr=0.01,beta_1=0.9, beta_2=0.999)).  If no arguments are
+        class (e.x. Adam(learning_rate=0.01,beta_1=0.9, beta_2=0.999)).  If no arguments are
         provided Keras default values will be set.
     optimizer_kwargs
         The arguments for the chosen optimizer. If not provided Keras'
@@ -88,8 +88,9 @@ def feedforward_model(
 
     # Instantiate optimizer with kwargs
     if isinstance(optimizer, str):
-        Optim = getattr(keras.optimizers, optimizer)
-        optimizer = Optim(**optimizer_kwargs)
+        optimizer = keras.optimizers.get(
+            {"class_name": optimizer, "config": optimizer_kwargs}
+        )
 
     # Final output layer
     model.add(Dense(n_features_out, activation=out_func))
@@ -132,7 +133,7 @@ def feedforward_symmetric(
         If str then the name of the optimizer must be provided (e.x. "Adam").
         The arguments of the optimizer can be supplied in optimization_kwargs.
         If a Keras optimizer call the instance of the respective
-        class (e.x. ``Adam(lr=0.01,beta_1=0.9, beta_2=0.999)``).  If no arguments are
+        class (e.x. ``Adam(learning_rate=0.01,beta_1=0.9, beta_2=0.999)``).  If no arguments are
         provided Keras default values will be set.
     optimizer_kwargs
         The arguments for the chosen optimizer. If not provided Keras'
@@ -193,7 +194,7 @@ def feedforward_hourglass(
         If str then the name of the optimizer must be provided (e.x. "Adam").
         The arguments of the optimizer can be supplied in optimization_kwargs.
         If a Keras optimizer call the instance of the respective
-        class (e.x. Adam(lr=0.01,beta_1=0.9, beta_2=0.999)).  If no arguments are
+        class (e.x. Adam(learning_rate=0.01,beta_1=0.9, beta_2=0.999)).  If no arguments are
         provided Keras default values will be set.
     optimizer_kwargs
         The arguments for the chosen optimizer. If not provided Keras'

--- a/gordo/machine/model/factories/lstm_autoencoder.py
+++ b/gordo/machine/model/factories/lstm_autoencoder.py
@@ -90,8 +90,9 @@ def lstm_model(
 
     # output layer
     if isinstance(optimizer, str):
-        Optim = getattr(keras.optimizers, optimizer)
-        optimizer = Optim(**optimizer_kwargs)
+        optimizer = keras.optimizers.get(
+            {"class_name": optimizer, "config": optimizer_kwargs}
+        )
 
     model.add(Dense(units=n_features_out, activation=out_func))
 

--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -83,8 +83,15 @@ class KerasBaseEstimator(KerasRegressor, GordoBase):
         # This new keras wrapper expects most of these kwargs to be set to the model attributes and uses them for
         # defaults in some places, but always gives precedence to kwargs passed to respective fit, predict and compile
         # methods, so this is just to make it happy again
-        _expected_kwargs = {*self._fit_kwargs, *self._predict_kwargs, *self._compile_kwargs}
-        KerasRegressor.__init__(self, **{key: value for key, value in kwargs.items() if key in _expected_kwargs})
+        _expected_kwargs = {
+            *self._fit_kwargs,
+            *self._predict_kwargs,
+            *self._compile_kwargs,
+        }
+        KerasRegressor.__init__(
+            self,
+            **{key: value for key, value in kwargs.items() if key in _expected_kwargs},
+        )
 
     @staticmethod
     def parse_module_path(module_path) -> Tuple[Optional[str], str]:

--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -418,7 +418,6 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     ...             input_shape: [4]
     ...         - tensorflow.keras.layers.Dense:
     ...             units: 1
-    ...             input_shape: [1]
     ... '''
     >>> config = yaml.safe_load(config_str)
     >>> model = KerasRawModelRegressor(kind=config)

--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -84,9 +84,9 @@ class KerasBaseEstimator(KerasRegressor, GordoBase):
         # defaults in some places, but always gives precedence to kwargs passed to respective fit, predict and compile
         # methods, so this is just to make it happy again
         _expected_kwargs = {
-            *self._fit_kwargs,
-            *self._predict_kwargs,
-            *self._compile_kwargs,
+            *KerasRegressor._fit_kwargs,
+            *KerasRegressor._predict_kwargs,
+            *KerasRegressor._compile_kwargs,
         }
         KerasRegressor.__init__(
             self,
@@ -313,7 +313,6 @@ class KerasBaseEstimator(KerasRegressor, GordoBase):
             Parameters used in this estimator
         """
         params = super().get_params(**params)
-        params.pop("model", None)
         params.update({"kind": self.kind})
         params.update(self.kwargs)
         return params
@@ -416,12 +415,10 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     ...       layers:
     ...         - tensorflow.keras.layers.Dense:
     ...             units: 4
-    ...             input_shape:
-    ...               - 4
+    ...             input_shape: [4]
     ...         - tensorflow.keras.layers.Dense:
     ...             units: 1
-    ...             input_shape:
-    ...               - 1
+    ...             input_shape: [1]
     ... '''
     >>> config = yaml.safe_load(config_str)
     >>> model = KerasRawModelRegressor(kind=config)

--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -2,25 +2,23 @@
 
 import abc
 import logging
-import io
 import importlib
+import tempfile
 from pprint import pformat
 from typing import Union, Callable, Dict, Any, Optional, Tuple
 from abc import ABCMeta
 from copy import copy, deepcopy
 from importlib.util import find_spec
 
-import h5py
 import tensorflow.keras.models
 from tensorflow.keras.models import load_model, save_model
 from tensorflow.keras.preprocessing.sequence import pad_sequences, TimeseriesGenerator
-from tensorflow.keras.wrappers.scikit_learn import KerasRegressor as BaseWrapper
-from tensorflow.keras.callbacks import History
+from scikeras.wrappers import KerasRegressor
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.base import TransformerMixin
 from sklearn.metrics import explained_variance_score
 from sklearn.exceptions import NotFittedError
 
@@ -35,7 +33,7 @@ from gordo.machine.model.register import register_model_builder
 logger = logging.getLogger(__name__)
 
 
-class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
+class KerasBaseEstimator(KerasRegressor, GordoBase):
     supported_fit_args = [
         "batch_size",
         "epochs",
@@ -78,11 +76,15 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
             building function and/or any additional args to be passed
             to Keras' fit() method
         """
-        self.build_fn = None
-        self.history = None
-
         self.kind = self.load_kind(kind)
         self.kwargs: Dict[str, Any] = kwargs
+        self._history = None
+
+        # This new keras wrapper expects most of these kwargs to be set to the model attributes and uses them for
+        # defaults in some places, but always gives precedence to kwargs passed to respective fit, predict and compile
+        # methods, so this is just to make it happy again
+        _expected_kwargs = {*self._fit_kwargs, *self._predict_kwargs, *self._compile_kwargs}
+        KerasRegressor.__init__(self, **{key: value for key, value in kwargs.items() if key in _expected_kwargs})
 
     @staticmethod
     def parse_module_path(module_path) -> Tuple[Optional[str], str]:
@@ -177,26 +179,26 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
 
         state = self.__dict__.copy()
 
-        if hasattr(self, "model") and self.model is not None:
-            buf = io.BytesIO()
-            with h5py.File(buf, compression="lzf", mode="w") as h5:
-                save_model(self.model, h5, overwrite=True, save_format="h5")
-                buf.seek(0)
-                state["model"] = buf
-            if hasattr(self, "history"):
-                from tensorflow.python.keras.callbacks import History
+        if self.model is not None:
+            with tempfile.NamedTemporaryFile("w", suffix=".keras") as tf:
+                save_model(self.model, tf.name, overwrite=True)
+                with open(tf.name, "rb") as inf:
+                    state["model"] = inf.read()
 
-                history = History()
-                history.history = self.history.history
-                history.params = self.history.params
-                history.epoch = self.history.epoch
-                state["history"] = history
+            from tensorflow.python.keras.callbacks import History
+
+            history = History()
+            history.history = self._history.history
+            history.params = self._history.params
+            history.epoch = self._history.epoch
+            state["history"] = history
         return state
 
     def __setstate__(self, state):
-        if "model" in state:
-            with h5py.File(state["model"], compression="lzf", mode="r") as h5:
-                state["model"] = load_model(h5, compile=False)
+        if "model" in state and state["model"] is not None:
+            with tempfile.NamedTemporaryFile("wb", suffix=".keras") as tf:
+                tf.write(state["model"])
+                state["model"] = load_model(tf.name, compile=False)
         self.__dict__ = state
         return self
 
@@ -269,9 +271,12 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         if isinstance(y, (pd.DataFrame, xr.DataArray)):
             y = y.values
         kwargs.setdefault("verbose", 0)
-        history = super().fit(X, y, sample_weight=None, **kwargs)
-        if isinstance(history, History):
-            self.history = history
+
+        if self.model is None:
+            self._prepare_model()
+        model = super().fit(X, y, sample_weight=None, **kwargs)
+        if isinstance(model, KerasRegressor):
+            self._history = model.model.history
         return self
 
     def predict(self, X: np.ndarray, **kwargs) -> np.ndarray:
@@ -301,16 +306,16 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
             Parameters used in this estimator
         """
         params = super().get_params(**params)
-        params.pop("build_fn", None)
+        params.pop("model", None)
         params.update({"kind": self.kind})
         params.update(self.kwargs)
         return params
 
-    def __call__(self):
+    def _prepare_model(self):
         module_name, class_name = self.parse_module_path(self.kind)
         if module_name is None:
             factories = register_model_builder.factories[self.__class__.__name__]
-            build_fn = factories[self.kind]
+            model = factories[self.kind]
         else:
             module = importlib.import_module(module_name)
             if not hasattr(module, class_name):
@@ -318,8 +323,8 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
                     "kind: %s, unable to find class %s in module '%s'"
                     % (self.kind, class_name, module_name)
                 )
-            build_fn = getattr(module, class_name)
-        return build_fn(**self.sk_params)
+            model = getattr(module, class_name)
+        self.model = model(**self.sk_params)
 
     def get_metadata(self):
         """
@@ -334,9 +339,9 @@ class KerasBaseEstimator(BaseWrapper, GordoBase, BaseEstimator):
         -------
             Metadata dictionary, including a history object if present
         """
-        if hasattr(self, "model") and hasattr(self, "history"):
-            history = self.history.history
-            history["params"] = self.history.params
+        if self._history is not None:
+            history = self._history.history
+            history["params"] = self._history.params
             return {"history": history}
         else:
             return {}
@@ -372,7 +377,7 @@ class KerasAutoEncoder(KerasBaseEstimator, TransformerMixin):
         -------
             Returns the explained variance score
         """
-        if not hasattr(self, "model"):
+        if self.model is None:
             raise NotFittedError(
                 f"This {self.__class__.__name__} has not been fitted yet."
             )
@@ -404,8 +409,12 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     ...       layers:
     ...         - tensorflow.keras.layers.Dense:
     ...             units: 4
+    ...             input_shape:
+    ...               - 4
     ...         - tensorflow.keras.layers.Dense:
     ...             units: 1
+    ...             input_shape:
+    ...               - 1
     ... '''
     >>> config = yaml.safe_load(config_str)
     >>> model = KerasRawModelRegressor(kind=config)
@@ -413,8 +422,10 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     >>> X, y = np.random.random((10, 4)), np.random.random((10, 1))
     >>> model.fit(X, y, verbose=0)
     KerasRawModelRegressor(kind: {'compile': {'loss': 'mse', 'optimizer': 'adam'},
-     'spec': {'tensorflow.keras.models.Sequential': {'layers': [{'tensorflow.keras.layers.Dense': {'units': 4}},
-                                                                {'tensorflow.keras.layers.Dense': {'units': 1}}]}}})
+     'spec': {'tensorflow.keras.models.Sequential': {'layers': [{'tensorflow.keras.layers.Dense': {'input_shape': [4],
+                                                                                                   'units': 4}},
+                                                                {'tensorflow.keras.layers.Dense': {'input_shape': [1],
+                                                                                                   'units': 1}}]}}})
     >>> out = model.predict(X)
     """
 
@@ -426,7 +437,7 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     def __repr__(self):
         return f"{self.__class__.__name__}(kind: {pformat(self.kind)})"
 
-    def __call__(self):
+    def _prepare_model(self):
         """Build Keras model from specification"""
         if not all(k in self.kind for k in self._expected_keys):
             raise ValueError(
@@ -438,9 +449,9 @@ class KerasRawModelRegressor(KerasAutoEncoder):
 
         # Load any compile kwargs as well, such as compile.optimizer which may map to class obj
         kwargs = serializer.from_definition(self.kind["compile"])
-
         model.compile(**kwargs)
-        return model
+
+        self.model = model
 
 
 class KerasLSTMBaseEstimator(KerasBaseEstimator, TransformerMixin, metaclass=ABCMeta):
@@ -479,7 +490,6 @@ class KerasLSTMBaseEstimator(KerasBaseEstimator, TransformerMixin, metaclass=ABC
             additional args to be passed to the intermediate fit method.
         """
         self.lookback_window = lookback_window
-        self.batch_size = batch_size
         kwargs["lookback_window"] = lookback_window
         kwargs["kind"] = kind
         kwargs["batch_size"] = batch_size
@@ -541,7 +551,6 @@ class KerasLSTMBaseEstimator(KerasBaseEstimator, TransformerMixin, metaclass=ABC
     def fit(  # type: ignore
         self, X: np.ndarray, y: np.ndarray, **kwargs
     ) -> "KerasLSTMForecast":
-
         """
         This fits a one step forecast LSTM architecture.
 
@@ -670,7 +679,7 @@ class KerasLSTMBaseEstimator(KerasBaseEstimator, TransformerMixin, metaclass=ABC
         -------
             Returns the explained variance score.
         """
-        if not hasattr(self, "model"):
+        if self.model is None:
             raise NotFittedError(
                 f"This {self.__class__.__name__} has not been fitted yet."
             )

--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -424,11 +424,19 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     >>>
     >>> X, y = np.random.random((10, 4)), np.random.random((10, 1))
     >>> model.fit(X, y, verbose=0)
-    KerasRawModelRegressor(kind: {'compile': {'loss': 'mse', 'optimizer': 'adam'},
-     'spec': {'tensorflow.keras.models.Sequential': {'layers': [{'tensorflow.keras.layers.Dense': {'input_shape': [4],
-                                                                                                   'units': 4}},
-                                                                {'tensorflow.keras.layers.Dense': {'input_shape': [1],
-                                                                                                   'units': 1}}]}}})
+    KerasRawModelRegressor(
+        kind: {
+            'compile': {'loss': 'mse', 'optimizer': 'adam'},
+            'spec': {
+                'tensorflow.keras.models.Sequential': {
+                    'layers': [
+                        {'tensorflow.keras.layers.Dense': {'input_shape': [4],'units': 4}},
+                        {'tensorflow.keras.layers.Dense': {'units': 1}}
+                    ]
+                }
+            }
+        }
+    )
     >>> out = model.predict(X)
     """
 

--- a/gordo/machine/model/models.py
+++ b/gordo/machine/model/models.py
@@ -424,19 +424,10 @@ class KerasRawModelRegressor(KerasAutoEncoder):
     >>>
     >>> X, y = np.random.random((10, 4)), np.random.random((10, 1))
     >>> model.fit(X, y, verbose=0)
-    KerasRawModelRegressor(
-        kind: {
-            'compile': {'loss': 'mse', 'optimizer': 'adam'},
-            'spec': {
-                'tensorflow.keras.models.Sequential': {
-                    'layers': [
-                        {'tensorflow.keras.layers.Dense': {'input_shape': [4],'units': 4}},
-                        {'tensorflow.keras.layers.Dense': {'units': 1}}
-                    ]
-                }
-            }
-        }
-    )
+    KerasRawModelRegressor(kind: {'compile': {'loss': 'mse', 'optimizer': 'adam'},
+     'spec': {'tensorflow.keras.models.Sequential': {'layers': [{'tensorflow.keras.layers.Dense': {'input_shape': [4],
+                                                                                                   'units': 4}},
+                                                                {'tensorflow.keras.layers.Dense': {'units': 1}}]}}})
     >>> out = model.predict(X)
     """
 

--- a/gordo/serializer/from_definition.py
+++ b/gordo/serializer/from_definition.py
@@ -259,7 +259,7 @@ def _build_callbacks(definitions: list):
     --------
     >>> callbacks=_build_callbacks([{'tensorflow.keras.callbacks.EarlyStopping': {'monitor': 'val_loss,', 'patience': 10}}])
     >>> type(callbacks[0])
-    <class 'keras.callbacks.EarlyStopping'>
+    <class 'keras.src.callbacks.early_stopping.EarlyStopping'>
 
     Returns
     -------

--- a/requirements/full_requirements.txt
+++ b/requirements/full_requirements.txt
@@ -6,6 +6,7 @@
 #
 absl-py==2.1.0
     # via
+    #   keras
     #   tensorboard
     #   tensorflow
 adal==1.2.7
@@ -68,9 +69,7 @@ bcrypt==4.1.2
 blinker==1.7.0
     # via flask
 cachetools==5.3.2
-    # via
-    #   google-auth
-    #   gordo-core
+    # via gordo-core
 catboost==1.2.2
     # via -r requirements.in
 certifi==2023.11.17
@@ -131,12 +130,6 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.41
     # via mlflow
-google-auth==2.26.2
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
 google-pasta==0.2.0
     # via tensorflow
 gordo-client==6.2.8
@@ -145,8 +138,6 @@ gordo-core==0.3.5
     # via gordo-client
 graphviz==0.20.1
     # via catboost
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.60.0
     # via
     #   tensorboard
@@ -157,7 +148,7 @@ gunicorn==20.1.0
     #   mlflow
 h5py==3.10.0
     # via
-    #   -r requirements.in
+    #   keras
     #   tensorflow
 humanfriendly==10.0
     # via azureml-core
@@ -178,8 +169,6 @@ isodate==0.6.1
     #   msrest
 itsdangerous==2.1.2
     # via flask
-jax==0.4.23
-    # via tensorflow
 jeepney==0.8.0
     # via secretstorage
 jinja2==3.1.3
@@ -195,8 +184,10 @@ joblib==1.3.2
     # via scikit-learn
 jsonpickle==3.0.2
     # via azureml-core
-keras==2.12.0
-    # via tensorflow
+keras==3.4.0
+    # via
+    #   scikeras
+    #   tensorflow
 kiwisolver==1.4.5
     # via matplotlib
 knack==0.11.0
@@ -209,6 +200,8 @@ markdown==3.5.2
     # via
     #   mlflow
     #   tensorboard
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.4
     # via
     #   jinja2
@@ -220,8 +213,12 @@ matplotlib==3.8.2
     # via
     #   catboost
     #   mlflow
+mdurl==0.1.2
+    # via markdown-it-py
 ml-dtypes==0.3.2
-    # via jax
+    # via
+    #   keras
+    #   tensorflow
 mlflow==2.9.2
     # via -r mlflow_requirements.in
 msal==1.26.0
@@ -243,6 +240,8 @@ msrestazure==0.6.4
     #   azureml-core
 mypy-extensions==1.0.0
     # via typing-inspect
+namex==0.0.8
+    # via keras
 ndg-httpsclient==0.5.1
     # via azureml-core
 numexpr==2.8.8
@@ -253,7 +252,7 @@ numpy==1.24.3
     #   contourpy
     #   gordo-core
     #   h5py
-    #   jax
+    #   keras
     #   matplotlib
     #   ml-dtypes
     #   mlflow
@@ -271,14 +270,15 @@ oauthlib==3.2.2
     #   databricks-cli
     #   requests-oauthlib
 opt-einsum==3.3.0
-    # via
-    #   jax
-    #   tensorflow
+    # via tensorflow
+optree==0.11.0
+    # via keras
 packaging==21.3
     # via
     #   -r requirements.in
     #   azureml-core
     #   docker
+    #   keras
     #   knack
     #   marshmallow
     #   matplotlib
@@ -320,18 +320,15 @@ pyarrow==14.0.2
     #   gordo-core
     #   mlflow
 pyasn1==0.5.1
-    # via
-    #   ndg-httpsclient
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.3.0
-    # via google-auth
+    # via ndg-httpsclient
 pycparser==2.21
     # via cffi
 pydantic==1.10.14
     # via gordo-client
 pygments==2.17.2
-    # via knack
+    # via
+    #   knack
+    #   rich
 pyjwt[crypto]==2.8.0
     # via
     #   adal
@@ -384,22 +381,22 @@ requests[socks]==2.31.0
     #   msal
     #   msrest
     #   requests-oauthlib
-    #   tensorboard
+    #   tensorflow
 requests-oauthlib==1.3.1
-    # via
-    #   google-auth-oauthlib
-    #   msrest
-rsa==4.9
-    # via google-auth
-scikit-learn==1.4.0
+    # via msrest
+rich==13.7.1
+    # via keras
+scikeras==0.13.0
+    # via -r requirements.in
+scikit-learn==1.5.0
     # via
     #   gordo-core
     #   mlflow
+    #   scikeras
 scipy==1.12.0
     # via
     #   catboost
     #   gordo-core
-    #   jax
     #   mlflow
     #   scikit-learn
 secretstorage==3.3.3
@@ -420,6 +417,7 @@ six==1.16.0
     #   msrestazure
     #   python-dateutil
     #   querystring-parser
+    #   tensorboard
     #   tensorflow
 smmap==5.0.1
     # via gitdb
@@ -435,15 +433,13 @@ tabulate==0.9.0
     #   knack
 tenacity==8.2.3
     # via plotly
-tensorboard==2.12.3
+tensorboard==2.16.2
     # via tensorflow
 tensorboard-data-server==0.7.2
     # via tensorboard
-tensorflow==2.12.1
+tensorflow==2.16.1
     # via -r requirements.in
-tensorflow-estimator==2.12.0
-    # via tensorflow
-tensorflow-io-gcs-filesystem==0.35.0
+tensorflow-io-gcs-filesystem==0.37.0
     # via tensorflow
 termcolor==2.4.0
     # via tensorflow
@@ -453,6 +449,7 @@ typing-extensions==4.5.0
     # via
     #   alembic
     #   azure-core
+    #   optree
     #   pydantic
     #   sqlalchemy
     #   tensorflow
@@ -472,9 +469,7 @@ werkzeug==3.0.1
     #   flask
     #   tensorboard
 wheel==0.42.0
-    # via
-    #   astunparse
-    #   tensorboard
+    # via astunparse
 wrapt==1.14.1
     # via
     #   gordo-client

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,10 +1,10 @@
 dictdiffer~=0.8
 dataclasses-json~=0.3
 gunicorn~=20.0
-h5py~=3.1
 jinja2~=3.1
 python-dateutil~=2.8
-tensorflow>=2.11,<2.13
+tensorflow~=2.16.0
+scikeras~=0.13.0
 Flask>=2.2.5,<3.0.0
 simplejson~=3.17
 catboost~=1.2.2

--- a/tests/gordo/machine/model/test_lstm_autoencoder.py
+++ b/tests/gordo/machine/model/test_lstm_autoencoder.py
@@ -54,24 +54,24 @@ class LSTMAutoEncoderTestCase(unittest.TestCase):
             func="tanh",
             out_func="relu",
             optimizer="SGD",
-            optimizer_kwargs={"lr": 0.02, "momentum": 0.001},
+            optimizer_kwargs={"learning_rate": 0.02, "momentum": 0.001},
             compile_kwargs={"loss": "mae"},
         )
 
         # Ensure that the input dimension to Keras model matches the number of features.
-        self.assertEqual(model.layers[0].input_shape[2], 3)
+        self.assertEqual(model.layers[0].input.shape[2], 3)
 
         # Ensure that the dimension of each encoding layer matches the expected dimension.
         self.assertEqual(
-            [model.layers[i].input_shape[2] for i in range(1, 4)], [3, 2, 2]
+            [model.layers[i].input.shape[2] for i in range(1, 4)], [3, 2, 2]
         )
 
         # Ensure that the dimension of each decoding layer (excluding last decoding layer)
         # matches the expected dimension.
-        self.assertEqual([model.layers[i].input_shape[2] for i in range(4, 6)], [2, 2])
+        self.assertEqual([model.layers[i].input.shape[2] for i in range(4, 6)], [2, 2])
 
         # Ensure that the dimension of last decoding layer matches the expected dimension.
-        self.assertEqual(model.layers[6].input_shape[1], 3)
+        self.assertEqual(model.layers[6].input.shape[1], 3)
 
         # Ensure activation functions in the encoding part (layers 0-2)
         # match expected activation functions
@@ -127,22 +127,22 @@ def test_lstm_symmetric_basic(n_features, n_features_out):
         funcs=("relu", "relu", "tanh", "tanh"),
         out_func="linear",
         optimizer="SGD",
-        optimizer_kwargs={"lr": 0.01},
+        optimizer_kwargs={"learning_rate": 0.01},
         loss="mse",
     )
 
     # Ensure that the input dimension to Keras model matches the number of features.
-    assert model.layers[0].input_shape[2] == n_features
+    assert model.layers[0].input.shape[2] == n_features
 
     # Ensure that the dimension of each encoding layer matches the expected dimension.
-    assert [model.layers[i].input_shape[2] for i in range(1, 5)] == [4, 3, 2, 1]
+    assert [model.layers[i].input.shape[2] for i in range(1, 5)] == [4, 3, 2, 1]
 
     # Ensure that the dimension of each decoding layer (excluding last decoding layer)
     # matches the expected dimension.
-    assert [model.layers[i].input_shape[2] for i in range(5, 8)] == [1, 2, 3]
+    assert [model.layers[i].input.shape[2] for i in range(5, 8)] == [1, 2, 3]
 
     # Ensure that the dimension of last decoding layer matches the expected dimension.
-    assert model.layers[8].input_shape[1] == 4
+    assert model.layers[8].input.shape[1] == 4
 
     # Ensure activation functions in the encoding part (layers 0-3)
     # match expected activation functions.

--- a/tests/gordo/machine/model/test_model.py
+++ b/tests/gordo/machine/model/test_model.py
@@ -12,7 +12,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import cross_val_score, TimeSeriesSplit
 
-from tensorflow.keras.wrappers.scikit_learn import KerasRegressor as BaseWrapper
+from scikeras.wrappers import KerasRegressor
 from tensorflow.keras.callbacks import EarlyStopping
 
 from tests.utils import get_model
@@ -105,7 +105,7 @@ def test_keras_type_config(model, kind):
     # Ensure we can poke the model the same
     model_out = get_model(config)
     assert isinstance(model_out, GordoBase)
-    assert isinstance(model_out, BaseWrapper)
+    assert isinstance(model_out, KerasRegressor)
     assert isinstance(model_out, pydoc.locate(f"gordo.machine.model.models.{model}"))
 
 
@@ -146,15 +146,15 @@ def test_save_load(model, kind):
     # Assert that epochs list, history dict and params dict in
     # the History object are the same
     assert (
-        model_out.history.epoch == model_out_clone.history.epoch
+        model_out._history.epoch == model_out_clone._history.epoch
     ), "Epoch lists differ between original and loaded model history"
 
     assert (
-        model_out.history.history == model_out_clone.history.history
+        model_out._history.history == model_out_clone._history.history
     ), "History dictionary with losses and accuracies differ between original and loaded model history"
 
     assert (
-        model_out.history.params == model_out_clone.history.params
+        model_out._history.params == model_out_clone._history.params
     ), "Params dictionaries differ between original and loaded model history"
 
 

--- a/tests/gordo/machine/model/test_raw_keras.py
+++ b/tests/gordo/machine/model/test_raw_keras.py
@@ -81,12 +81,10 @@ def test_raw_keras_part_of_pipeline():
                             layers:
                                 - tensorflow.keras.layers.Dense:
                                     units: 4
-                                    input_shape:
-                                        - 4
+                                    input_shape: [4]
                                 - tensorflow.keras.layers.Dense:
                                     units: 1
-                                    input_shape:
-                                        - 1
+                                    input_shape: [1]
     """
     config = yaml.safe_load(config_str)
     pipe = serializer.from_definition(config)

--- a/tests/gordo/machine/model/test_raw_keras.py
+++ b/tests/gordo/machine/model/test_raw_keras.py
@@ -84,7 +84,6 @@ def test_raw_keras_part_of_pipeline():
                                     input_shape: [4]
                                 - tensorflow.keras.layers.Dense:
                                     units: 1
-                                    input_shape: [1]
     """
     config = yaml.safe_load(config_str)
     pipe = serializer.from_definition(config)

--- a/tests/gordo/machine/model/test_raw_keras.py
+++ b/tests/gordo/machine/model/test_raw_keras.py
@@ -55,8 +55,9 @@ def test_raw_keras_basic(spec_str: str):
     """
     spec = yaml.safe_load(spec_str)
     pipe = KerasRawModelRegressor(spec)
-    model = pipe()
-    assert isinstance(model, tf.keras.models.Sequential)
+    pipe._prepare_model()
+
+    assert isinstance(pipe.model, tf.keras.models.Sequential)
 
 
 def test_raw_keras_part_of_pipeline():
@@ -80,8 +81,12 @@ def test_raw_keras_part_of_pipeline():
                             layers:
                                 - tensorflow.keras.layers.Dense:
                                     units: 4
+                                    input_shape:
+                                        - 4
                                 - tensorflow.keras.layers.Dense:
                                     units: 1
+                                    input_shape:
+                                        - 1
     """
     config = yaml.safe_load(config_str)
     pipe = serializer.from_definition(config)

--- a/tests/gordo/serializer/test_serializer_into_definition.py
+++ b/tests/gordo/serializer/test_serializer_into_definition.py
@@ -171,6 +171,7 @@ sklearn.pipeline.Pipeline:
           verbose: false
       transformer_weights: null
       verbose: false
+      verbose_feature_names_out: true
   - gordo.machine.model.models.KerasAutoEncoder:
       kind: feedforward_hourglass
   verbose: false


### PR DESCRIPTION
To accommodate the upgrade, next changes to the code were made:

* `tensorflow` no longer has keras wrappers, which are now used from `scikeras` library, recommended for use by them. They have largely the same interface, but slightly different innerworkings, which were accomodated for.
* Since `keras 3.*` now clones the input `regressor` that is provided to the `BaseEstimator` into a `regressor_` attribute, and ONLY updates the `regressor_` one after fitting, metadata extraction in `gordo.builder.build_model.ModelBuilder` was changed to seek the `regressor_` in the `steps`.
* Accessing `keras.optimizers` has changed in `keras 3.*` to having to use the `keras.optimizers.get` method and providing a `class_name` and `config` to deserialize. Relevant for lstm and feedforward autoencoders.
* Model config now requires for `tensorflow.keras.models.Sequential` to define `input_shape` in its layers, otherwise model is not properly built after compiling and prior to fitting. Relevant for `KerasRawModelRegressor`.

`KerasBaseEstimator` underwent the most changes.

* We now need to run the `__init__` of the KerasRegressor with the expected `kwargs` for proper initialisation of the object, but the `kwargs` will always take precedence for `fit`, `predict` and `compile`, so they are mostly for making `keras` happy.
* Saving model for pickling was changed ƒrom `h5` format, which is now considered legacy to `keras` native zip format, and the file is now stored to a temporary file and read into a buffer instead of using the `h5py` library, since `save_model` and `load_model` now exclusively expect an actual file instead of an io buffer.
* Current implementation of model preparation for fit depends on the `__call__` method, which is no longer used in `keras 3.*`, and was changed to `_prepare_model` to replicate the same behaviour right before we call our own `fit` since it requires the `X` and `Y` to be present to set the `n_features` and `n_features_out`.
* `History` is no longer returned from calling `fit` and must be extracted from under `model.history`.
* Manually stored history now resides in `self._history` instead of `self.history` to avoid attribute name clash.

Adjustments to tests were made:

* `input_shape` now resides under `input.shape` in `model.layers`.
* `optimizer_kwargs.lr` is now `optimizer_kwargs.learning_rate`