### PR TITLE
Fix: pin `keras` to `3.3.3` due to a bug in `keras==3.4.0`

### DIFF
--- a/requirements/full_requirements.txt
+++ b/requirements/full_requirements.txt
@@ -184,8 +184,9 @@ joblib==1.3.2
     # via scikit-learn
 jsonpickle==3.0.2
     # via azureml-core
-keras==3.4.0
+keras==3.3.3
     # via
+    #   -r requirements.in
     #   scikeras
     #   tensorflow
 kiwisolver==1.4.5
@@ -278,7 +279,6 @@ packaging==21.3
     #   -r requirements.in
     #   azureml-core
     #   docker
-    #   keras
     #   knack
     #   marshmallow
     #   matplotlib

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -5,6 +5,8 @@ jinja2~=3.1
 python-dateutil~=2.8
 tensorflow~=2.16.0
 scikeras~=0.13.0
+# There's a bug in keras 3.4.0 with loading models (https://github.com/keras-team/keras/issues/19921)
+keras<3.4.0
 Flask>=2.2.5,<3.0.0
 simplejson~=3.17
 catboost~=1.2.2


### PR DESCRIPTION
A bug (https://github.com/keras-team/keras/issues/19921) in `keras` causes an exception when loading a saved `.keras` model. Even though the tests do not seem to fail for model save/load, it's safer to pin it back.